### PR TITLE
Fix text alignment of about screen

### DIFF
--- a/YAFCui/ImGui/ImGuiBuilding.cs
+++ b/YAFCui/ImGui/ImGuiBuilding.cs
@@ -168,7 +168,7 @@ namespace YAFC.UI {
             rebuildRequested = false;
             ClearDrawCommandList();
             DoGui(ImGuiAction.Build);
-            contentSize = new Vector2(lastContentRect.Width, lastContentRect.Height);
+            contentSize = new Vector2(lastContentRect.Right, lastContentRect.Height);
             if (boxColor != SchemeColor.None) {
                 var rect = new Rect(default, contentSize);
                 rects.Add(new DrawCommand<RectangleBorder>(rect, boxShadow, boxColor));

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,7 @@
 Version: 0.6.2
 Date: soon(tm)
     Changes:
-        - 
+        - Fix text alignment of about screen
 ----------------------------------------------------------------------------------------------------------------------
 Version: 0.6.1
 Date: Feb 2024


### PR DESCRIPTION
This partially reverts a457eb2c5ab916f73ca3d565620f2f3438d1ca74

It looks like a bug (a right coordinate is not 'the size'), but it seems that AboutScreen is depending on this. Probably because the close icon is right aligned.

Fixes #47 