### PR TITLE
Add optional built building count to recipe rows (v2)

### DIFF
--- a/YAFC/Workspace/ProductionTable/ProductionTableView.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableView.cs
@@ -255,16 +255,28 @@ namespace YAFC
                 if (recipe.isOverviewMode)
                     return;
                 bool clicked;
-                if (recipe.fixedBuildings > 0)
+                using (var group = gui.EnterGroup(default, RectAllocator.Stretch, spacing:0f))
                 {
-                    var evt = gui.BuildFactorioObjectWithEditableAmount(recipe.entity, recipe.fixedBuildings, UnitOfMeasure.None, out var newAmount);
-                    if (evt == GoodsWithAmountEvent.TextEditing)
-                        recipe.RecordUndo().fixedBuildings = newAmount;
-                    clicked = evt == GoodsWithAmountEvent.ButtonClick;
+                    group.SetWidth(3f);
+                    if (recipe.fixedBuildings > 0)
+                    {
+                        var evt = gui.BuildFactorioObjectWithEditableAmount(recipe.entity, recipe.fixedBuildings, UnitOfMeasure.None, out var newAmount);
+                        if (evt == GoodsWithAmountEvent.TextEditing)
+                            recipe.RecordUndo().fixedBuildings = newAmount;
+                        clicked = evt == GoodsWithAmountEvent.ButtonClick;
+                    }
+                    else
+                        clicked = gui.BuildFactorioObjectWithAmount(recipe.entity, recipe.buildingCount, UnitOfMeasure.None) && recipe.recipe.crafters.Length > 0; 
+
+                    if (recipe.builtBuildings != null)
+                    {
+                        if (gui.BuildTextInput(DataUtils.FormatAmount(Convert.ToSingle(recipe.builtBuildings), UnitOfMeasure.None), out var newText, null, Icon.None, true, default, RectAlignment.Middle, SchemeColor.Grey))
+                        {
+                            if (DataUtils.TryParseAmount(newText, out var newAmount, UnitOfMeasure.None))
+                                recipe.RecordUndo().builtBuildings = Convert.ToInt32(newAmount);
+                        }
+                    }
                 }
-                else
-                    clicked = gui.BuildFactorioObjectWithAmount(recipe.entity, recipe.buildingCount, UnitOfMeasure.None) && recipe.recipe.crafters.Length > 0; 
-            
             
                 if (clicked)
                 {

--- a/YAFC/Workspace/ProductionTable/ProductionTableView.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableView.cs
@@ -1084,7 +1084,8 @@ namespace YAFC
             {WarningFlags.TemperatureForIngredientNotMatch, "This recipe does care about ingridient temperature, and the temperature range does not match"},
             {WarningFlags.ReactorsNeighboursFromPrefs, "Assumes reactor formation from preferences"},
             {WarningFlags.AssumesNauvisSolarRatio, "Energy production values assumes Nauvis solar ration (70% power output). Don't forget accumulators."},
-            {WarningFlags.RecipeTickLimit, "Production is limited to 60 recipes per second (1/tick). This interacts weirdly with productivity bonus - actual productivity may be imprecise and may depend on your setup - test your setup before commiting to it."}
+            {WarningFlags.RecipeTickLimit, "Production is limited to 60 recipes per second (1/tick). This interacts weirdly with productivity bonus - actual productivity may be imprecise and may depend on your setup - test your setup before commiting to it."},
+            {WarningFlags.ExceedsBuiltCount, "This recipe requires more buildings than are currently built."}
         };
         
         private void BuildRecipePad(ImGui gui, RecipeRow row)

--- a/YAFC/Workspace/ProductionTable/ProductionTableView.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableView.cs
@@ -325,6 +325,17 @@ namespace YAFC
                         if (gui.BuildButton("Set fixed building count") && gui.CloseDropdown())
                             recipe.RecordUndo().fixedBuildings = recipe.buildingCount <= 0f ? 1f : recipe.buildingCount;
                     }
+
+                    if (recipe.builtBuildings != null)
+                    {
+                        if (gui.BuildButton("Clear built building count") && gui.CloseDropdown())
+                            recipe.RecordUndo().builtBuildings = null;
+                    }
+                    else
+                    {
+                        if (gui.BuildButton("Set built building count") && gui.CloseDropdown())
+                            recipe.RecordUndo().builtBuildings = Math.Max(0, Convert.ToInt32(Math.Ceiling(recipe.buildingCount)));
+                    }
                     
                     if (recipe.entity != null && gui.BuildButton("Create single building blueprint") && gui.CloseDropdown())
                     {
@@ -907,7 +918,7 @@ namespace YAFC
                 if (recipe.entity != null)
                 {
                     shopList.TryGetValue(recipe.entity, out var prev);
-                    var count = MathUtils.Ceil(recipe.buildingCount);
+                    var count = MathUtils.Ceil(recipe.builtBuildings ?? recipe.buildingCount);
                     shopList[recipe.entity] = prev + count;
                     if (recipe.parameters.modules.modules != null)
                     {

--- a/YAFCmodel/Model/ProductionTable.cs
+++ b/YAFCmodel/Model/ProductionTable.cs
@@ -465,6 +465,9 @@ namespace YAFC.Model
             {
                 var recipe = allRecipes[i];
                 recipe.recipesPerSecond = vars[i].SolutionValue();
+
+                if (recipe.buildingCount > recipe.builtBuildings)
+                    recipe.parameters.warningFlags |= WarningFlags.ExceedsBuiltCount;
             }
 
             CalculateFlow(null);

--- a/YAFCmodel/Model/ProductionTable.cs
+++ b/YAFCmodel/Model/ProductionTable.cs
@@ -460,23 +460,38 @@ namespace YAFC.Model
                 }
 
             }
-                
-            var builtCountExceeded = false;
+
             for (var i = 0; i < allRecipes.Count; i++)
             {
                 var recipe = allRecipes[i];
                 recipe.recipesPerSecond = vars[i].SolutionValue();
-
-                if (recipe.buildingCount > recipe.builtBuildings)
-                {
-                    recipe.parameters.warningFlags |= WarningFlags.ExceedsBuiltCount;
-                    builtCountExceeded = true;
-                }
             }
+
+            var builtCountExceeded = CheckBuiltCountExceeded();
 
             CalculateFlow(null);
             solver.Dispose();
             return builtCountExceeded ? "This model requires more buildings than are currently built" : null;
+        }
+
+        private bool CheckBuiltCountExceeded() {
+            var builtCountExceeded = false;
+            for (var i = 0; i < recipes.Count; i++)
+            {
+                var recipe = recipes[i];
+                if (recipe.buildingCount > recipe.builtBuildings)
+                {
+                    recipe.parameters.warningFlags |= WarningFlags.ExceedsBuiltCount;
+                    builtCountExceeded = true;
+                } else if (recipe.subgroup != null) {
+                    if (recipe.subgroup.CheckBuiltCountExceeded()) {
+                        recipe.parameters.warningFlags |= WarningFlags.ExceedsBuiltCount;
+                        builtCountExceeded = true;
+                    }
+                }
+            }
+
+            return builtCountExceeded;
         }
 
         private void FindAllRecipeLinks(RecipeRow recipe, List<ProductionLink> sources, List<ProductionLink> targets)

--- a/YAFCmodel/Model/ProductionTable.cs
+++ b/YAFCmodel/Model/ProductionTable.cs
@@ -461,18 +461,22 @@ namespace YAFC.Model
 
             }
                 
+            var builtCountExceeded = false;
             for (var i = 0; i < allRecipes.Count; i++)
             {
                 var recipe = allRecipes[i];
                 recipe.recipesPerSecond = vars[i].SolutionValue();
 
                 if (recipe.buildingCount > recipe.builtBuildings)
+                {
                     recipe.parameters.warningFlags |= WarningFlags.ExceedsBuiltCount;
+                    builtCountExceeded = true;
+                }
             }
 
             CalculateFlow(null);
             solver.Dispose();
-            return null;
+            return builtCountExceeded ? "This model requires more buildings than are currently built" : null;
         }
 
         private void FindAllRecipeLinks(RecipeRow recipe, List<ProductionLink> sources, List<ProductionLink> targets)

--- a/YAFCmodel/Model/ProductionTableContent.cs
+++ b/YAFCmodel/Model/ProductionTableContent.cs
@@ -178,6 +178,7 @@ namespace YAFC.Model
         public Goods fuel { get; set; }
         public RecipeLinks links { get; internal set; }
         public float fixedBuildings { get; set; }
+        public int? builtBuildings { get; set; }
         public bool enabled { get; set; } = true;
         public bool hierarchyEnabled { get; internal set; }
         public int tag { get; set; }

--- a/YAFCmodel/Model/RecipeParameters.cs
+++ b/YAFCmodel/Model/RecipeParameters.cs
@@ -22,6 +22,7 @@ namespace YAFC.Model
         // Solution errors
         DeadlockCandidate = 1 << 16,
         OverproductionRequired = 1 << 17,
+        ExceedsBuiltCount = 1 << 18,
         
         // Not implemented warnings
         TemperatureForIngredientNotMatch = 1 << 24,


### PR DESCRIPTION
This PR extends PR https://github.com/ShadowTheAge/yafc/pull/118 by @Saklad5 (I rebased their commits for YAFC-CE)

> Users can now specify the actual number of buildings that are built for a recipe. This has no impact on the model itself, but makes it easier to tell if existing infrastructure needs to be revisited following a change.
>
> A certain amount of surplus production capacity is almost always necessary, whether to futureproof, maintain belt balance, maximize beacon utility, or because demand is met by a non-integral number of machines. With this feature, that surplus can be tracked even if the recipe is linked.

My own addition is to make the check recursive so it shows the error on the top recipe and all subgroups until the actual recipe that has not enough buildings.

![image](https://github.com/have-fun-was-taken/yafc-ce/assets/171827/2b202499-3f5f-4ae6-8a8f-88e60a34169a)

You can see that `Tree seedling` requires 1.04 build instead of the 1 I have. The parent group (`Wood`) also has the exclamation mark and error message.
And the sheet itself shows a red error box with the message as well. (not visible in the screenshot).

This makes lack of buildings more clear, compared when they are hidden in multiple nested groups deep.