### PR TITLE
Select multiple objects

### DIFF
--- a/YAFC/Widgets/ImmediateWidgets.cs
+++ b/YAFC/Widgets/ImmediateWidgets.cs
@@ -150,7 +150,12 @@ namespace YAFC {
                 }
 
                 if (list.Count > count && gui.BuildButton("See full list") && gui.CloseDropdown()) {
-                    SelectObjectPanel.Select(list, header, select, ordering, allowNone);
+                    if (multiple) {
+                        SelectMultiObjectPanel.Select(list, header, select, ordering, allowNone);
+                    }
+                    else {
+                        SelectSingleObjectPanel.Select(list, header, select, ordering, allowNone);
+                    }
                 }
 
                 if (multiple && list.Count > 1) {

--- a/YAFC/Widgets/ImmediateWidgets.cs
+++ b/YAFC/Widgets/ImmediateWidgets.cs
@@ -151,7 +151,7 @@ namespace YAFC {
 
                 if (list.Count > count && gui.BuildButton("See full list") && gui.CloseDropdown()) {
                     if (multiple) {
-                        SelectMultiObjectPanel.Select(list, header, select, ordering, allowNone);
+                        SelectMultiObjectPanel.Select(list, header, select, ordering, allowNone, checkMark);
                     }
                     else {
                         SelectSingleObjectPanel.Select(list, header, select, ordering, allowNone);

--- a/YAFC/Widgets/PseudoScreen.cs
+++ b/YAFC/Widgets/PseudoScreen.cs
@@ -68,9 +68,14 @@ namespace YAFC {
             if (key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_ESCAPE) {
                 Close(false);
             }
+            if (key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_RETURN || key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_RETURN2 || key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_KP_ENTER) {
+                ReturnPressed();
+            }
 
             return true;
         }
+
+        protected virtual void ReturnPressed() { }
 
         public virtual bool TextInput(string input) {
             return true;

--- a/YAFC/Windows/DependencyExplorer.cs
+++ b/YAFC/Windows/DependencyExplorer.cs
@@ -111,7 +111,7 @@ namespace YAFC {
             using (gui.EnterRow()) {
                 gui.BuildText("Currently inspecting:", Font.subheader);
                 if (gui.BuildFactorioObjectButtonWithText(current)) {
-                    SelectObjectPanel.Select(Database.objects.all, "Select something", Change);
+                    SelectSingleObjectPanel.Select(Database.objects.all, "Select something", Change);
                 }
 
                 gui.BuildText("(Click to change)", color: SchemeColor.BackgroundTextFaint);

--- a/YAFC/Windows/MainScreen.cs
+++ b/YAFC/Windows/MainScreen.cs
@@ -340,7 +340,7 @@ namespace YAFC {
         }
 
         private void ShowNeie() {
-            SelectObjectPanel.Select(Database.goods.all, "Open NEIE", NeverEnoughItemsPanel.Show);
+            SelectSingleObjectPanel.Select(Database.goods.all, "Open NEIE", NeverEnoughItemsPanel.Show);
         }
 
         private void SetSearch(SearchQuery searchQuery) {
@@ -420,7 +420,7 @@ namespace YAFC {
             }
 
             if (gui.BuildContextMenuButton("Dependency Explorer") && gui.CloseDropdown()) {
-                SelectObjectPanel.Select(Database.objects.all, "Open Dependency Explorer", DependencyExplorer.Show);
+                SelectSingleObjectPanel.Select(Database.objects.all, "Open Dependency Explorer", DependencyExplorer.Show);
             }
 
             BuildSubHeader(gui, "Extra");

--- a/YAFC/Windows/MessageBox.cs
+++ b/YAFC/Windows/MessageBox.cs
@@ -5,17 +5,12 @@ using YAFC.UI;
 namespace YAFC {
     public class MessageBox : PseudoScreen<bool> {
         public MessageBox() : base(30f) { }
-        private static readonly MessageBox Instance = new MessageBox();
 
         private string title, message, yes, no;
 
         public static void Show(Action<bool, bool> result, string title, string message, string yes, string no) {
-            Instance.title = title;
-            Instance.complete = result;
-            Instance.message = message;
-            Instance.yes = yes;
-            Instance.no = no;
-            _ = MainScreen.Instance.ShowPseudoScreen(Instance);
+            MessageBox instance = new MessageBox { title = title, complete = result, message = message, yes = yes, no = no };
+            _ = MainScreen.Instance.ShowPseudoScreen(instance);
         }
 
         public static void Show(string title, string message, string yes) {

--- a/YAFC/Windows/MilestonesEditor.cs
+++ b/YAFC/Windows/MilestonesEditor.cs
@@ -53,7 +53,7 @@ namespace YAFC {
                     milestoneList.RebuildContents();
                 }
                 if (gui.BuildButton("Add milestone")) {
-                    SelectObjectPanel.Select(Database.objects.all, "Add new milestone", AddMilestone);
+                    SelectMultiObjectPanel.Select(Database.objects.all, "Add new milestone", AddMilestone);
                 }
             }
         }

--- a/YAFC/Windows/MilestonesEditor.cs
+++ b/YAFC/Windows/MilestonesEditor.cs
@@ -1,4 +1,5 @@
-﻿using System.Numerics;
+﻿using System.Linq;
+using System.Numerics;
 using YAFC.Model;
 using YAFC.UI;
 
@@ -53,7 +54,7 @@ namespace YAFC {
                     milestoneList.RebuildContents();
                 }
                 if (gui.BuildButton("Add milestone")) {
-                    SelectMultiObjectPanel.Select(Database.objects.all, "Add new milestone", AddMilestone);
+                    SelectMultiObjectPanel.Select(Database.objects.all.Except(Project.current.settings.milestones), "Add new milestone", AddMilestone);
                 }
             }
         }

--- a/YAFC/Windows/NeverEnoughItemsPanel.cs
+++ b/YAFC/Windows/NeverEnoughItemsPanel.cs
@@ -343,7 +343,7 @@ namespace YAFC {
             }
 
             if (gui.BuildFactorioObjectButton(gui.lastRect, current, SchemeColor.Grey)) {
-                SelectObjectPanel.Select(Database.goods.all, "Select item", SetItem);
+                SelectSingleObjectPanel.Select(Database.goods.all, "Select item", SetItem);
             }
 
             using (var split = gui.EnterHorizontalSplit(2)) {

--- a/YAFC/Windows/ProjectPageSettingsPanel.cs
+++ b/YAFC/Windows/ProjectPageSettingsPanel.cs
@@ -22,7 +22,7 @@ namespace YAFC {
         public static void Build(ImGui gui, ref string name, FactorioObject icon, Action<FactorioObject> setIcon) {
             _ = gui.BuildTextInput(name, out name, "Input name");
             if (gui.BuildFactorioObjectButton(icon, 4f, MilestoneDisplay.None, SchemeColor.Grey)) {
-                SelectObjectPanel.Select(Database.objects.all, "Select icon", setIcon);
+                SelectSingleObjectPanel.Select(Database.objects.all, "Select icon", setIcon);
             }
 
             if (icon == null && gui.isBuilding) {

--- a/YAFC/Windows/SelectMultiObjectPanel.cs
+++ b/YAFC/Windows/SelectMultiObjectPanel.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Numerics;
 using YAFC.Model;
 using YAFC.UI;
 
@@ -9,16 +10,18 @@ namespace YAFC {
         private static readonly SelectMultiObjectPanel Instance = new SelectMultiObjectPanel();
         private readonly HashSet<FactorioObject> results = new HashSet<FactorioObject>();
         private bool allowAutoClose;
+        private Predicate<FactorioObject> checkMark;
 
         public SelectMultiObjectPanel() : base() { }
 
-        public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, bool allowNone = false) where T : FactorioObject {
-            Select(list, header, select, DataUtils.DefaultOrdering, allowNone);
+        public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, bool allowNone = false, Predicate<T> checkMark = null) where T : FactorioObject {
+            Select(list, header, select, DataUtils.DefaultOrdering, allowNone, checkMark);
         }
 
-        public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, IComparer<T> ordering, bool allowNone = false) where T : FactorioObject {
+        public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, IComparer<T> ordering, bool allowNone = false, Predicate<T> checkMark = null) where T : FactorioObject {
             Instance.allowAutoClose = true;
             Instance.results.Clear();
+            Instance.checkMark = (o) => checkMark?.Invoke((T)o) ?? false; // This is messy, but pushing T all the way around the call stack and type tree was messier.
             Instance.Select(list, header, select, ordering, (xs, selectItem) => {
                 foreach (var x in xs ?? Enumerable.Empty<T>()) {
                     selectItem(x);
@@ -27,7 +30,13 @@ namespace YAFC {
         }
 
         protected override void NonNullElementDrawer(ImGui gui, FactorioObject element, int index) {
-            if (gui.BuildFactorioObjectButton(element, display: MilestoneDisplay.Contained, bgColor: results.Contains(element) ? SchemeColor.Primary : SchemeColor.None, extendHeader: extendHeader)) {
+            bool click = gui.BuildFactorioObjectButton(element, display: MilestoneDisplay.Contained, bgColor: results.Contains(element) ? SchemeColor.Primary : SchemeColor.None, extendHeader: extendHeader);
+
+            if (checkMark(element)) {
+                gui.DrawIcon(Rect.SideRect(gui.lastRect.TopLeft + new Vector2(1, 0), gui.lastRect.BottomRight - new Vector2(0, 1)), Icon.Check, SchemeColor.Green);
+            }
+
+            if (click) {
                 if (!results.Add(element)) {
                     results.Remove(element);
                 }

--- a/YAFC/Windows/SelectMultiObjectPanel.cs
+++ b/YAFC/Windows/SelectMultiObjectPanel.cs
@@ -1,0 +1,37 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using YAFC.Model;
+using YAFC.UI;
+
+namespace YAFC {
+    public class SelectMultiObjectPanel : SelectObjectPanel<IEnumerable<FactorioObject>> {
+        private static readonly SelectMultiObjectPanel Instance = new SelectMultiObjectPanel();
+        private readonly HashSet<FactorioObject> results = new HashSet<FactorioObject>();
+        public SelectMultiObjectPanel() : base() { }
+
+        public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, bool allowNone = false) where T : FactorioObject {
+            Select(list, header, select, DataUtils.DefaultOrdering, allowNone);
+        }
+
+        public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, IComparer<T> ordering, bool allowNone = false) where T : FactorioObject {
+            Instance.results.Clear();
+            Instance.Select(list, header, select, ordering, (xs, selectItem) => {
+                foreach (var x in xs ?? Enumerable.Empty<T>()) {
+                    selectItem(x);
+                }
+            }, allowNone);
+        }
+
+        protected override void NonNullElementDrawer(ImGui gui, FactorioObject element, int index) {
+            if (gui.BuildFactorioObjectButton(element, display: MilestoneDisplay.Contained, bgColor: results.Contains(element) ? SchemeColor.Primary : SchemeColor.None, extendHeader: extendHeader)) {
+                if (!results.Add(element)) {
+                    results.Remove(element);
+                }
+                if (!InputSystem.Instance.control) {
+                    CloseWithResult(results);
+                }
+            }
+        }
+    }
+}

--- a/YAFC/Windows/SelectMultiObjectPanel.cs
+++ b/YAFC/Windows/SelectMultiObjectPanel.cs
@@ -8,6 +8,8 @@ namespace YAFC {
     public class SelectMultiObjectPanel : SelectObjectPanel<IEnumerable<FactorioObject>> {
         private static readonly SelectMultiObjectPanel Instance = new SelectMultiObjectPanel();
         private readonly HashSet<FactorioObject> results = new HashSet<FactorioObject>();
+        private bool allowAutoClose;
+
         public SelectMultiObjectPanel() : base() { }
 
         public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, bool allowNone = false) where T : FactorioObject {
@@ -15,6 +17,7 @@ namespace YAFC {
         }
 
         public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, IComparer<T> ordering, bool allowNone = false) where T : FactorioObject {
+            Instance.allowAutoClose = true;
             Instance.results.Clear();
             Instance.Select(list, header, select, ordering, (xs, selectItem) => {
                 foreach (var x in xs ?? Enumerable.Empty<T>()) {
@@ -28,9 +31,20 @@ namespace YAFC {
                 if (!results.Add(element)) {
                     results.Remove(element);
                 }
-                if (!InputSystem.Instance.control) {
+                if (!InputSystem.Instance.control && allowAutoClose) {
                     CloseWithResult(results);
                 }
+                allowAutoClose = false;
+            }
+        }
+
+        public override void Build(ImGui gui) {
+            base.Build(gui);
+            using (gui.EnterGroup(default, RectAllocator.Center)) {
+                if (gui.BuildButton("OK")) {
+                    CloseWithResult(results);
+                }
+                gui.BuildText("Hint: ctrl+click to select multiple", color: SchemeColor.BackgroundTextFaint);
             }
         }
     }

--- a/YAFC/Windows/SelectMultiObjectPanel.cs
+++ b/YAFC/Windows/SelectMultiObjectPanel.cs
@@ -47,5 +47,9 @@ namespace YAFC {
                 gui.BuildText("Hint: ctrl+click to select multiple", color: SchemeColor.BackgroundTextFaint);
             }
         }
+
+        protected override void ReturnPressed() {
+            CloseWithResult(results);
+        }
     }
 }

--- a/YAFC/Windows/SelectObjectPanel.cs
+++ b/YAFC/Windows/SelectObjectPanel.cs
@@ -6,62 +6,62 @@ using YAFC.Model;
 using YAFC.UI;
 
 namespace YAFC {
-    public class SelectObjectPanel : PseudoScreen<FactorioObject> {
-        private static readonly SelectObjectPanel Instance = new SelectObjectPanel();
-        private readonly SearchableList<FactorioObject> list;
-        private string header;
-        private Rect searchBox;
-        private bool extendHeader;
-        public SelectObjectPanel() : base(40f) {
+    public abstract class SelectObjectPanel<T> : PseudoScreen<T> {
+        protected readonly SearchableList<FactorioObject> list;
+        protected string header;
+        protected Rect searchBox;
+        protected bool extendHeader;
+
+        protected SelectObjectPanel() : base(40f) {
             list = new SearchableList<FactorioObject>(30, new Vector2(2.5f, 2.5f), ElementDrawer, ElementFilter);
         }
 
-        private bool ElementFilter(FactorioObject data, SearchQuery query) {
-            return data.Match(query);
-        }
-
-        public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, IComparer<T> ordering, bool allowNone) where T : FactorioObject {
-            _ = MainScreen.Instance.ShowPseudoScreen(Instance);
-            Instance.extendHeader = typeof(T) == typeof(FactorioObject);
-            List<T> data = new List<T>(list);
+        protected void Select<U>(IEnumerable<U> list, string header, Action<U> select, IComparer<U> ordering, Action<T, Action<FactorioObject>> process, bool allowNone) where U : FactorioObject {
+            _ = MainScreen.Instance.ShowPseudoScreen(this);
+            extendHeader = typeof(U) == typeof(FactorioObject);
+            List<U> data = new List<U>(list);
             data.Sort(ordering);
             if (allowNone) {
                 data.Insert(0, null);
             }
 
-            Instance.list.filter = default;
-            Instance.list.data = data;
-            Instance.header = header;
-            Instance.Rebuild();
-            Instance.complete = (selected, x) => {
-                if (x is T t) {
-                    if (ordering is DataUtils.FavoritesComparer<T> favoritesComparer) {
-                        favoritesComparer.AddToFavorite(t);
+            this.list.filter = default;
+            this.list.data = data;
+            this.header = header;
+            Rebuild();
+            complete = (selected, x) => process(x, x => {
+                if (x is U u) {
+                    if (ordering is DataUtils.FavoritesComparer<U> favoritesComparer) {
+                        favoritesComparer.AddToFavorite(u);
                     }
 
-                    select(t);
+                    select(u);
                 }
                 else if (allowNone && selected) {
                     select(null);
                 }
-            };
+            });
         }
 
-        public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, bool allowNone = false) where T : FactorioObject {
-            Select(list, header, select, DataUtils.DefaultOrdering, allowNone);
+        protected void Select<U>(IEnumerable<U> list, string header, Action<U> select, Action<T, Action<FactorioObject>> process, bool allowNone = false) where U : FactorioObject {
+            Select(list, header, select, DataUtils.DefaultOrdering, process, allowNone);
         }
 
         private void ElementDrawer(ImGui gui, FactorioObject element, int index) {
             if (element == null) {
                 if (gui.BuildRedButton(Icon.Close)) {
-                    CloseWithResult(null);
+                    CloseWithResult(default);
                 }
             }
             else {
-                if (gui.BuildFactorioObjectButton(element, display: MilestoneDisplay.Contained, extendHeader: extendHeader)) {
-                    CloseWithResult(element);
-                }
+                NonNullElementDrawer(gui, element, index);
             }
+        }
+
+        protected abstract void NonNullElementDrawer(ImGui gui, FactorioObject element, int index);
+
+        private bool ElementFilter(FactorioObject data, SearchQuery query) {
+            return data.Match(query);
         }
 
         public override void Build(ImGui gui) {

--- a/YAFC/Windows/SelectSingleObjectPanel.cs
+++ b/YAFC/Windows/SelectSingleObjectPanel.cs
@@ -1,0 +1,25 @@
+﻿using System;
+using System.Collections.Generic;
+using YAFC.Model;
+using YAFC.UI;
+
+namespace YAFC {
+    public class SelectSingleObjectPanel : SelectObjectPanel<FactorioObject> {
+        private static readonly SelectSingleObjectPanel Instance = new SelectSingleObjectPanel();
+        public SelectSingleObjectPanel() : base() { }
+
+        public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, bool allowNone = false) where T : FactorioObject {
+            Select(list, header, select, DataUtils.DefaultOrdering, allowNone);
+        }
+
+        public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, IComparer<T> ordering, bool allowNone = false) where T : FactorioObject {
+            Instance.Select(list, header, select, ordering, (x, selectItem) => selectItem(x), allowNone);
+        }
+
+        protected override void NonNullElementDrawer(ImGui gui, FactorioObject element, int index) {
+            if (gui.BuildFactorioObjectButton(element, display: MilestoneDisplay.Contained, extendHeader: extendHeader)) {
+                CloseWithResult(element);
+            }
+        }
+    }
+}

--- a/YAFC/Workspace/AutoPlannerView.cs
+++ b/YAFC/Workspace/AutoPlannerView.cs
@@ -45,7 +45,7 @@ namespace YAFC {
                     }
                     grid.Next();
                     if (gui.BuildButton(Icon.Plus, SchemeColor.Primary, SchemeColor.PrimaryAlt, size: 2.5f)) {
-                        SelectObjectPanel.Select(Database.goods.all, "New production goal", x => {
+                        SelectSingleObjectPanel.Select(Database.goods.all, "New production goal", x => {
                             goal.Add(new AutoPlannerGoal { amount = 1f, item = x });
                             gui.Rebuild();
                         });

--- a/YAFC/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/YAFC/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -31,7 +31,7 @@ namespace YAFC {
             if (template != null) {
                 using (gui.EnterRow()) {
                     if (gui.BuildFactorioObjectButton(template.icon)) {
-                        SelectObjectPanel.Select(Database.objects.all, "Select icon", x => {
+                        SelectSingleObjectPanel.Select(Database.objects.all, "Select icon", x => {
                             template.RecordUndo().icon = x;
                             Rebuild();
                         });
@@ -53,7 +53,7 @@ namespace YAFC {
                 }
                 grid.Next();
                 if (gui.BuildButton(Icon.Plus, SchemeColor.Primary, SchemeColor.PrimaryAlt, size: 1.5f)) {
-                    SelectObjectPanel.Select(Database.allCrafters.Where(x => x.allowedEffects != AllowedEffects.None && !template.filterEntities.Contains(x)), "Add module template filter", sel => {
+                    SelectSingleObjectPanel.Select(Database.allCrafters.Where(x => x.allowedEffects != AllowedEffects.None && !template.filterEntities.Contains(x)), "Add module template filter", sel => {
                         template.RecordUndo().filterEntities.Add(sel);
                         gui.Rebuild();
                     });
@@ -162,7 +162,7 @@ namespace YAFC {
                 grid.Next();
                 var evt = gui.BuildFactorioObjectWithEditableAmount(module.module, module.fixedCount, UnitOfMeasure.None, out float newAmount);
                 if (evt == GoodsWithAmountEvent.ButtonClick) {
-                    SelectObjectPanel.Select(GetModules(beacon), "Select module", sel => {
+                    SelectSingleObjectPanel.Select(GetModules(beacon), "Select module", sel => {
                         if (sel == null) {
                             _ = modules.RecordUndo().list.Remove(module);
                         }

--- a/YAFC/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
+++ b/YAFC/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
@@ -46,13 +46,13 @@ namespace YAFC {
             gui.BuildText("Filler module:", Font.subheader);
             gui.BuildText("Use this module when aufofill doesn't add anything (for example when productivity modules doesn't fit)", wrap: true);
             if (gui.BuildFactorioObjectButtonWithText(modules.fillerModule)) {
-                SelectObjectPanel.Select(Database.allModules, "Select filler module", select => { modules.RecordUndo().fillerModule = select; }, true);
+                SelectSingleObjectPanel.Select(Database.allModules, "Select filler module", select => { modules.RecordUndo().fillerModule = select; }, true);
             }
 
             gui.AllocateSpacing();
             gui.BuildText("Beacons & beacon modules:", Font.subheader);
             if (gui.BuildFactorioObjectButtonWithText(modules.beacon)) {
-                SelectObjectPanel.Select(Database.allBeacons, "Select beacon", select => {
+                SelectSingleObjectPanel.Select(Database.allBeacons, "Select beacon", select => {
                     _ = modules.RecordUndo();
                     modules.beacon = select;
                     if (modules.beaconModule != null && (modules.beacon == null || !modules.beacon.CanAcceptModule(modules.beaconModule.module))) {
@@ -64,7 +64,7 @@ namespace YAFC {
             }
 
             if (gui.BuildFactorioObjectButtonWithText(modules.beaconModule)) {
-                SelectObjectPanel.Select(Database.allModules.Where(x => modules.beacon?.CanAcceptModule(x.module) ?? false), "Select module for beacon", select => { modules.RecordUndo().beaconModule = select; }, true);
+                SelectSingleObjectPanel.Select(Database.allModules.Where(x => modules.beacon?.CanAcceptModule(x.module) ?? false), "Select module for beacon", select => { modules.RecordUndo().beaconModule = select; }, true);
             }
 
             using (gui.EnterRow()) {

--- a/YAFC/Workspace/ProductionTable/ProductionTableView.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableView.cs
@@ -117,7 +117,7 @@ namespace YAFC {
                         }
 
                         if (recipe.subgroup != null && imgui.BuildButton("Add raw recipe") && imgui.CloseDropdown()) {
-                            SelectMultiObjectPanel.Select(Database.recipes.all, "Select raw recipe", r => view.AddRecipe(recipe.subgroup, r));
+                            SelectMultiObjectPanel.Select(Database.recipes.all, "Select raw recipe", r => view.AddRecipe(recipe.subgroup, r), checkMark: r => recipe.subgroup.recipes.Any(rr => rr.recipe == r));
                         }
 
                         if (recipe.subgroup != null && imgui.BuildButton("Unpack nested table")) {
@@ -168,7 +168,7 @@ namespace YAFC {
 
             public override void BuildMenu(ImGui gui) {
                 if (gui.BuildButton("Add recipe") && gui.CloseDropdown()) {
-                    SelectMultiObjectPanel.Select(Database.recipes.all, "Select raw recipe", r => view.AddRecipe(view.model, r));
+                    SelectMultiObjectPanel.Select(Database.recipes.all, "Select raw recipe", r => view.AddRecipe(view.model, r), checkMark: r => view.model.recipes.Any(rr => rr.recipe == r));
                 }
 
                 gui.BuildText("Export inputs and outputs to blueprint with constant combinators:", wrap: true);

--- a/YAFC/Workspace/ProductionTable/ProductionTableView.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableView.cs
@@ -117,7 +117,7 @@ namespace YAFC {
                         }
 
                         if (recipe.subgroup != null && imgui.BuildButton("Add raw recipe") && imgui.CloseDropdown()) {
-                            SelectObjectPanel.Select(Database.recipes.all, "Select raw recipe", r => view.AddRecipe(recipe.subgroup, r));
+                            SelectMultiObjectPanel.Select(Database.recipes.all, "Select raw recipe", r => view.AddRecipe(recipe.subgroup, r));
                         }
 
                         if (recipe.subgroup != null && imgui.BuildButton("Unpack nested table")) {
@@ -168,7 +168,7 @@ namespace YAFC {
 
             public override void BuildMenu(ImGui gui) {
                 if (gui.BuildButton("Add recipe") && gui.CloseDropdown()) {
-                    SelectObjectPanel.Select(Database.recipes.all, "Select raw recipe", r => view.AddRecipe(view.model, r));
+                    SelectMultiObjectPanel.Select(Database.recipes.all, "Select raw recipe", r => view.AddRecipe(view.model, r));
                 }
 
                 gui.BuildText("Export inputs and outputs to blueprint with constant combinators:", wrap: true);
@@ -366,7 +366,7 @@ goodsHaveNoProduction:;
 
             public override void BuildMenu(ImGui gui) {
                 if (gui.BuildButton("Mass set assembler") && gui.CloseDropdown()) {
-                    SelectObjectPanel.Select(Database.allCrafters, "Set assembler for all recipes", set => {
+                    SelectSingleObjectPanel.Select(Database.allCrafters, "Set assembler for all recipes", set => {
                         DataUtils.FavoriteCrafter.AddToFavorite(set, 10);
                         foreach (var recipe in view.GetRecipesRecursive()) {
                             if (recipe.recipe.crafters.Contains(set)) {
@@ -380,7 +380,7 @@ goodsHaveNoProduction:;
                 }
 
                 if (gui.BuildButton("Mass set fuel") && gui.CloseDropdown()) {
-                    SelectObjectPanel.Select(Database.goods.all.Where(x => x.fuelValue > 0), "Set fuel for all recipes", set => {
+                    SelectSingleObjectPanel.Select(Database.goods.all.Where(x => x.fuelValue > 0), "Set fuel for all recipes", set => {
                         DataUtils.FavoriteFuel.AddToFavorite(set, 10);
                         foreach (var recipe in view.GetRecipesRecursive()) {
                             if (recipe.entity != null && recipe.entity.energy.fuels.Contains(set)) {
@@ -1116,7 +1116,7 @@ goodsHaveNoProduction:;
         }
 
         private void AddDesiredProductAtLevel(ProductionTable table) {
-            SelectObjectPanel.Select(Database.goods.all, "Add desired product", product => {
+            SelectMultiObjectPanel.Select(Database.goods.all, "Add desired product", product => {
                 if (table.linkMap.TryGetValue(product, out var existing)) {
                     if (existing.amount != 0) {
                         return;

--- a/YAFC/Workspace/ProductionTable/ProductionTableView.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableView.cs
@@ -1116,7 +1116,7 @@ goodsHaveNoProduction:;
         }
 
         private void AddDesiredProductAtLevel(ProductionTable table) {
-            SelectMultiObjectPanel.Select(Database.goods.all, "Add desired product", product => {
+            SelectMultiObjectPanel.Select(Database.goods.all.Except(table.linkMap.Where(p => p.Value.amount != 0).Select(p => p.Key)), "Add desired product", product => {
                 if (table.linkMap.TryGetValue(product, out var existing)) {
                     if (existing.amount != 0) {
                         return;

--- a/YAFC/Workspace/ProductionTable/ProductionTableView.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableView.cs
@@ -663,7 +663,7 @@ goodsHaveNoProduction:;
                         }
                     }
                 }
-                if (!allRecipes.Contains(rec) || (await MessageBox.Show("Recipe already exists", "Add a second copy?", "Add a copy", "Cancel")).choice) {
+                if (!allRecipes.Contains(rec) || (await MessageBox.Show("Recipe already exists", $"Add a second copy of {rec.locName}?", "Add a copy", "Cancel")).choice) {
                     _ = AddRecipe(context, rec);
                 }
             }

--- a/changelog.txt
+++ b/changelog.txt
@@ -2,7 +2,7 @@
 Version: 0.6.3
 Date: TBA
     Changes:
-        - 
+        - Allow selecting multiple object with CTRL-click in places it makes sense.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 0.6.2
 Date: March 2024


### PR DESCRIPTION
Another PR by @DaleStan (https://github.com/ShadowTheAge/yafc/pull/168) which I use quite often.
I had to fully rebase it due to all the changes we made in YAFC-CE. I tested it a bit, and it seems to be working.

From the original PR:

> Where logical (The Add production recipe, Add consumption recipe, Select raw recipe, and Add new milestone windows) this allows you to control-click to select multiple items. The currently selected items are highlighted, and you can control-click again to deselect them. After control-clicking at least one item, use the OK button to add all selected items and close the window.
>
> ![image](https://user-images.githubusercontent.com/21223975/175794752-09023b47-97f4-47a9-93c8-478d15d2342b.png)
>
> If you do not control-click, the single clicked-on item is selected and added, and the window is closed, as before.

~Note that I split the `MessageBox` refactoring (getting rid of singleton implementation) into a separate commit. If this change is not desired, we can easily get rid of it.~ [It is required!](https://github.com/have-fun-was-taken/yafc-ce/pull/81#issuecomment-2021886648)

The original PR contains 2 more commits, of which I didn't fully understand https://github.com/ShadowTheAge/yafc/pull/168/commits/651c0790a748dc9a39ee2129834f239f1d4c701a but it seemed unrelated to this feature.