### PR TITLE
chore: Update titles to call out community edition of YAFC

### DIFF
--- a/YAFC/Windows/MainScreen.cs
+++ b/YAFC/Windows/MainScreen.cs
@@ -50,7 +50,7 @@ namespace YAFC
             Instance = this;
             tabBar = new MainScreenTabBar(this);
             allPages = new VirtualScrollList<ProjectPage>(30, new Vector2(0f, 2f), BuildPage, collapsible:true);
-            Create("Yet Another Factorio Calculator v"+YafcLib.version, display);
+            Create("Yet Another Factorio Calculator CE v"+YafcLib.version, display);
             SetProject(project);
         }
 

--- a/YAFC/Windows/WelcomeScreen.cs
+++ b/YAFC/Windows/WelcomeScreen.cs
@@ -72,7 +72,7 @@ namespace YAFC
             errorScroll = new VerticalScrollCustom(20f, BuildError, collapsible:true);
             recentProjectScroll = new VerticalScrollCustom(20f, BuildRecentProjectList, collapsible:true);
             languageScroll = new VerticalScrollCustom(20f, LanguageSelection, collapsible: true);
-            Create("Welcome to YAFC v"+YafcLib.version.ToString(3), 45, null);
+            Create("Welcome to YAFC CE v"+YafcLib.version.ToString(3), 45, null);
             IconCollection.ClearCustomIcons();
             if (tips == null)
                 tips = File.ReadAllLines("Data/Tips.txt");


### PR DESCRIPTION
I've got both the original version of YAFC and the community edition (CE) on my computer.  I then realized you can't differentiate between them, so I wanted to update the titles so you can tell the difference. 

<img width="507" alt="Welcome to YAFC CE v0 6 0" src="https://github.com/have-fun-was-taken/yafc-ce/assets/98995/efa507e6-2325-461b-92b0-8f0281b511ff">
<img width="345" alt="Yet Another Factorio Calculator CE v0 6 0 0" src="https://github.com/have-fun-was-taken/yafc-ce/assets/98995/bd2458ef-deeb-4309-824e-18489bfc64b8">
