### PR TITLE
Update LinuxOsxInstall.md

### DIFF
--- a/Docs/LinuxOsxInstall.md
+++ b/Docs/LinuxOsxInstall.md
@@ -13,15 +13,21 @@
 - Make sure you have OpenGL availible
 
 ## Linux installation instructions
+### Arch 
+The AUR package `factorio-yafc-git` points to the original upstream project by ShadowTheAge. Download the PKGBUILD and edit the url to the following: https://github.com/have-fun-was-taken/yafc-ce
+In the same folder, run `makepkg -sri` to build YAFC. Run with `factorio-yafc`. 
+### Debian
+- Download the latest release from this repo.
+- [Install dotnet core (v6.0 or later)](https://learn.microsoft.com/en-us/dotnet/core/install/linux-debian)
+- Install SDL2:
+  - `sudo apt-get install libsdl2-2.0-0`
+  - `sudo apt-get install libsdl2-image-2.0-0`
+  - `sudo apt-get install libsdl2-ttf-2.0-0`
+  - For reference, have following libraries: SDL2-2.0.so.0, SDL2_ttf-2.0.so.0, SDL2_image-2.0.so.0
+- Make sure you have OpenGL available
+- To run either use `dotnet YAFC.dll` in the terminal, or run `YAFC` as an executable
+### Other
+In general, ensure you have SDL2, OpenGL and dotnet 6 or later. 
 
-1. YAFC is available on [Flathub.](https://flathub.org/apps/details/com.github.petebuffon.yafc)
-2. Download release
-  - [Install dotnet core (v6.0 or later)](https://dotnet.microsoft.com/download)
-  - Install SDL2 (The following commands for debian):
-    - `sudo apt-get install libsdl2-2.0-0`
-    - `sudo apt-get install libsdl2-image-2.0-0`
-    - `sudo apt-get install libsdl2-ttf-2.0-0`
-    - If you have other distribution, visit https://wiki.libsdl.org/Installation
-    - For reference, have following libraries: SDL2-2.0.so.0, SDL2_ttf-2.0.so.0, SDL2_image-2.0.so.0
-  - To run either use `dotnet YAFC.dll` in the terminal, or run `YAFC` as an executable
-  - Make sure you have OpenGL availible
+### Flathub
+Note that [the version available on Flathub](https://flathub.org/apps/details/com.github.petebuffon.yafc) is not the Community Edition. Its repo can be found at https://github.com/petebuffon/yafc. 

--- a/Docs/LinuxOsxInstall.md
+++ b/Docs/LinuxOsxInstall.md
@@ -18,7 +18,7 @@ The AUR package [`factorio-yafc-git`](https://aur.archlinux.org/packages/factori
 1. Clone the AUR package
 2. Open PKGBUILD
 3. Edit the `source` to use the following URL: https://github.com/have-fun-was-taken/yafc-ce
-In the same folder, run `makepkg -sri` to build YAFC. Run with `factorio-yafc`. 
+In the same folder, run `makepkg -sri` to build and install YAFC. Run with `factorio-yafc`. 
 ### Debian
 - Download the latest release from this repo.
 - [Install dotnet core (v6.0 or later)](https://learn.microsoft.com/en-us/dotnet/core/install/linux-debian)

--- a/Docs/LinuxOsxInstall.md
+++ b/Docs/LinuxOsxInstall.md
@@ -14,7 +14,10 @@
 
 ## Linux installation instructions
 ### Arch 
-The AUR package [`factorio-yafc-git`](https://aur.archlinux.org/packages/factorio-yafc-git) points to the original upstream project by ShadowTheAge. Clone the AUR package and edit the url to the following: https://github.com/have-fun-was-taken/yafc-ce
+The AUR package [`factorio-yafc-git`](https://aur.archlinux.org/packages/factorio-yafc-git) points to the original upstream project by ShadowTheAge. To make this package suitable for YAFC-CE take the following steps:
+1. Clone the AUR package
+2. Open PKGBUILD
+3. Edit the `source` to use the following URL: https://github.com/have-fun-was-taken/yafc-ce
 In the same folder, run `makepkg -sri` to build YAFC. Run with `factorio-yafc`. 
 ### Debian
 - Download the latest release from this repo.

--- a/Docs/LinuxOsxInstall.md
+++ b/Docs/LinuxOsxInstall.md
@@ -14,7 +14,7 @@
 
 ## Linux installation instructions
 ### Arch 
-The AUR package `factorio-yafc-git` points to the original upstream project by ShadowTheAge. Clone the AUR package and edit the url to the following: https://github.com/have-fun-was-taken/yafc-ce
+The AUR package [`factorio-yafc-git`](https://aur.archlinux.org/packages/factorio-yafc-git) points to the original upstream project by ShadowTheAge. Clone the AUR package and edit the url to the following: https://github.com/have-fun-was-taken/yafc-ce
 In the same folder, run `makepkg -sri` to build YAFC. Run with `factorio-yafc`. 
 ### Debian
 - Download the latest release from this repo.

--- a/Docs/LinuxOsxInstall.md
+++ b/Docs/LinuxOsxInstall.md
@@ -14,7 +14,7 @@
 
 ## Linux installation instructions
 ### Arch 
-The AUR package `factorio-yafc-git` points to the original upstream project by ShadowTheAge. Download the PKGBUILD and edit the url to the following: https://github.com/have-fun-was-taken/yafc-ce
+The AUR package `factorio-yafc-git` points to the original upstream project by ShadowTheAge. Clone the AUR package and edit the url to the following: https://github.com/have-fun-was-taken/yafc-ce
 In the same folder, run `makepkg -sri` to build YAFC. Run with `factorio-yafc`. 
 ### Debian
 - Download the latest release from this repo.

--- a/Docs/LinuxOsxInstall.md
+++ b/Docs/LinuxOsxInstall.md
@@ -1,7 +1,6 @@
 # Both OSX and Linux builds are experimental!
 
 ## OSX installation instructions
-
 - [Install dotnet core (v6.0 or later)](https://dotnet.microsoft.com/download)
 - [Install brew](https://brew.sh/)
 - Install SDL2 using brew (type the following in the terminal):
@@ -14,11 +13,8 @@
 
 ## Linux installation instructions
 ### Arch 
-The AUR package [`factorio-yafc-git`](https://aur.archlinux.org/packages/factorio-yafc-git) points to the original upstream project by ShadowTheAge. To make this package suitable for YAFC-CE take the following steps:
-1. Clone the AUR package
-2. Open PKGBUILD
-3. Edit the `source` to use the following URL: https://github.com/have-fun-was-taken/yafc-ce
-In the same folder, run `makepkg -sri` to build and install YAFC. Run with `factorio-yafc`. 
+There is an AUR package for yafc-ce: [`factorio-yafc-ce-git`](https://aur.archlinux.org/packages/factorio-yafc-ce-git) 
+Once the package is installed, it can be run with `factorio-yafc`. Note that at least dotnet 6 or later is required.
 ### Debian
 - Download the latest release from this repo.
 - [Install dotnet core (v6.0 or later)](https://learn.microsoft.com/en-us/dotnet/core/install/linux-debian)


### PR DESCRIPTION
The current Linux/OSX install instructions are somewhat vague for both Linux and OSX, and promote the Flathub version. This is somewhat problematic, as the Flathub version is not the same code as in this repo. 

This PR amends the Linux/OSX install instructions, to add separate instructions for Arch Linux, update the link for dotnet core for Debian Linux, re-order the install steps, and highlight that the flathub version is not the Community Edition. 

Comments/Suggestions welcome. 