### PR TITLE
Update to net 8

### DIFF
--- a/CommandLineToolExample/CommandLineToolExample.csproj
+++ b/CommandLineToolExample/CommandLineToolExample.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>YafcCommandLineToolExample</RootNamespace>
-    <LangVersion>8</LangVersion>
     <OutputType>Exe</OutputType>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>

--- a/CommandLineToolExample/CommandLineToolExample.csproj
+++ b/CommandLineToolExample/CommandLineToolExample.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
-    <PropertyGroup>
-        <TargetFramework>netcoreapp6.0</TargetFramework>
-        <RootNamespace>YafcCommandLineToolExample</RootNamespace>
-        <LangVersion>8</LangVersion>
-        <OutputType>Exe</OutputType>
-        <PlatformTarget>x64</PlatformTarget>
-    </PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <RootNamespace>YafcCommandLineToolExample</RootNamespace>
+    <LangVersion>8</LangVersion>
+    <OutputType>Exe</OutputType>
+    <PlatformTarget>x64</PlatformTarget>
+  </PropertyGroup>
 
     <ItemGroup>
       <ProjectReference Include="..\Yafc.Model\Yafc.Model.csproj" />

--- a/Yafc.Model.Tests/Yafc.Model.Tests.csproj
+++ b/Yafc.Model.Tests/Yafc.Model.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 

--- a/Yafc.Model/Yafc.Model.csproj
+++ b/Yafc.Model/Yafc.Model.csproj
@@ -2,7 +2,7 @@
 
     <PropertyGroup>
         <RootNamespace>Yafc.Model</RootNamespace>
-        <TargetFramework>netcoreapp6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Yafc.Model/Yafc.Model.csproj
+++ b/Yafc.Model/Yafc.Model.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <RootNamespace>Yafc.Model</RootNamespace>
         <TargetFramework>net8.0</TargetFramework>
+        <RootNamespace>Yafc.Model</RootNamespace>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Yafc.Parser/Yafc.Parser.csproj
+++ b/Yafc.Parser/Yafc.Parser.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <RootNamespace>Yafc.Parser</RootNamespace>
         <TargetFramework>net8.0</TargetFramework>
+        <RootNamespace>Yafc.Parser</RootNamespace>
         <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
         <PlatformTarget>x64</PlatformTarget>
     </PropertyGroup>

--- a/Yafc.Parser/Yafc.Parser.csproj
+++ b/Yafc.Parser/Yafc.Parser.csproj
@@ -2,9 +2,9 @@
 
     <PropertyGroup>
         <RootNamespace>Yafc.Parser</RootNamespace>
-        <TargetFramework>netcoreapp6.0</TargetFramework>
-		<RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
-		<PlatformTarget>x64</PlatformTarget>
+        <TargetFramework>net8.0</TargetFramework>
+        <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
+        <PlatformTarget>x64</PlatformTarget>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/Yafc.UI/Yafc.UI.csproj
+++ b/Yafc.UI/Yafc.UI.csproj
@@ -4,7 +4,7 @@
         <LangVersion>8</LangVersion>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <RootNamespace>Yafc.UI</RootNamespace>
-        <TargetFramework>netcoreapp6.0</TargetFramework>
+        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Yafc.UI/Yafc.UI.csproj
+++ b/Yafc.UI/Yafc.UI.csproj
@@ -1,10 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>net8.0</TargetFramework>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
         <RootNamespace>Yafc.UI</RootNamespace>
-        <TargetFramework>net8.0</TargetFramework>
     </PropertyGroup>
 
     <ItemGroup>

--- a/Yafc/Yafc.csproj
+++ b/Yafc/Yafc.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <LangVersion>8</LangVersion>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>netcoreapp6.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>
     <PlatformTarget>x64</PlatformTarget>
     <AssemblyVersion>0.6.4</AssemblyVersion>

--- a/Yafc/Yafc.csproj
+++ b/Yafc/Yafc.csproj
@@ -1,6 +1,5 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>8</LangVersion>
     <OutputType>WinExe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifiers>win-x64;linux-x64;osx-x64</RuntimeIdentifiers>

--- a/build.bat
+++ b/build.bat
@@ -1,5 +1,5 @@
 del /s /q Build 
-dotnet publish Yafc/Yafc.csproj -r win-x64 -c Release -o Build/Windows -p:PublishTrimmed=true
+dotnet publish Yafc/Yafc.csproj -r win-x64 -c Release -o Build/Windows
 dotnet publish Yafc/Yafc.csproj -r osx-x64 --self-contained false -c Release -o Build/OSX
 dotnet publish Yafc/Yafc.csproj -r linux-x64 --self-contained false -c Release -o Build/Linux
 

--- a/build.sh
+++ b/build.sh
@@ -1,5 +1,5 @@
 rm -rf Build
-dotnet publish Yafc/Yafc.csproj -r win-x64 -c Release -o Build/Windows -p:PublishTrimmed=true
+dotnet publish Yafc/Yafc.csproj -r win-x64 -c Release -o Build/Windows
 dotnet publish Yafc/Yafc.csproj -r osx-x64 --self-contained false -c Release -o Build/OSX
 dotnet publish Yafc/Yafc.csproj -r linux-x64 --self-contained false -c Release -o Build/Linux
 


### PR DESCRIPTION
#25

.net 8 upgrade. My quick non-scientific test shows no improvements in performance or mem usage (it even got marginally worse in  my tests lol)

Loading my large project:
old
![afbeelding](https://github.com/Dorus/yafc-ce/assets/4461459/19067876-f276-4609-85cf-fb192af16c4f)
new
![afbeelding](https://github.com/Dorus/yafc-ce/assets/4461459/55c90491-14eb-45db-9d51-92cb370c071c)

As a bonus, i solved:

![afbeelding](https://github.com/have-fun-was-taken/yafc-ce/assets/4461459/9ebd0d96-61ea-45b4-be63-1d2b95a14645)

Currently the project gives [MSB3270](https://learn.microsoft.com/en-us/visualstudio/msbuild/errors/msb3270?view=vs-2022).

This can be solved in 2 ways. Either remove x64 platform target from YAFCparser, or add it to the test or command line project. I've done the latter, considering it was probably added to the parser for good reaons (?).
