### PR TITLE
misc: add icon to Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# YAFC: Community Edition
+<h1 align="center">YAFC: Community Edition</h1>
+<p align="center"><IMG style="width:50px; height:auto;" src="YAFC/image.ico" alt="yafc_icon.png"></p>
+
 ### Why new repo?
 The [original](https://github.com/ShadowTheAge/yafc) YAFC repository has been inactive for a year. Bugfixes piled up, but there was no one to review and merge them. This repository aims to fix that.
 


### PR DESCRIPTION
Github aggressively sanitizes HTML, including image padding, so I didn't manage to vertically align the icon to the left of the name -- it was slightly above it. Therefore, I settled on how Angular [did][1] it, placing the icon below the name.

[1]: https://github.com/angular/angular/blob/main/README.md