### PR TITLE
Make the "Check for updates" action check the YAFC-CE releases

### DIFF
--- a/YAFC/Windows/AboutScreen.cs
+++ b/YAFC/Windows/AboutScreen.cs
@@ -2,7 +2,7 @@ using YAFC.UI;
 
 namespace YAFC {
     public class AboutScreen : WindowUtility {
-        public const string Github = "https://github.com/ShadowTheAge/yafc";
+        public const string Github = "https://github.com/have-fun-was-taken/yafc-ce";
 
         public AboutScreen(Window parent) : base(ImGuiUtils.DefaultScreenPadding) {
             Create("About YAFC", 50, parent);
@@ -11,6 +11,7 @@ namespace YAFC {
         protected override void BuildContents(ImGui gui) {
             gui.allocator = RectAllocator.Center;
             gui.BuildText("Yet Another Factorio Calculator", Font.header, align: RectAlignment.Middle);
+            gui.BuildText("(Community Edition)", align: RectAlignment.Middle);
             gui.BuildText("Copyright 2020-2021 ShadowTheAge", align: RectAlignment.Middle);
             gui.allocator = RectAllocator.LeftAlign;
             gui.AllocateSpacing(1.5f);
@@ -21,7 +22,7 @@ namespace YAFC {
                 BuildLink(gui, "https://gnu.org/licenses/gpl-3.0.html");
             }
             using (gui.EnterRow(0.3f)) {
-                gui.BuildText("Github YAFC page and documentation:");
+                gui.BuildText("Github YAFC-CE page and documentation:");
                 BuildLink(gui, Github);
             }
             gui.AllocateSpacing(1.5f);

--- a/YAFC/Windows/MainScreen.cs
+++ b/YAFC/Windows/MainScreen.cs
@@ -399,8 +399,8 @@ namespace YAFC {
         private async void DoCheckForUpdates() {
             try {
                 var client = new HttpClient();
-                client.DefaultRequestHeaders.Add("User-Agent", "YAFC (check for updates)");
-                var result = await client.GetStringAsync(new Uri("https://api.github.com/repos/ShadowTheAge/yafc/releases/latest"));
+                client.DefaultRequestHeaders.Add("User-Agent", "YAFC-CE (check for updates)");
+                var result = await client.GetStringAsync(new Uri("https://api.github.com/repos/have-fun-was-taken/yafc-ce/releases/latest"));
                 var release = JsonSerializer.Deserialize<GithubReleaseInfo>(result);
                 var version = release.tag_name.StartsWith("v", StringComparison.Ordinal) ? release.tag_name.Substring(1) : release.tag_name;
                 if (new Version(version) > YafcLib.version) {


### PR DESCRIPTION
This addresses #42. As suspected, the original code will target the original YAFC repo's releases API endpoint.

In addition to changing the update check URL, I also updated the GitHub URL from which the user can get the latest release when their version is out of date. The same GitHub URL is shown on the About screen too, and thus I also modified this screen's text in two places to point out that the user is running the community edition of the app.