### PR TITLE
Link summary should include all duplicate recipes

### DIFF
--- a/YAFCmodel/Model/ProductionTable.cs
+++ b/YAFCmodel/Model/ProductionTable.cs
@@ -233,7 +233,7 @@ namespace YAFC.Model
         {
             if (link.lastRecipe == recipe.recipe)
                 amount += (float)cst.GetCoefficient(var);
-            else link.capturedRecipes.Add(recipe);
+	        link.capturedRecipes.Add(recipe);
             link.lastRecipe = recipe.recipe;
             cst.SetCoefficient(var, amount);
         }

--- a/YAFCmodel/Model/ProductionTable.cs
+++ b/YAFCmodel/Model/ProductionTable.cs
@@ -63,7 +63,6 @@ namespace YAFC.Model
                     containsDesiredProducts = true;
                 allLinks.Add(link);
                 link.capturedRecipes.Clear();
-                link.lastRecipe = null;
             }
 
             foreach (var recipe in recipes)
@@ -228,13 +227,13 @@ namespace YAFC.Model
             flow = flowArr;
         }
 
+        /// <summary>Add/update the variable value for the constraint with the given amount, and store the recipe to the production link.</summary>
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        private void AddLinkCoef(Constraint cst, Variable var, ProductionLink link, RecipeRow recipe, float amount)
+        private static void AddLinkCoef(Constraint cst, Variable var, ProductionLink link, RecipeRow recipe, float amount)
         {
-            if (link.lastRecipe == recipe.recipe)
-                amount += (float)cst.GetCoefficient(var);
-	        link.capturedRecipes.Add(recipe);
-            link.lastRecipe = recipe.recipe;
+            // GetCoefficient will return 0 when the variable is not available in the constraint
+            amount += (float)cst.GetCoefficient(var);
+            link.capturedRecipes.Add(recipe);
             cst.SetCoefficient(var, amount);
         }
 
@@ -579,3 +578,4 @@ namespace YAFC.Model
         }
     }
 }
+

--- a/YAFCmodel/Model/ProductionTableContent.cs
+++ b/YAFCmodel/Model/ProductionTableContent.cs
@@ -336,9 +336,9 @@ namespace YAFC.Model
         public Flags flags { get; internal set; }
         public float linkFlow { get; internal set; }
         public float notMatchedFlow { get; internal set; }
+        /// <summary>List of recipes belonging to this production link</summary>
         [SkipSerialization] public List<RecipeRow> capturedRecipes { get; } = new List<RecipeRow>();
         internal int solverIndex;
-        internal Recipe lastRecipe;
         public float dualValue { get; internal set; }
 
         public ProductionLink(ProductionTable group, Goods goods) : base(group)


### PR DESCRIPTION
I had some trouble with this issue (https://github.com/ShadowTheAge/yafc/issues/167) myself and noticed it was already fixed by @macs23.
So I just rebased for YAFC-CE and the fix still works flawlessly. 

_Edit_ I fixed the formatting (tabs vs spaces)