### PR TITLE
Fix showing disallowed modules v2

### DIFF
--- a/YAFCmodel/Data/DataClasses.cs
+++ b/YAFCmodel/Data/DataClasses.cs
@@ -524,6 +524,7 @@ namespace YAFC.Model
         public float productivity { get; internal set; }
         public float pollution { get; internal set; }
         public Recipe[] limitation { get; internal set; }
+        public Recipe[] limitation_blacklist { get; internal set; }
     }
     
     public struct TemperatureRange

--- a/YAFCparser/Data/FactorioDataDeserializer.cs
+++ b/YAFCparser/Data/FactorioDataDeserializer.cs
@@ -92,7 +92,7 @@ namespace YAFC.Parser
                 Func<Item, bool> AllowedModulesFilter(Recipe key) => item => item.module.limitation_blacklist == null || !item.module.limitation_blacklist.Contains(key);
                 return universalModulesArray.Where(AllowedModulesFilter(item));
             }
-            recipeModules.SealAndDeduplicate(FilteredModules);
+            recipeModules.Seal(FilteredModules);
 
             allModules = allObjects.OfType<Item>().Where(x => x.module != null).ToArray();
             progress.Report(("Loading", "Loading fluids"));

--- a/YAFCparser/Data/FactorioDataDeserializer.cs
+++ b/YAFCparser/Data/FactorioDataDeserializer.cs
@@ -84,7 +84,7 @@ namespace YAFC.Parser
             raw = (LuaTable)data["raw"];
             foreach (var prototypeName in ((LuaTable)prototypes["item"]).ObjectElements.Keys)
                 DeserializePrototypes(raw, (string)prototypeName, DeserializeItem, progress);
-            recipeModules.SealAndDeduplicate(universalModules.ToArray());
+            recipeModules.SealAndDeduplicate(universalModules.ToArray(), null, key => x => !x.module.limitation_blacklist.Contains(key));   //Filter prevents adding univerrsal modules that have been blacklisted
             allModules = allObjects.OfType<Item>().Where(x => x.module != null).ToArray();
             progress.Report(("Loading", "Loading fluids"));
             DeserializePrototypes(raw, "fluid", DeserializeFluid, progress);
@@ -324,6 +324,16 @@ namespace YAFC.Parser
                         item.module.limitation = limitationArr;
                         foreach (var recipe in item.module.limitation)
                             recipeModules.Add(recipe, item, true);
+                    }
+                }
+
+                //Load blacklisted modules for these recipes, this will be applied later against the universal modules
+                if (table.Get("limitation_blacklist", out LuaTable limitation_blacklist))
+                {
+                    var limitationArr = limitation_blacklist.ArrayElements<string>().Select(GetObject<Recipe>).ToArray();
+                    if (limitationArr.Length > 0)
+                    {
+                        item.module.limitation_blacklist = limitationArr;
                     }
                 }
 

--- a/YAFCparser/Data/FactorioDataDeserializer.cs
+++ b/YAFCparser/Data/FactorioDataDeserializer.cs
@@ -84,7 +84,7 @@ namespace YAFC.Parser
             raw = (LuaTable)data["raw"];
             foreach (var prototypeName in ((LuaTable)prototypes["item"]).ObjectElements.Keys)
                 DeserializePrototypes(raw, (string)prototypeName, DeserializeItem, progress);
-            recipeModules.SealAndDeduplicate(universalModules.ToArray(), null, key => x => !x.module.limitation_blacklist.Contains(key));   // Filter prevents adding univerrsal modules that have been blacklisted
+            recipeModules.SealAndDeduplicate(universalModules.ToArray(), null, key => x => !x.module.limitation_blacklist.Contains(key));   // Filter prevents adding universal modules that have been blacklisted
             allModules = allObjects.OfType<Item>().Where(x => x.module != null).ToArray();
             progress.Report(("Loading", "Loading fluids"));
             DeserializePrototypes(raw, "fluid", DeserializeFluid, progress);

--- a/YAFCparser/Data/FactorioDataDeserializer.cs
+++ b/YAFCparser/Data/FactorioDataDeserializer.cs
@@ -84,7 +84,7 @@ namespace YAFC.Parser
             raw = (LuaTable)data["raw"];
             foreach (var prototypeName in ((LuaTable)prototypes["item"]).ObjectElements.Keys)
                 DeserializePrototypes(raw, (string)prototypeName, DeserializeItem, progress);
-            recipeModules.SealAndDeduplicate(universalModules.ToArray(), null, key => x => !x.module.limitation_blacklist.Contains(key));   //Filter prevents adding univerrsal modules that have been blacklisted
+            recipeModules.SealAndDeduplicate(universalModules.ToArray(), null, key => x => !x.module.limitation_blacklist.Contains(key));   // Filter prevents adding univerrsal modules that have been blacklisted
             allModules = allObjects.OfType<Item>().Where(x => x.module != null).ToArray();
             progress.Report(("Loading", "Loading fluids"));
             DeserializePrototypes(raw, "fluid", DeserializeFluid, progress);
@@ -327,7 +327,7 @@ namespace YAFC.Parser
                     }
                 }
 
-                //Load blacklisted modules for these recipes, this will be applied later against the universal modules
+                // Load blacklisted modules for these recipes, this will be applied later against the universal modules
                 if (table.Get("limitation_blacklist", out LuaTable limitation_blacklist))
                 {
                     var limitationArr = limitation_blacklist.ArrayElements<string>().Select(GetObject<Recipe>).ToArray();

--- a/YAFCparser/Data/FactorioDataDeserializer_Context.cs
+++ b/YAFCparser/Data/FactorioDataDeserializer_Context.cs
@@ -390,7 +390,7 @@ namespace YAFC.Parser
                         storage[key] = prev;
                     else
                     {
-                        //Filter the extra items based on the current key, value being processed
+                        // Filter the extra items based on the current key, value being processed
                         var tempExtra = filter != null ? addExtra.Where(filter(key)) : addExtra;
                         
                         var mergedList = tempExtra == null ? list : list.Concat(tempExtra); 

--- a/YAFCparser/Data/FactorioDataDeserializer_Context.cs
+++ b/YAFCparser/Data/FactorioDataDeserializer_Context.cs
@@ -1,7 +1,6 @@
 using System;
 using System.Collections.Generic;
 using System.Linq;
-using Microsoft.VisualBasic;
 using YAFC.Model;
 
 namespace YAFC.Parser
@@ -372,41 +371,55 @@ namespace YAFC.Parser
         private class DataBucket<TKey, TValue>: IEqualityComparer<List<TValue>>
         {
             private readonly Dictionary<TKey, IList<TValue>> storage = new Dictionary<TKey, IList<TValue>>();
-            private TValue[] def = Array.Empty<TValue>();
-            private bool seal;
+            /// <summary>This function provides a default list of values for the key for when the key is not present in the storage.</summary>
+            /// <remarks>The provided function must *must not* return null.</remarks>
+            private Func<TKey,IEnumerable<TValue>> defaultList = NoExtraItems;
 
-            // Replaces lists in storage with arrays. List with same contents get replaced with the same arrays
-            public void SealAndDeduplicate(TValue[] addExtra = null, IComparer<TValue> sort = null, System.Func<TKey, System.Func<TValue, bool>> filter = null)
+            /// <summary>When true, it is not allowed to add new items to this bucket.</summary>
+            private bool isSealed;
+
+            /// <summary>
+            /// Replaces the list values in storage with array values while (optionally) adding extra values depending on the item.
+            /// </summary>
+            /// <remarks>
+            /// Lists with same contents get replaced with the same arrays for efficiency reasons.
+            /// </remarks>
+            /// <param name="addExtraItems">Function to provide extra items, *must not* return null.</param>
+            public void SealAndDeduplicate(Func<TKey,IEnumerable<TValue>> addExtraItems = null)
             {
-                if (addExtra != null)
-                    def = addExtra;
-                var mapDict = new Dictionary<List<TValue>, TValue[]>(this);
-                var vals = storage.ToArray();
-                foreach (var (key, value) in vals)
+                if (isSealed)
+                    throw new InvalidOperationException("Data bucket is already sealed");
+
+                if (addExtraItems != null)
+                    defaultList = addExtraItems;
+
+                Dictionary<List<TValue>, TValue[]> processedValues = new Dictionary<List<TValue>, TValue[]>(this);
+                KeyValuePair<TKey, IList<TValue>>[] values = storage.ToArray();
+                foreach ((TKey key, IList<TValue> value) in values)
                 {
-                    if (!(value is List<TValue> list)) 
+                    if (value is not List<TValue> list)
+                        // Unexpected type, (probably) never happens
                         continue;
-                    if (mapDict.TryGetValue(list, out var prev))
+                    if (processedValues.TryGetValue(list, out TValue[] prev))
+                        // Already processed, just store under the new/current key
                         storage[key] = prev;
                     else
                     {
-                        IEnumerable<TValue> tempExtra = addExtra == null ? Enumerable.Empty<TValue>() : addExtra;
-                        tempExtra = filter == null ? tempExtra : tempExtra.Where(filter(key)); // Filter the extra items based on the current key and value being processed
+                        // Add the extra values to the list when provided
+                        IEnumerable<TValue> completeList = addExtraItems != null ? list.Concat(addExtraItems(key)) : list;
+                        TValue[] completeArray = completeList.ToArray();
 
-                        var mergedList = list.Concat(tempExtra);
-                        var arr = mergedList.ToArray();
-                        if (sort != null && arr.Length > 1)
-                            Array.Sort(arr, sort);
-                        mapDict[list] = arr;
-                        storage[key] = arr;
+                        processedValues[list] = completeArray;
+                        storage[key] = completeArray;
                     }
                 }
-                seal = true;
+
+                isSealed = true;
             }
 
             public void Add(TKey key, TValue value, bool checkUnique = false)
             {
-                if (seal)
+                if (isSealed)
                     throw new InvalidOperationException("Data bucket is sealed");
                 if (key == null)
                     return;
@@ -419,15 +432,26 @@ namespace YAFC.Parser
             public TValue[] GetArray(TKey key)
             {
                 if (!storage.TryGetValue(key, out var list))
-                    return def;
+                    return defaultList(key).ToArray();
                 return list is TValue[] value ? value : list.ToArray();
             }
 
             public IList<TValue> GetRaw(TKey key)
             {
                 if (!storage.TryGetValue(key, out var list))
-                    return storage[key] = def;
+                {
+                    list = defaultList(key).ToList();
+                    if (isSealed)
+                        list = list.ToArray();
+                    storage[key] = list;
+                }
                 return list;
+            }
+
+            ///<summary>Just return an empty enumerable.</summary>
+            private static IEnumerable<TValue> NoExtraItems(TKey item)
+            {
+                return Enumerable.Empty<TValue>();
             }
 
             public bool Equals(List<TValue> x, List<TValue> y)

--- a/YAFCparser/Data/FactorioDataDeserializer_Context.cs
+++ b/YAFCparser/Data/FactorioDataDeserializer_Context.cs
@@ -390,10 +390,10 @@ namespace YAFC.Parser
                         storage[key] = prev;
                     else
                     {
-                        // Filter the extra items based on the current key, value being processed
-                        var tempExtra = filter != null ? addExtra.Where(filter(key)) : addExtra;
-                        
-                        var mergedList = tempExtra == null ? list : list.Concat(tempExtra); 
+                        IEnumerable<TValue> tempExtra = addExtra == null ? Enumerable.Empty<TValue>() : addExtra;
+                        tempExtra = filter == null ? tempExtra : tempExtra.Where(filter(key)); // Filter the extra items based on the current key and value being processed
+
+                        var mergedList = list.Concat(tempExtra);
                         var arr = mergedList.ToArray();
                         if (sort != null && arr.Length > 1)
                             Array.Sort(arr, sort);

--- a/YAFCparser/Data/FactorioDataDeserializer_Context.cs
+++ b/YAFCparser/Data/FactorioDataDeserializer_Context.cs
@@ -376,7 +376,7 @@ namespace YAFC.Parser
             private bool seal;
 
             // Replaces lists in storage with arrays. List with same contents get replaced with the same arrays
-            public void SealAndDeduplicate(TValue[] addExtra = null, IComparer<TValue> sort = null)
+            public void SealAndDeduplicate(TValue[] addExtra = null, IComparer<TValue> sort = null, System.Func<TKey, System.Func<TValue, bool>> filter = null)
             {
                 if (addExtra != null)
                     def = addExtra;
@@ -390,7 +390,10 @@ namespace YAFC.Parser
                         storage[key] = prev;
                     else
                     {
-                        var mergedList = addExtra == null ? list : list.Concat(addExtra); 
+                        //Filter the extra items based on the current key, value being processed
+                        var tempExtra = filter != null ? addExtra.Where(filter(key)) : addExtra;
+                        
+                        var mergedList = tempExtra == null ? list : list.Concat(tempExtra); 
                         var arr = mergedList.ToArray();
                         if (sort != null && arr.Length > 1)
                             Array.Sort(arr, sort);

--- a/changelog.txt
+++ b/changelog.txt
@@ -9,5 +9,6 @@ Date: soon(tm)
         - YAFC:CE has an icon now!
         - Fix link summary, so it includes duplicate recipes. Previously it showed only one, which was wrong.
         - Collapse state is no longer part of the undo history.
+        - Fix showing disallowed modules for modded games.
         - other minor fixes
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
A v2 for #5 made by @craig-johnston

> It stops the efficiency and speed modules from being displayed when it's not allowed in py. by respecting the limitation_blacklist on the recipe.
> The second fix was a bit hard to fix due to the way SealAndDeduplicate was setup in the original code. Rather than refactor or clone that function. I extended it for to handle this special case.

This PR has the following additions compared to the original:
* Removed unused sort feature
* Made extraItems a function depending on the key to allow adding different items per key
* Moved 'default item' outside of SealAndDeduplicate function
* Renamed some variables to make more clear
* Added comments to clarify code