### PR TITLE
Support filtering on Factorio type

### DIFF
--- a/YAFCmodel/Data/DataUtils.cs
+++ b/YAFCmodel/Data/DataUtils.cs
@@ -536,7 +536,8 @@ namespace YAFC.Model
             {   
                 if (obj.name.IndexOf(token, StringComparison.OrdinalIgnoreCase) < 0 &&
                     obj.locName.IndexOf(token, StringComparison.InvariantCultureIgnoreCase) < 0 &&
-                    (obj.locDescr == null || obj.locDescr.IndexOf(token, StringComparison.InvariantCultureIgnoreCase) < 0)) 
+                    (obj.locDescr == null || obj.locDescr.IndexOf(token, StringComparison.InvariantCultureIgnoreCase) < 0) &&
+                    (obj.factorioType == null || obj.factorioType.IndexOf(token, StringComparison.InvariantCultureIgnoreCase) < 0))
                     return false;
             }
 


### PR DESCRIPTION
When searching for an Technology, Item, Entity, etc. in the Pyanodon mod pack. The list of entries is huge, especially when adding milestones (as it shows everything unfiltered).

This PR add the possibility to filter on types by checking the `factorioType` for the searched words as well.

Without type filter(ing) which is the original/current behavior:
![image](https://github.com/have-fun-was-taken/yafc-ce/assets/171827/d1f28426-1aff-4af6-8311-15764167c970)

Filtered on `item`:
![image](https://github.com/have-fun-was-taken/yafc-ce/assets/171827/9fdf8629-efdb-4166-a333-fa0c4abff520)

Filtered on `tech`nology:
![image](https://github.com/have-fun-was-taken/yafc-ce/assets/171827/be3f26f6-4085-41b8-b0fc-8cb54e226edc)
