### PR TITLE
Keep original lastRect to fix some drawing glitches (e.g. in ErrorRow)

### DIFF
--- a/YAFCui/ImGui/ImGuiBuilding.cs
+++ b/YAFCui/ImGui/ImGuiBuilding.cs
@@ -191,7 +191,7 @@ namespace YAFC.UI
             rebuildRequested = false;
             ClearDrawCommandList();
             DoGui(ImGuiAction.Build);
-            contentSize = new Vector2(lastRect.Right, lastRect.Bottom);
+            contentSize = new Vector2(lastContentRect.Width, lastContentRect.Height);
             if (boxColor != SchemeColor.None)
             {
                 var rect = new Rect(default, contentSize);

--- a/YAFCui/ImGui/ImGuiLayout.cs
+++ b/YAFCui/ImGui/ImGuiLayout.cs
@@ -8,6 +8,7 @@ namespace YAFC.UI
     {
         private CopyableState state;
         public Rect lastRect { get; set; }
+        public Rect lastContentRect { get; set; }
         public float width => state.right - state.left;
         public Rect statePosition => new Rect(state.left, state.top, width, 0f);
         public ref RectAllocator allocator => ref state.allocator;
@@ -242,8 +243,8 @@ namespace YAFC.UI
                 rect.Height += padding.top + padding.bottom;
                 if (hasContent)
                 {
-                    gui.state.EncapsulateRect(rect);
-                    gui.lastRect = rect;
+                    gui.lastRect = gui.state.EncapsulateRect(rect);
+                    gui.lastContentRect = rect;
                 }
                 else gui.lastRect = default;
             }

--- a/YAFCui/ImGui/ScrollArea.cs
+++ b/YAFCui/ImGui/ScrollArea.cs
@@ -219,7 +219,7 @@ namespace YAFC.UI
         }
 
         protected override void BuildContents(ImGui gui) => builder(gui);
-        public void Rebuild() => contents.Rebuild();
+        public void Rebuild() => RebuildContents();
     }
 
     public class VirtualScrollList<TData> : ScrollAreaBase
@@ -240,7 +240,7 @@ namespace YAFC.UI
             set
             {
                 _spacing = value;
-                contents.Rebuild();
+                RebuildContents();
             }
         }
 
@@ -252,7 +252,7 @@ namespace YAFC.UI
             set
             {
                 _data = value ?? Array.Empty<TData>();
-                contents.Rebuild();
+                RebuildContents();
             }
         }
 
@@ -275,7 +275,7 @@ namespace YAFC.UI
                 base.scroll2d = value;
                 var row = CalcFirstBlock();
                 if (row != firstVisibleBlock)
-                    contents.Rebuild();
+                    RebuildContents();
             }
         }
 


### PR DESCRIPTION
#31 was missing an additional fix for the scroll area and their scrollbars.
With this I did not see any glitches anymore, and the ScrollArea size is set correctly now (showing scrollbars if needed).(hard to see/test, as it was visible for the Summary tab which will be my next PR)

Adding a lastContentRect which contains the (correct/out-of-window) size, fixes the contentSize calculation in BuildGui().
