### PR TITLE
Keep file permissions when archiving

### DIFF
--- a/Docs/LinuxOsxInstall.md
+++ b/Docs/LinuxOsxInstall.md
@@ -4,7 +4,7 @@
 - [Install dotnet core (v6.0 or later)](https://dotnet.microsoft.com/download)
 - [Install brew](https://brew.sh/)
 - Install SDL2 using brew (type the following in the terminal):
-    - `brew install SDL2`
+  - `brew install SDL2`
 	- `brew install SDL2_image`
 	- `brew install SDL2_ttf`
 	- For reference, have following libraries: libSDL2.dylib, libSDL2_ttf.dylib, libSDL2_image.dylib
@@ -26,11 +26,10 @@ Once the package is installed, it can be run with `factorio-yafc`. Note that at 
   - `sudo apt-get install libsdl2-ttf-2.0-0`
   - For reference, have following libraries: SDL2-2.0.so.0, SDL2_ttf-2.0.so.0, SDL2_image-2.0.so.0
 - Make sure you have OpenGL available
-- Make `YAFC` executable with `chmod +x YAFC`
 - Use the `YAFC` executable to run.
 
 ### Other
-In general, ensure you have SDL2, OpenGL and dotnet 6 or later. Make `YAFC` executable with `chmod +x YAFC` and run it.
+In general, ensure you have SDL2, OpenGL and dotnet 6 or later. Use the `YAFC` executable to run.
 
 ### Flathub
 Note that [the version available on Flathub](https://flathub.org/apps/details/com.github.petebuffon.yafc) is not the Community Edition. Its repo can be found at https://github.com/petebuffon/yafc. 

--- a/build.bat
+++ b/build.bat
@@ -2,4 +2,11 @@ del /s /q Build
 dotnet publish YAFC/YAFC.csproj -r win-x64 -c Release -o Build/Windows -p:PublishTrimmed=true
 dotnet publish YAFC/YAFC.csproj -r osx-x64 --self-contained false -c Release -o Build/OSX
 dotnet publish YAFC/YAFC.csproj -r linux-x64 --self-contained false -c Release -o Build/Linux
+
+cd Build
+%SystemRoot%\System32\tar.exe -czf Linux.tar.gz Linux
+%SystemRoot%\System32\tar.exe -czf OSX.tar.gz OSX
+powershell Compress-Archive Windows Windows.zip
+
 pause;
+

--- a/build.sh
+++ b/build.sh
@@ -2,5 +2,10 @@ rm -rf Build
 dotnet publish YAFC/YAFC.csproj -r win-x64 -c Release -o Build/Windows -p:PublishTrimmed=true
 dotnet publish YAFC/YAFC.csproj -r osx-x64 --self-contained false -c Release -o Build/OSX
 dotnet publish YAFC/YAFC.csproj -r linux-x64 --self-contained false -c Release -o Build/Linux
-read -p "Press enter to continue"
+
+pushd Build
+tar czf Linux.tar.gz Linux
+tar czf OSX.tar.gz OSX
+zip -r Windows.zip Windows
+popd
 


### PR DESCRIPTION
Tar archives keep the file permissions and both Linux and OSX should not have any issues with tar.gz files. So those have changed. For Windows I still kept the zip archive, as I do not know how how commons tar archives are for Windows.

I tested `build.sh` which creates the 3 archives. For the Linux archive I verified that the file permissions are correct. As OSX is Unix based, I would assume this would be the case of the as well. (And since the Windows archive is a zip, there are not (additional)  file permissions).

I could only test `build.sh`, as I do not have a Window install. So please test `build.bat` as part of the review. For example, make the created Linux.tar.gz available and I can check the file permissions under Linux.

Fixes #10 
