### PR TITLE
Enforce Java-style curly braces

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -108,7 +108,7 @@ csharp_style_inlined_variable_declaration = true:suggestion
 # C# Formatting Rules         #
 ###############################
 # New line preferences
-csharp_new_line_before_open_brace = all
+csharp_new_line_before_open_brace = none
 csharp_new_line_before_else = true
 csharp_new_line_before_catch = true
 csharp_new_line_before_finally = true
@@ -134,3 +134,7 @@ csharp_space_between_method_call_empty_parameter_list_parentheses = false
 # Wrapping preferences
 csharp_preserve_single_line_statements = true
 csharp_preserve_single_line_blocks = true
+###############################
+# YAFC-CE Code Style          #
+###############################
+dotnet_diagnostic.IDE0055.severity = error


### PR DESCRIPTION
Before anything else, the enforcement of this code style is so that it is more pleasant for me to work on the code base, because my main job is in Java.

The default of Visual Studio is opening a curly brace on a new line. However, the convention doesn't forbid changing that default.

The Java-style of opening a curly brace on the same line even has its own name in Visual Studio: [K&R][1]. K&R stands for [Kernighan & Ritchie][3].

If anyone wants to read more on why this style has merit, please refer to [this][2] article.

[1]: https://learn.microsoft.com/en-us/dotnet/fundamentals/code-analysis/style-rules/csharp-formatting-options#csharp_new_line_before_open_brace
[2]: https://gist.github.com/jesseschalken/0f47a2b5a738ced9c845
[3]: https://en.wikipedia.org/wiki/Indentation_style#K&R_style