### PR TITLE
Add missing dependency to YAFCparser

### DIFF
--- a/CommandLineToolExample/CommandLineToolExample.csproj
+++ b/CommandLineToolExample/CommandLineToolExample.csproj
@@ -10,6 +10,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\YAFCmodel\YAFCmodel.csproj" />
+      <ProjectReference Include="..\YAFCparser\YAFCparser.csproj" />
       <ProjectReference Include="..\YAFC\YAFC.csproj" />
     </ItemGroup>
 


### PR DESCRIPTION
The dependency is used here:
https://github.com/have-fun-was-taken/yafc-ce/blob/703127a859190b58fe02586036363cd5ce4e1f8b/CommandLineToolExample/Program.cs#L4