### PR TITLE
Color allowed and actual overproduction

### DIFF
--- a/YAFC/Workspace/ProductionTable/ProductionTableView.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableView.cs
@@ -822,8 +822,15 @@ goodsHaveNoProduction:;
         private void DrawDesiredProduct(ImGui gui, ProductionLink element) {
             gui.allocator = RectAllocator.Stretch;
             gui.spacing = 0f;
-            bool error = element.flags.HasFlags(ProductionLink.Flags.LinkNotMatched);
-            var evt = gui.BuildFactorioObjectWithEditableAmount(element.goods, element.amount, element.goods.flowUnitOfMeasure, out float newAmount, error ? SchemeColor.Error : SchemeColor.Primary);
+
+            SchemeColor iconColor;
+            if (element.flags.HasFlags(ProductionLink.Flags.LinkNotMatched)) {
+                iconColor = SchemeColor.Error;
+            }
+            else {
+                iconColor = SchemeColor.Primary;
+            }
+            var evt = gui.BuildFactorioObjectWithEditableAmount(element.goods, element.amount, element.goods.flowUnitOfMeasure, out float newAmount, iconColor);
             if (evt == GoodsWithAmountEvent.ButtonClick) {
                 OpenProductDropdown(gui, gui.lastRect, element.goods, element.amount, element, ProductDropdownType.DesiredProduct, null, element.owner);
             }
@@ -838,9 +845,28 @@ goodsHaveNoProduction:;
         }
 
         private void BuildGoodsIcon(ImGui gui, Goods goods, ProductionLink link, float amount, ProductDropdownType dropdownType, RecipeRow recipe, ProductionTable context, Goods[] variants = null) {
-            bool linkIsError = link != null && ((link.flags & (ProductionLink.Flags.HasProductionAndConsumption | ProductionLink.Flags.LinkRecursiveNotMatched | ProductionLink.Flags.ChildNotMatched)) != ProductionLink.Flags.HasProductionAndConsumption);
-            bool linkIsForeign = link != null && link.owner != context;
-            if (gui.BuildFactorioObjectWithAmount(goods, amount, goods?.flowUnitOfMeasure ?? UnitOfMeasure.None, link != null ? linkIsError ? SchemeColor.Error : linkIsForeign ? SchemeColor.Secondary : SchemeColor.Primary : goods.IsSourceResource() ? SchemeColor.Green : SchemeColor.None)) {
+            SchemeColor iconColor;
+            if (link != null) {
+                // The icon is part of a production link
+                if ((link.flags & (ProductionLink.Flags.HasProductionAndConsumption | ProductionLink.Flags.LinkRecursiveNotMatched | ProductionLink.Flags.ChildNotMatched)) != ProductionLink.Flags.HasProductionAndConsumption) {
+                    // The link has production and consumption sides, but either the production and consumption is not matched, or 'child was not matched'
+                    iconColor = SchemeColor.Error;
+                }
+                else if (link.owner != context) {
+                    // It is a foreign link (e.g. not part of the sub group)
+                    iconColor = SchemeColor.Secondary;
+                }
+                else {
+                    // Regular (nothing going on) linked icon
+                    iconColor = SchemeColor.Primary;
+                }
+            }
+            else {
+                // The icon is not part of a production link
+                iconColor = goods.IsSourceResource() ? SchemeColor.Green : SchemeColor.None;
+            }
+
+            if (gui.BuildFactorioObjectWithAmount(goods, amount, goods?.flowUnitOfMeasure ?? UnitOfMeasure.None, iconColor)) {
                 OpenProductDropdown(gui, gui.lastRect, goods, amount, link, dropdownType, recipe, context, variants);
             }
         }

--- a/YAFC/Workspace/ProductionTable/ProductionTableView.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableView.cs
@@ -825,7 +825,8 @@ goodsHaveNoProduction:;
 
             SchemeColor iconColor;
             if (element.flags.HasFlags(ProductionLink.Flags.LinkNotMatched)) {
-                iconColor = SchemeColor.Error;
+                // Actual overproduction occurred for this product
+                iconColor = SchemeColor.Magenta;
             }
             else {
                 iconColor = SchemeColor.Primary;
@@ -851,6 +852,10 @@ goodsHaveNoProduction:;
                 if ((link.flags & (ProductionLink.Flags.HasProductionAndConsumption | ProductionLink.Flags.LinkRecursiveNotMatched | ProductionLink.Flags.ChildNotMatched)) != ProductionLink.Flags.HasProductionAndConsumption) {
                     // The link has production and consumption sides, but either the production and consumption is not matched, or 'child was not matched'
                     iconColor = SchemeColor.Error;
+                }
+                else if (link.algorithm == LinkAlgorithm.AllowOverProduction && dropdownType == ProductDropdownType.Product && (link.flags & ProductionLink.Flags.LinkNotMatched) != 0) {
+                    // Actual overproduction occurred in the recipe
+                    iconColor = SchemeColor.Magenta;
                 }
                 else if (link.owner != context) {
                     // It is a foreign link (e.g. not part of the sub group)

--- a/YAFC/Workspace/SummaryView.cs
+++ b/YAFC/Workspace/SummaryView.cs
@@ -102,7 +102,6 @@ namespace YAFC {
                     iconColor = SchemeColor.Error;
                 }
 
-
                 gui.allocator = RectAllocator.Stretch;
                 gui.spacing = 0f;
                 GoodsWithAmountEvent evt = gui.BuildFactorioObjectWithEditableAmount(element.goods, element.amount, element.goods.flowUnitOfMeasure, out float newAmount, iconColor);

--- a/YAFCui/Core/Structs.cs
+++ b/YAFCui/Core/Structs.cs
@@ -35,6 +35,11 @@
         GreyAlt,
         GreyText,
         GreyTextFaint,
+        // Magenta group (indicate overproduction)
+        Magenta,
+        MagentaAlt,
+        MagentaText,
+        MagentaTextFaint,
         // Green group
         Green,
         GreenAlt,

--- a/YAFCui/Rendering/RenderingUtils.cs
+++ b/YAFCui/Rendering/RenderingUtils.cs
@@ -32,6 +32,7 @@ namespace YAFC.UI {
             ColorFromHex(0xff9800), ColorFromHex(0xc66900), Black, BlackTransparent, // Secondary group
             ColorFromHex(0xbf360c), ColorFromHex(0x870000), White, WhiteTransparent, // Error group
             ColorFromHex(0xe4e4e4), ColorFromHex(0xc4c4c4), Black, BlackTransparent, // Grey group
+            ColorFromHex(0xbd33a4), ColorFromHex(0x8b008b), Black, BlackTransparent, // Magenta group
             ColorFromHex(0x6abf69), ColorFromHex(0x388e3c), Black, BlackTransparent, // Green group
         };
 
@@ -44,6 +45,7 @@ namespace YAFC.UI {
             ColorFromHex(0x5b2800), ColorFromHex(0x8c5100), White, WhiteTransparent, // Secondary group
             ColorFromHex(0xbf360c), ColorFromHex(0x870000), White, WhiteTransparent, // Error group
             ColorFromHex(0x343434), ColorFromHex(0x545454), White, WhiteTransparent, // Grey group
+            ColorFromHex(0x8b008b), ColorFromHex(0xbd33a4), Black, BlackTransparent, // Magenta group
             ColorFromHex(0x00600f), ColorFromHex(0x00701a), Black, BlackTransparent, // Green group
         };
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -8,6 +8,7 @@ Expected Date: March 2024
           - Support the search box (ctrl+F)
         - Fix text alignment of about screen
         - Fix width of 'Target technology for cost analysis' preference popup
+        - Show actual overproduction with a magenta background color
         - Fix some typos
 ----------------------------------------------------------------------------------------------------------------------
 Version: 0.6.1


### PR DESCRIPTION
First I cleaned up the coloring logic. Unfortunately the link flags are not documented, so I have no idea what some of the flags mean (in their nuanced ways)... Especially `ChildNotMatched` I have no idea about.

I added a new color for allowed overproduction. I picked magenta as it is close to red (error), feel free to provide another color scheme. BTW For light/dark theme I switched the main/highlight colors (I am not too artistic and finding only/just one set of colors was already the hardest part of the PR :rofl: )

Activated Carbon allows for overproduction:
![image](https://github.com/have-fun-was-taken/yafc-ce/assets/171827/51954692-4de5-4e35-81ee-174a5fedec19)

Activated Carbon is over produced (forced by the increased Nitrogen production):
![image](https://github.com/have-fun-was-taken/yafc-ce/assets/171827/713d1882-ad50-461f-9739-86772b960557)

The allowed overproduction is also shown in the Summary tab (actual over production is not, as there are already enough errors when the production sheets are unbalanced).

Fixes #8 