### PR TITLE
Also use 'over color' when default background is used

### DIFF
--- a/YAFC/Widgets/ImmediateWidgets.cs
+++ b/YAFC/Widgets/ImmediateWidgets.cs
@@ -66,8 +66,10 @@ namespace YAFC
             else
             {
                 overColor = bgColor + 1;
-                if (MainScreen.Instance.IsSameObjectHovered(gui, obj))
-                    bgColor = overColor;
+            }
+            if (MainScreen.Instance.IsSameObjectHovered(gui, obj))
+            {
+                bgColor = overColor;
             }
             var evt = gui.BuildButton(rect, bgColor, overColor, button: 0);
             if (evt == ButtonEvent.MouseOver && obj != null)


### PR DESCRIPTION
When hovering over an item, which has other items it highlights them as well.
Except, when the other item has the 'default' background (black), then it is not highlighted.

This issue gets fixed by this PR.

Before (broken), when hovering over the electricity icon at the bottom right:
![before](https://github.com/have-fun-was-taken/yafc-ce/assets/171827/0296a799-215a-40c4-88c5-dafa9829f57e)

After, when hovering on the same item:
![after](https://github.com/have-fun-was-taken/yafc-ce/assets/171827/6ed33be5-0186-415f-8e68-c4cd4a14a324)
