### PR TITLE
Assign application icon to the YAFC windows

### DIFF
--- a/YAFC/YAFC.csproj
+++ b/YAFC/YAFC.csproj
@@ -14,6 +14,9 @@
     <None Update="Data/**/*">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Update="image.ico">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <ContentWithTargetPath Include="lib\windows\*" Condition="('$(RuntimeIdentifier)' == 'win-x64') Or ('$(OS)' == 'Windows_NT')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <TargetPath>%(Filename)%(Extension)</TargetPath>

--- a/YAFCui/Core/Window.cs
+++ b/YAFCui/Core/Window.cs
@@ -6,6 +6,8 @@ namespace YAFC.UI {
     public abstract class Window : IDisposable {
         public readonly ImGui rootGui;
         internal IntPtr window;
+        /// <summary>Window icon, singleton so it is reused for all windows</summary>
+        internal static IntPtr icon;
         internal Vector2 contentSize;
         internal uint id;
         internal bool repaintRequired = true;
@@ -33,11 +35,26 @@ namespace YAFC.UI {
         }
 
         internal void Create() {
+            SDL.SDL_SetWindowIcon(window, GetIcon());
+
             _ = SDL.SDL_SetRenderDrawBlendMode(surface.renderer, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
             id = SDL.SDL_GetWindowID(window);
             Ui.CloseWidowOfType(GetType());
             Ui.RegisterWindow(id, this);
             visible = true;
+        }
+
+        /// <summary>Load, if needed, the window icon and return its SDL_Surface pointer, or IntPtr.Zero if not loaded due to errors</summary>
+        internal static IntPtr GetIcon() {
+            if (icon == IntPtr.Zero) {
+                icon = SDL_image.IMG_Load("image.ico");
+                if (icon == IntPtr.Zero) {
+                    string error = SDL.SDL_GetError();
+                    Console.WriteLine("Failed to load application icon: " + error);
+                }
+            }
+
+            return icon;
         }
 
         internal int CalculateUnitsToPixels(int display) {


### PR DESCRIPTION
Tested under Linux, and it shows the icon in all the windows:

![image](https://github.com/have-fun-was-taken/yafc-ce/assets/171827/e95e8187-d7a1-4619-b6e8-e3ba2906e0ba)

As mentioned in #36, it looks like they made some changed in dotnet 8.0 by embedded the icon, manifest, etc. into the non-Windows binaries as well. So when we switch to this, we might need to take a look and check if this is still needed.

This PR also includes the icon in the releases (archives), so it can be used for other purposes (for example by packagers to show the icon in a start menu, or as a save file icon).

It would be nice if others can check if this also works for MacOS and it is not breaking Windows icons.

Fixes #36