### PR TITLE
Load projects from commandline parameters

### DIFF
--- a/Docs/CLI.md
+++ b/Docs/CLI.md
@@ -1,0 +1,23 @@
+# Command line interface
+
+YAFC can be invoked via command line:
+
+`yafc PROJECT_FILE DATA_DIR MODS_DIR [expensive]`
+
+## Description
+- `PROJECT_FILE`: The path to the project file that should be opened.
+
+- `DATA_DIR`: The path to Factorio's data directory containing game data.
+
+- `MODS_DIR`: The path to Factorio's mods directory containing additional game modifications.
+
+- `expensive`: An optional parameter to use expensive variants of recipes. If provided, the program will use expensive recipes. If not provided, the normal recipe cost is used.
+
+## Examples
+These examples assume that Factorio is installed in `C:\Factorio`.
+
+To open a project file called my_project.yafc located in the current directory:
+`yafc my_project.yafc "C:\Factorio\data" "C:\Factorio\mods"`
+
+To open the same project file with expensive recipes:
+`yafc my_project.yafc "C:\Factorio\data" "C:\Factorio\mods" expensive`

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ For tricky use cases, please refer to the [Tips and Tricks](/Docs/TipsAndTricks.
     - Automation analysis: YAFC tries to find objects that can be fully automated. For example, wood in a vanilla game cannot be fully automated because it requires to cut trees.
     - Cost analysis: YAFC assigns a cost to each object. The cost is a sum of logistic actions you need to perform to get that object, using the most optimal recipes. YAFC cost is very useful to quickly compare items and recipes. This cost also helps to find which recipes are suboptimal.
     - Flow analysis: YAFC calculates a base that produces enough science packs for all non-infinite research. It knows how much of everything you will probably need.
+- Load projects from the [command line](/Docs/CLI.md).
 
 ## Possible incompatibilities
 

--- a/YAFC/Program.cs
+++ b/YAFC/Program.cs
@@ -27,14 +27,39 @@ namespace YAFC {
 
             ProjectDefinition cliProject = null;
 
-            if (args != null && args.Length >= 3) {
+            if (args != null) {
+                if (args.Length < 3) {
+                    Console.WriteLine("Usage: YAFC <projectPath> <dataPath> <modsPath> [expensive]");
+                    Console.WriteLine("<projectPath> - path to the project file");
+                    Console.WriteLine("<dataPath>    - path to the data folder, e.g. C:\\Factorio\\data or /home/user/Factorio/data");
+                    Console.WriteLine("<modsPath>    - path to the mods folder, e.g. C:\\Factorio\\mods or /home/user/Factorio/mods");
+                    Console.WriteLine("expensive     - optional, if provided YAFC will use expensive recipes");
+                    return;
+                }
+
                 cliProject = new ProjectDefinition {
                     path = args[0],
                     dataPath = args[1],
                     modsPath = args[2]
                 };
+
                 if (args.Length >= 4) {
                     cliProject.expensive = args[3] == "expensive";
+                }
+
+                if (!File.Exists(cliProject.path)) {
+                    Console.WriteLine("Project file not found: " + cliProject.path);
+                    return;
+                }
+
+                if (!Directory.Exists(cliProject.dataPath)) {
+                    Console.WriteLine("Data folder not found: " + cliProject.dataPath);
+                    return;
+                }
+
+                if (!Directory.Exists(cliProject.modsPath)) {
+                    Console.WriteLine("Mods folder not found: " + cliProject.modsPath);
+                    return;
                 }
             }
 

--- a/YAFC/Program.cs
+++ b/YAFC/Program.cs
@@ -24,7 +24,21 @@ namespace YAFC {
             var regular = overriddenFontFile ?? new FontFile("Data/Roboto-Regular.ttf");
             Font.subheader = new Font(regular, 1.5f);
             Font.text = new Font(regular, 1f);
-            var window = new WelcomeScreen();
+
+            ProjectDefinition cliProject = null;
+
+            if (args != null && args.Length >= 3) {
+                cliProject = new ProjectDefinition {
+                    path = args[0],
+                    dataPath = args[1],
+                    modsPath = args[2]
+                };
+                if (args.Length >= 4) {
+                    cliProject.expensive = args[3] == "expensive";
+                }
+            }
+
+            var window = new WelcomeScreen(cliProject);
             Ui.MainLoop();
         }
     }

--- a/YAFC/Utils/Preferences.cs
+++ b/YAFC/Utils/Preferences.cs
@@ -38,19 +38,19 @@ namespace YAFC {
             var data = JsonSerializer.SerializeToUtf8Bytes(this, JsonUtils.DefaultOptions);
             File.WriteAllBytes(fileName, data);
         }
-        public RecentProject[] recentProjects { get; set; } = Array.Empty<RecentProject>();
+        public ProjectDefinition[] recentProjects { get; set; } = Array.Empty<ProjectDefinition>();
         public bool darkMode { get; set; }
         public string language { get; set; } = "en";
         public string overrideFont { get; set; }
 
         public void AddProject(string path, string dataPath, string modsPath, bool expensiveRecipes) {
             recentProjects = recentProjects.Where(x => string.Compare(path, x.path, StringComparison.InvariantCultureIgnoreCase) != 0)
-                .Prepend(new RecentProject { path = path, modsPath = modsPath, dataPath = dataPath, expensive = expensiveRecipes }).ToArray();
+                .Prepend(new ProjectDefinition { path = path, modsPath = modsPath, dataPath = dataPath, expensive = expensiveRecipes }).ToArray();
             Save();
         }
     }
 
-    public struct RecentProject {
+    public class ProjectDefinition {
         public string path { get; set; }
         public string dataPath { get; set; }
         public string modsPath { get; set; }

--- a/YAFC/Windows/WelcomeScreen.cs
+++ b/YAFC/Windows/WelcomeScreen.cs
@@ -61,17 +61,25 @@ namespace YAFC {
             Workspace, Factorio, Mods
         }
 
-        public WelcomeScreen() : base(ImGuiUtils.DefaultScreenPadding) {
+        public WelcomeScreen(ProjectDefinition cliProject = null) : base(ImGuiUtils.DefaultScreenPadding) {
+            tips = File.ReadAllLines("Data/Tips.txt");
+
+            IconCollection.ClearCustomIcons();
             RenderingUtils.SetColorScheme(Preferences.Instance.darkMode);
-            var lastProject = Preferences.Instance.recentProjects.FirstOrDefault();
-            SetProject(lastProject);
-            errorScroll = new ScrollArea(20f, BuildError, collapsible: true);
+
             recentProjectScroll = new ScrollArea(20f, BuildRecentProjectList, collapsible: true);
             languageScroll = new ScrollArea(20f, LanguageSelection, collapsible: true);
+            errorScroll = new ScrollArea(20f, BuildError, collapsible: true);
             Create("Welcome to YAFC CE v" + YafcLib.version.ToString(3), 45, null);
-            IconCollection.ClearCustomIcons();
-            if (tips == null)
-                tips = File.ReadAllLines("Data/Tips.txt");
+
+            if (cliProject != null) {
+                SetProject(cliProject);
+                LoadProject();
+            }
+            else {
+                ProjectDefinition lastProject = Preferences.Instance.recentProjects.FirstOrDefault();
+                SetProject(lastProject);
+            }
         }
 
         private void BuildError(ImGui gui) {
@@ -238,7 +246,7 @@ namespace YAFC {
             gui.spacing = 1.5f;
         }
 
-        private void SetProject(RecentProject project) {
+        private void SetProject(ProjectDefinition project) {
             expensive = project.expensive;
             modsPath = project.modsPath ?? "";
             path = project.path ?? "";


### PR DESCRIPTION
If there are parameters for a project file and the mods and data directories, YAFC will load the project without user interaction.
Expensive recipes are optional. Just add `expensive` at the end of the cli.

Example: `$ yafc my-mod-pack.yafc "C:\Factorio\data" "C:\Factorio\mods" expensive`

Closes #51