### PR TITLE
(minor) fixes

### DIFF
--- a/YAFC/Widgets/ObjectTooltip.cs
+++ b/YAFC/Widgets/ObjectTooltip.cs
@@ -432,7 +432,7 @@ namespace YAFC
                                     gui.BuildText(DataUtils.FormatAmount(ingredient.amount, UnitOfMeasure.None));
                                 }
 
-                                gui.allocator = RectAllocator.RemainigRow;
+                                gui.allocator = RectAllocator.RemainingRow;
                                 gui.BuildFactorioObjectButtonWithText(technology);
                             }
                         }

--- a/YAFC/Windows/DependencyExplorer.cs
+++ b/YAFC/Windows/DependencyExplorer.cs
@@ -1,6 +1,5 @@
 using System.Collections.Generic;
 using System.Linq;
-using System.Runtime.CompilerServices;
 using SDL2;
 using YAFC.Model;
 using YAFC.UI;
@@ -11,8 +10,8 @@ namespace YAFC
     {
         private static readonly DependencyExplorer Instance = new DependencyExplorer();
     
-        private readonly VerticalScrollCustom dependencies;
-        private readonly VerticalScrollCustom dependants;
+        private readonly ScrollArea dependencies;
+        private readonly ScrollArea dependants;
         private static readonly Padding listPad = new Padding(0.5f);
         
         private readonly List<FactorioObject> history = new List<FactorioObject>();
@@ -34,8 +33,8 @@ namespace YAFC
         
         public DependencyExplorer() : base(60f)
         {
-            dependencies = new VerticalScrollCustom(30f, DrawDependencies);
-            dependants = new VerticalScrollCustom(30f, DrawDependants);
+            dependencies = new ScrollArea(30f, DrawDependencies);
+            dependants = new ScrollArea(30f, DrawDependants);
         }
 
         public static void Show(FactorioObject target)

--- a/YAFC/Windows/ErrorListPanel.cs
+++ b/YAFC/Windows/ErrorListPanel.cs
@@ -7,12 +7,12 @@ namespace YAFC
     {
         private static readonly ErrorListPanel Instance = new ErrorListPanel();
         private ErrorCollector collector;
-        private readonly VerticalScrollCustom verticalList;
+        private readonly ScrollArea verticalList;
         private (string error, ErrorSeverity severity)[] errors;
 
         public ErrorListPanel() : base(60f)
         {
-            verticalList = new VerticalScrollCustom(30f, BuildErrorList, default, true);
+            verticalList = new ScrollArea(30f, BuildErrorList, default, true);
         }
 
         private void BuildErrorList(ImGui gui)

--- a/YAFC/Windows/NeverEnoughItemsPanel.cs
+++ b/YAFC/Windows/NeverEnoughItemsPanel.cs
@@ -14,8 +14,8 @@ namespace YAFC
         private readonly List<Goods> recent = new List<Goods>();
         private bool atCurrentMilestones;
 
-        private readonly VerticalScrollCustom productionList;
-        private readonly VerticalScrollCustom usageList;
+        private readonly ScrollArea productionList;
+        private readonly ScrollArea usageList;
         
         private enum EntryStatus
         {
@@ -62,8 +62,8 @@ namespace YAFC
         
         public NeverEnoughItemsPanel() : base(76f)
         {
-            productionList = new VerticalScrollCustom(40f, BuildItemProduction, new Padding(0.5f));
-            usageList = new VerticalScrollCustom(40f, BuildItemUsages, new Padding(0.5f));
+            productionList = new ScrollArea(40f, BuildItemProduction, new Padding(0.5f));
+            usageList = new ScrollArea(40f, BuildItemUsages, new Padding(0.5f));
         }
 
         private void SetItem(Goods current)
@@ -204,7 +204,7 @@ namespace YAFC
                         if (recipe.products.Length < 3 && recipe.ingredients.Length < 5)
                             gui.AllocateSpacing((3 - entry.recipe.products.Length) * 3f);
                         else if (recipe.products.Length < 3)
-                            gui.allocator = RectAllocator.RemainigRow;
+                            gui.allocator = RectAllocator.RemainingRow;
                         gui.BuildIcon(Icon.ArrowRight, 3f);
                     }
                 }

--- a/YAFC/Windows/WelcomeScreen.cs
+++ b/YAFC/Windows/WelcomeScreen.cs
@@ -18,9 +18,9 @@ namespace YAFC
         private bool expensive;
         private string createText;
         private bool canCreate;
-        private readonly VerticalScrollCustom errorScroll;
-        private readonly VerticalScrollCustom recentProjectScroll;
-        private readonly VerticalScrollCustom languageScroll;
+        private readonly ScrollArea errorScroll;
+        private readonly ScrollArea recentProjectScroll;
+        private readonly ScrollArea languageScroll;
         private string errorMod;
         private string errorMessage;
         private string tip;
@@ -69,9 +69,9 @@ namespace YAFC
             RenderingUtils.SetColorScheme(Preferences.Instance.darkMode);
             var lastProject = Preferences.Instance.recentProjects.FirstOrDefault();
             SetProject(lastProject);
-            errorScroll = new VerticalScrollCustom(20f, BuildError, collapsible:true);
-            recentProjectScroll = new VerticalScrollCustom(20f, BuildRecentProjectList, collapsible:true);
-            languageScroll = new VerticalScrollCustom(20f, LanguageSelection, collapsible: true);
+            errorScroll = new ScrollArea(20f, BuildError, collapsible:true);
+            recentProjectScroll = new ScrollArea(20f, BuildRecentProjectList, collapsible:true);
+            languageScroll = new ScrollArea(20f, LanguageSelection, collapsible: true);
             Create("Welcome to YAFC CE v"+YafcLib.version.ToString(3), 45, null);
             IconCollection.ClearCustomIcons();
             if (tips == null)

--- a/YAFC/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
@@ -12,22 +12,22 @@ namespace YAFC
         private readonly List<(RecipeRow row, float flow)> input = new List<(RecipeRow, float)>();
         private readonly List<(RecipeRow row, float flow)> output = new List<(RecipeRow, float)>();
         private float totalInput, totalOutput;
-        private readonly VerticalScrollCustom scrollArea;
+        private readonly ScrollArea scrollArea;
 
         private ProductionLinkSummaryScreen()
         {
-            scrollArea = new VerticalScrollCustom(30, BuildScrollArea);
+            scrollArea = new ScrollArea(30, BuildScrollArea);
         }
 
         private void BuildScrollArea(ImGui gui)
         {
-            gui.BuildText("Production: "+DataUtils.FormatAmount(totalInput, link.goods.flowUnitOfMeasure), Font.subheader);
+            gui.BuildText("Production: " + DataUtils.FormatAmount(totalInput, link.goods.flowUnitOfMeasure), Font.subheader);
             BuildFlow(gui, input, totalInput);
             gui.spacing = 0.5f;
-            gui.BuildText("Consumption: "+DataUtils.FormatAmount(totalOutput, link.goods.flowUnitOfMeasure), Font.subheader);
+            gui.BuildText("Consumption: " + DataUtils.FormatAmount(totalOutput, link.goods.flowUnitOfMeasure), Font.subheader);
             BuildFlow(gui, output, totalOutput);
             if (link.flags.HasFlags(ProductionLink.Flags.LinkNotMatched) && totalInput != totalOutput)
-                gui.BuildText((totalInput > totalOutput ? "Overproduction: " : "Overconsumption: ") + DataUtils.FormatAmount(MathF.Abs(totalInput-totalOutput), link.goods.flowUnitOfMeasure), Font.subheader, color:SchemeColor.Error);
+                gui.BuildText((totalInput > totalOutput ? "Overproduction: " : "Overconsumption: ") + DataUtils.FormatAmount(MathF.Abs(totalInput - totalOutput), link.goods.flowUnitOfMeasure), Font.subheader, color: SchemeColor.Error);
         }
 
         public override void Build(ImGui gui)
@@ -71,7 +71,7 @@ namespace YAFC
                 {
                     input.Add((recipe, localFlow));
                     totalInput += localFlow;
-                } 
+                }
                 else if (localFlow < 0)
                 {
                     output.Add((recipe, -localFlow));

--- a/YAFCui/ImGui/ImGui.cs
+++ b/YAFCui/ImGui/ImGui.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Numerics;
 using System.Runtime.CompilerServices;
 using SDL2;
@@ -47,7 +46,7 @@ namespace YAFC.UI
         Center,
         LeftRow,
         RightRow,
-        RemainigRow,
+        RemainingRow,
         FixedRect,
         HalfRow
     }
@@ -56,17 +55,17 @@ namespace YAFC.UI
     
     public sealed partial class ImGui : IDisposable, IPanel
     {
-        public ImGui(GuiBuilder gui, Padding padding, RectAllocator defaultAllocator = RectAllocator.Stretch, bool clip = false)
+        public ImGui(GuiBuilder guiBuilder, Padding padding, RectAllocator defaultAllocator = RectAllocator.Stretch, bool clip = false)
         {
-            this.gui = gui;
-            if (gui == null)
+            this.guiBuilder = guiBuilder;
+            if (guiBuilder == null)
                 action = ImGuiAction.Build;
             this.defaultAllocator = defaultAllocator;
             this.clip = clip;
             initialPadding = padding;
         }
         
-        public readonly GuiBuilder gui;
+        public readonly GuiBuilder guiBuilder;
         public Window window { get; private set; }
         public ImGui parent { get; private set; }
         IPanel IPanel.Parent => parent;

--- a/YAFCui/ImGui/ImGuiBuilding.cs
+++ b/YAFCui/ImGui/ImGuiBuilding.cs
@@ -26,7 +26,7 @@ namespace YAFC.UI
                 color = this.color;
             }
         }
-        
+
         private readonly List<DrawCommand<RectangleBorder>> rects = new List<DrawCommand<RectangleBorder>>();
         private readonly List<DrawCommand<Icon>> icons = new List<DrawCommand<Icon>>();
         private readonly List<DrawCommand<IRenderable>> renderables = new List<DrawCommand<IRenderable>>();
@@ -75,10 +75,10 @@ namespace YAFC.UI
 
         public void ManualDrawingClear()
         {
-            if (gui == null)
+            if (guiBuilder == null)
                 ClearDrawCommandList();
         }
-        
+
         public readonly ImGuiCache<TextCache, (FontFile.FontSize size, string text, uint wrapWidth)>.Cache textCache = new ImGuiCache<TextCache, (FontFile.FontSize size, string text, uint wrapWidth)>.Cache();
 
         public FontFile.FontSize GetFontSize(Font font = null) => (font ?? Font.text).GetFontSize(pixelsPerUnit);
@@ -108,7 +108,7 @@ namespace YAFC.UI
             }
             else
             {
-                cache = textCache.GetCached((fontSize, text, wrap ? (uint) UnitsToPixels(MathF.Max(width, 5f)) : uint.MaxValue));
+                cache = textCache.GetCached((fontSize, text, wrap ? (uint)UnitsToPixels(MathF.Max(width, 5f)) : uint.MaxValue));
                 rect = AllocateRect(cache.texRect.w / pixelsPerUnit, topOffset + cache.texRect.h / pixelsPerUnit, align);
             }
 
@@ -141,7 +141,7 @@ namespace YAFC.UI
                 textInputHelper = new ImGuiTextInputHelper(this);
             return textInputHelper.BuildTextInput(text, out newText, placeholder, GetFontSize(), delayed, icon, padding, alignment, color);
         }
-        
+
         public void BuildIcon(Icon icon, float size = 1.5f, SchemeColor color = SchemeColor.None)
         {
             if (color == SchemeColor.None)
@@ -162,7 +162,7 @@ namespace YAFC.UI
 
         private bool DoGui(ImGuiAction action)
         {
-            if (gui == null)
+            if (guiBuilder == null)
                 return false;
             this.action = action;
             ResetLayout();
@@ -170,7 +170,7 @@ namespace YAFC.UI
             buildGroupsIndex = -1;
             using (EnterGroup(initialPadding, defaultAllocator, initialTextColor))
             {
-                gui(this);
+                guiBuilder(this);
             }
             actionParameter = 0;
             if (action == ImGuiAction.Build)
@@ -184,14 +184,14 @@ namespace YAFC.UI
 
         private void BuildGui(float width)
         {
-            if (gui == null)
+            if (guiBuilder == null)
                 return;
             buildWidth = width;
             nextRebuildTimer = long.MaxValue;
             rebuildRequested = false;
             ClearDrawCommandList();
             DoGui(ImGuiAction.Build);
-            contentSize = new Vector2(buildingWidth, lastRect.Bottom);
+            contentSize = new Vector2(lastRect.Right, lastRect.Bottom);
             if (boxColor != SchemeColor.None)
             {
                 var rect = new Rect(default, contentSize);
@@ -252,7 +252,7 @@ namespace YAFC.UI
                 SDL.SDL_SetCursor(RenderingUtils.cursorHand);
                 cursorSetByMouseDown = false;
             }
-                
+
             actionParameter = button;
             DoGui(ImGuiAction.MouseUp);
         }
@@ -354,7 +354,7 @@ namespace YAFC.UI
             mouseDownRect = rect;
             Rebuild();
         }
-        
+
         public void SetTextInputFocus(Rect rect, string text)
         {
             if (textInputHelper != null && InputSystem.Instance.currentKeyboardFocus != textInputHelper)
@@ -366,7 +366,6 @@ namespace YAFC.UI
 
         public void SaveToImage()
         {
-            
         }
     }
 }

--- a/YAFCui/ImGui/ImGuiLayout.cs
+++ b/YAFCui/ImGui/ImGuiLayout.cs
@@ -12,7 +12,7 @@ namespace YAFC.UI
         public Rect statePosition => new Rect(state.left, state.top, width, 0f);
         public ref RectAllocator allocator => ref state.allocator;
         public ref float spacing => ref state.spacing;
-        public Rect layoutRect => new Rect(state.left, state.top, state.bottom - state.top, state.right - state.left);
+        public Rect layoutRect => new Rect(state.left, state.top, state.right - state.left, state.bottom - state.top);
 
         private void ResetLayout()
         {
@@ -38,7 +38,8 @@ namespace YAFC.UI
 
         public Rect EncapsulateRect(Rect rect)
         {
-            return lastRect = state.EncapsulateRect(rect);
+            lastRect = state.EncapsulateRect(rect);
+            return lastRect;
         }
 
         public Rect AllocateRect(float width, float height, RectAlignment alignment, float spacing = float.NegativeInfinity)
@@ -54,15 +55,15 @@ namespace YAFC.UI
             switch (alignment)
             {
                 case RectAlignment.Middle:
-                    return new Rect(boundary.X + (boundary.Width - width) * 0.5f, boundary.Y + (boundary.Height-height) * 0.5f, width, height);
+                    return new Rect(boundary.X + (boundary.Width - width) * 0.5f, boundary.Y + (boundary.Height - height) * 0.5f, width, height);
                 case RectAlignment.MiddleLeft:
-                    return new Rect(boundary.X, boundary.Y + (boundary.Height-height) * 0.5f, width, height);
+                    return new Rect(boundary.X, boundary.Y + (boundary.Height - height) * 0.5f, width, height);
                 case RectAlignment.MiddleRight:
-                    return new Rect(boundary.X, boundary.Y + (boundary.Height-height) * 0.5f, width, height);
+                    return new Rect(boundary.X, boundary.Y + (boundary.Height - height) * 0.5f, width, height);
                 case RectAlignment.UpperCenter:
                     return new Rect(boundary.X + (boundary.Width - width) * 0.5f, boundary.Y, width, height);
                 case RectAlignment.MiddleFullRow:
-                    return new Rect(boundary.X, boundary.Y + (boundary.Height-height) * 0.5f, boundary.Width, height);
+                    return new Rect(boundary.X, boundary.Y + (boundary.Height - height) * 0.5f, boundary.Width, height);
                 default:
                     return boundary;
             }
@@ -71,7 +72,7 @@ namespace YAFC.UI
         public ImGui RemainingRow(float spacing = float.NegativeInfinity)
         {
             state.AllocateSpacing(spacing);
-            allocator = RectAllocator.RemainigRow;
+            allocator = RectAllocator.RemainingRow;
             return this;
         }
 
@@ -102,7 +103,7 @@ namespace YAFC.UI
                 state.textColor = textColor;
             return context;
         }
-        
+
         private struct CopyableState
         {
             public RectAllocator allocator;
@@ -121,23 +122,23 @@ namespace YAFC.UI
                 switch (allocator)
                 {
                     case RectAllocator.Stretch:
-                        return new Rect(left, top, right-left, height);
+                        return new Rect(left, top, right - left, height);
                     case RectAllocator.LeftAlign:
                         return new Rect(left, top, width, height);
                     case RectAllocator.RightAlign:
-                        return new Rect(right-width, top, width, height);
+                        return new Rect(right - width, top, width, height);
                     case RectAllocator.Center:
-                        return new Rect((right+left-width) * 0.5f, top, width, height);
+                        return new Rect((right + left - width) * 0.5f, top, width, height);
                     case RectAllocator.LeftRow:
                         return new Rect(left, top, width, rowHeight);
                     case RectAllocator.RightRow:
-                        return new Rect(right-width, top, width, rowHeight);
-                    case RectAllocator.RemainigRow:
-                        return new Rect(left, top, right-left, rowHeight);
+                        return new Rect(right - width, top, width, rowHeight);
+                    case RectAllocator.RemainingRow:
+                        return new Rect(left, top, right - left, rowHeight);
                     case RectAllocator.FixedRect:
-                        return new Rect(left, top, right-left, rowHeight);
+                        return new Rect(left, top, right - left, rowHeight);
                     case RectAllocator.HalfRow:
-                        return new Rect(left, top, (right-left-spacing)/2f, rowHeight);
+                        return new Rect(left, top, (right - left - spacing) / 2f, rowHeight);
                     default:
                         throw new ArgumentOutOfRangeException();
                 }
@@ -166,7 +167,7 @@ namespace YAFC.UI
                         break;
                 }
             }
-            
+
             public Rect EncapsulateRect(Rect rect)
             {
                 contextRect = hasContent ? Rect.Union(contextRect, rect) : rect;
@@ -179,28 +180,28 @@ namespace YAFC.UI
                         rect.Width = right - left;
                         break;
                     case RectAllocator.RightAlign:
-                        top = bottom = MathF.Max(rect.Bottom, top);;
+                        top = bottom = MathF.Max(rect.Bottom, top);
                         rect.Right = right;
                         break;
                     case RectAllocator.LeftAlign:
-                        top = bottom = MathF.Max(rect.Bottom, top);;
+                        top = bottom = MathF.Max(rect.Bottom, top);
                         rect.Left = left;
                         break;
                     case RectAllocator.Center:
-                        top = bottom = MathF.Max(rect.Bottom, top);;
+                        top = bottom = MathF.Max(rect.Bottom, top);
                         break;
                     case RectAllocator.LeftRow:
                         left = rect.Right;
-                        bottom = MathF.Max(rect.Bottom, bottom);;
+                        bottom = MathF.Max(rect.Bottom, bottom);
                         break;
                     case RectAllocator.RightRow:
                         right = rect.Left;
-                        bottom = MathF.Max(rect.Bottom, bottom);;
+                        bottom = MathF.Max(rect.Bottom, bottom);
                         break;
                     case RectAllocator.HalfRow:
-                        allocator = RectAllocator.RemainigRow;
+                        allocator = RectAllocator.RemainingRow;
                         left = rect.Right + spacing;
-                        bottom = MathF.Max(rect.Bottom, bottom);;
+                        bottom = MathF.Max(rect.Bottom, bottom);
                         break;
                 }
 
@@ -237,10 +238,13 @@ namespace YAFC.UI
                 gui.state = state;
                 rect.X -= padding.left;
                 rect.Y -= padding.top;
-                rect.Width += (padding.left + padding.right);
-                rect.Height += (padding.top + padding.bottom);
+                rect.Width += padding.left + padding.right;
+                rect.Height += padding.top + padding.bottom;
                 if (hasContent)
-                    gui.lastRect = gui.state.EncapsulateRect(rect);
+                {
+                    gui.state.EncapsulateRect(rect);
+                    gui.lastRect = rect;
+                }
                 else gui.lastRect = default;
             }
 

--- a/YAFCui/ImGui/ScrollArea.cs
+++ b/YAFCui/ImGui/ScrollArea.cs
@@ -77,20 +77,20 @@ namespace YAFC.UI
             {
                 if (horizontal && maxScroll.X > 0f)
                 {
-                    var fullScrollRect = new Rect(rect.X, rect.Bottom-ScrollbarSize, rect.Width, ScrollbarSize);
+                    var fullScrollRect = new Rect(rect.X, rect.Bottom - ScrollbarSize, rect.Width, ScrollbarSize);
                     var scrollRect = new Rect(rect.X + scrollStart.X, fullScrollRect.Y, scrollSize.X, ScrollbarSize);
                     BuildScrollBar(gui, 0, in fullScrollRect, in scrollRect);
                 }
 
                 if (vertical && maxScroll.Y > 0f)
                 {
-                    var fullScrollRect = new Rect(rect.Right-ScrollbarSize, rect.Y, ScrollbarSize, rect.Height);
+                    var fullScrollRect = new Rect(rect.Right - ScrollbarSize, rect.Y, ScrollbarSize, rect.Height);
                     var scrollRect = new Rect(fullScrollRect.X, rect.Y + scrollStart.Y, ScrollbarSize, scrollSize.Y);
                     BuildScrollBar(gui, 1, in fullScrollRect, in scrollRect);
                 }
             }
         }
-        
+
         private void BuildScrollBar(ImGui gui, int axis, in Rect fullScrollRect, in Rect scrollRect)
         {
             switch (gui.action)
@@ -132,7 +132,7 @@ namespace YAFC.UI
             get => _scroll.Y;
             set => scroll2d = new Vector2(_scroll.X, value);
         }
-        
+
         public float scrollX
         {
             get => _scroll.X;
@@ -175,17 +175,17 @@ namespace YAFC.UI
 
         public bool TextInput(string input) => false;
         public bool KeyUp(SDL.SDL_Keysym key) => false;
-        public void FocusChanged(bool focused) {}
+        public void FocusChanged(bool focused) { }
     }
-    
-    public abstract class ScrollArea : Scrollable
+
+    public abstract class ScrollAreaBase : Scrollable
     {
-        protected readonly ImGui contents;
+        protected ImGui contents;
         protected readonly float height;
 
-        public ScrollArea(float height, Padding padding, bool collapsible = false, bool vertical = true, bool horizontal = false) : base(vertical, horizontal, collapsible)
+        public ScrollAreaBase(float height, Padding padding, bool collapsible = false, bool vertical = true, bool horizontal = false) : base(vertical, horizontal, collapsible)
         {
-            contents = new ImGui(BuildContents, padding, clip:true);
+            contents = new ImGui(BuildContents, padding, clip: true);
             this.height = height;
         }
 
@@ -197,7 +197,7 @@ namespace YAFC.UI
 
         public void Build(ImGui gui) => Build(gui, height);
         protected abstract void BuildContents(ImGui gui);
-        
+
         public void RebuildContents()
         {
             contents.Rebuild();
@@ -209,11 +209,11 @@ namespace YAFC.UI
         }
     }
 
-    public class VerticalScrollCustom : ScrollArea
+    public class ScrollArea : ScrollAreaBase
     {
         private readonly GuiBuilder builder;
 
-        public VerticalScrollCustom(float height, GuiBuilder builder, Padding padding = default, bool collapsible = false) : base(height, padding, collapsible)
+        public ScrollArea(float height, GuiBuilder builder, Padding padding = default, bool collapsible = false, bool vertical = true, bool horizontal = false) : base(height, padding, collapsible, vertical, horizontal)
         {
             this.builder = builder;
         }
@@ -222,7 +222,7 @@ namespace YAFC.UI
         public void Rebuild() => contents.Rebuild();
     }
 
-    public class VirtualScrollList<TData> : ScrollArea
+    public class VirtualScrollList<TData> : ScrollAreaBase
     {
         private readonly Vector2 elementSize;
         protected readonly int bufferRows;


### PR DESCRIPTION
It is a collection of changes I made for https://github.com/ShadowTheAge/yafc/pull/145 to fix various things.
In order to make this (big) PR adding the summary view smaller, I moved this (and some other changed) to their own PR, before submitting the PR to add the summary view.

List of improvements/fixes:
* _Don't use 'weird' output of `EncapsulateRect()` as 'lastRect', but the actual rect of the (old) state_
  `EncapsulateRect()` changes the returned rectangle while processing it, causing rendering issues (I forgot the details, it is ages ago)
* _Improve ScrollArea class names to reflect horizontal scrolling as well, including a constructor parameter to enable horizontal scrolling_
  The ScrollArea is capable of having both vertical and horizontal scrollbars. The horizontal scrollbar is never used, and was not exposed. But the summary view needs it for larger factories or the user needs an ultra, mega, super wide screen :stuck_out_tongue: 
* _Renamed some variables_
  For clarification
* Typos and some formatting