### PR TITLE
Added row highlighting based on chosen tag

### DIFF
--- a/YAFC/Widgets/ImmediateWidgets.cs
+++ b/YAFC/Widgets/ImmediateWidgets.cs
@@ -164,13 +164,13 @@ namespace YAFC {
             }
         }
 
-        public static bool BuildFactorioObjectWithAmount(this ImGui gui, FactorioObject goods, float amount, UnitOfMeasure unit, SchemeColor color = SchemeColor.None) {
+        public static bool BuildFactorioObjectWithAmount(this ImGui gui, FactorioObject goods, float amount, UnitOfMeasure unit, SchemeColor bgColor = SchemeColor.None, SchemeColor textColor = SchemeColor.None) {
             using (gui.EnterFixedPositioning(3f, 3f, default)) {
                 gui.allocator = RectAllocator.Stretch;
                 gui.spacing = 0f;
-                bool clicked = gui.BuildFactorioObjectButton(goods, 3f, MilestoneDisplay.Contained, color);
+                bool clicked = gui.BuildFactorioObjectButton(goods, 3f, MilestoneDisplay.Contained, bgColor);
                 if (goods != null) {
-                    gui.BuildText(DataUtils.FormatAmount(amount, unit), Font.text, false, RectAlignment.Middle);
+                    gui.BuildText(DataUtils.FormatAmount(amount, unit), Font.text, false, RectAlignment.Middle, textColor);
                     if (InputSystem.Instance.control && gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.Grey) == ButtonEvent.MouseOver) {
                         ShowPrecisionValueTooltip(gui, amount, unit, goods);
                     }

--- a/YAFC/Workspace/ProductionTable/ProductionTableFlatHierarchy.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableFlatHierarchy.cs
@@ -274,6 +274,14 @@ namespace YAFC {
             };
         }
 
+        /// <summary>
+        /// This method is used to determine the text color for a highlighted row. To avoid
+        /// excessive coupling, the tag state and the row color are kept separate.
+        /// </summary>
+        /// <param name="highlighting">
+        /// Represents the highlighting state for which the corresponding color needs to be determined.
+        /// </param>
+        /// <returns></returns>
         private static SchemeColor GetHighlightingTextColor(RowHighlighting highlighting) {
             return highlighting switch {
                 RowHighlighting.Green => SchemeColor.TagColorGreenText,

--- a/YAFC/Workspace/ProductionTable/ProductionTableFlatHierarchy.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableFlatHierarchy.cs
@@ -4,10 +4,15 @@ using YAFC.Model;
 using YAFC.UI;
 
 namespace YAFC {
+    /// <summary>
+    /// This is a flat hierarchy that can be used to display a table with nested groups in a single list.
+    /// The method <see cref="BuildFlatHierarchy"/> flattens the tree.
+    /// </summary>
     public class FlatHierarchy<TRow, TGroup> where TRow : ModelObject<TGroup>, IGroupedElement<TGroup> where TGroup : ModelObject<ModelObject>, IElementGroup<TRow> {
         private readonly DataGrid<TRow> grid;
         private readonly List<TRow> flatRecipes = new List<TRow>();
         private readonly List<TGroup> flatGroups = new List<TGroup>();
+        private readonly List<RowHighlighting> rowHighlighting = new List<RowHighlighting>();
         private TRow draggingRecipe;
         private TGroup root;
         private bool rebuildRequired;
@@ -82,11 +87,16 @@ namespace YAFC {
             flatGroups.MoveListElementIndex(indexFrom, indexTo);
         }
 
-        //private readonly List<(Rect, SchemeColor)> listBackgrounds = new List<(Rect, SchemeColor)>();
         private readonly Stack<float> depthStart = new Stack<float>();
+
         private void SwapBgColor(ref SchemeColor color) {
-            color = color == SchemeColor.Background ? SchemeColor.PureBackground : SchemeColor.Background;
+            color = nextRowIsHighlighted ? nextRowBackgroundColor :
+                color == SchemeColor.Background ? SchemeColor.PureBackground : SchemeColor.Background;
         }
+
+        public bool nextRowIsHighlighted { get; private set; }
+        public SchemeColor nextRowBackgroundColor { get; private set; }
+        public SchemeColor nextRowTextColor { get; private set; }
 
         public void Build(ImGui gui) {
             if (draggingRecipe != null && !gui.isDragging) {
@@ -105,6 +115,17 @@ namespace YAFC {
             for (int i = 0; i < flatRecipes.Count; i++) {
                 var recipe = flatRecipes[i];
                 var item = flatGroups[i];
+
+                nextRowIsHighlighted = typeof(TRow) == typeof(RecipeRow) && rowHighlighting[i] != RowHighlighting.None;
+                if (nextRowIsHighlighted) {
+                    nextRowBackgroundColor = GetHighlightingBackgroundColor(rowHighlighting[i]);
+                    nextRowTextColor = GetHighlightingTextColor(rowHighlighting[i]);
+                }
+                else {
+                    nextRowBackgroundColor = bgColor;
+                    nextRowTextColor = SchemeColor.BackgroundText;
+                }
+
                 if (recipe != null) {
                     if (!recipe.visible) {
                         if (item != null) {
@@ -131,11 +152,17 @@ namespace YAFC {
                         else if (gui.ConsumeDrag(rect.Center, recipe)) {
                             MoveFlatHierarchy(gui.GetDraggingObject<TRow>(), recipe);
                         }
+
+                        if (nextRowIsHighlighted) {
+                            rect.X += depWidth;
+                            rect.Width -= depWidth;
+                            gui.DrawRectangle(rect, nextRowBackgroundColor);
+                        }
                     }
                     if (item != null) {
                         if (item.elements.Count == 0) {
                             using (gui.EnterGroup(new Padding(0.5f + depWidth, 0.5f, 0.5f, 0.5f))) {
-                                gui.BuildText(emptyGroupMessage, wrap: true);
+                                gui.BuildText(emptyGroupMessage, wrap: true); // set color if nested row is empty
                             }
                         }
 
@@ -149,6 +176,7 @@ namespace YAFC {
                 else {
                     if (gui.isBuilding) {
                         float top = depthStart.Pop();
+                        // set color bgColor if row is nested table and not collapsed
                         gui.DrawRectangle(new Rect(depWidth, top, grid.width - depWidth, gui.statePosition.Bottom - top), bgColor, RectangleBorder.Thin);
                     }
                     SwapBgColor(ref bgColor);
@@ -156,6 +184,8 @@ namespace YAFC {
                     depWidth = depth * 0.5f;
                     _ = gui.AllocateRect(20f, 0.5f);
                 }
+
+                nextRowIsHighlighted = false;
             }
             var fullRect = grid.EndBuildingContent(gui);
             gui.DrawRectangle(fullRect, SchemeColor.PureBackground);
@@ -164,19 +194,36 @@ namespace YAFC {
         private void Rebuild() {
             flatRecipes.Clear();
             flatGroups.Clear();
+            rowHighlighting.Clear();
+
             BuildFlatHierarchy(root);
             rebuildRequired = false;
         }
 
-        private void BuildFlatHierarchy(TGroup table) {
+        private void BuildFlatHierarchy(TGroup table, RowHighlighting parentHighlight = RowHighlighting.None) {
             foreach (var recipe in table.elements) {
                 flatRecipes.Add(recipe);
+
+                RowHighlighting highlight = parentHighlight;
+
+                if (recipe is RecipeRow r && r.highlighting != RowHighlighting.None) {
+                    // Only respect any highlighting if the recipe is in fact a RecipeRow
+                    highlight = r.highlighting;
+                }
+
+                rowHighlighting.Add(highlight);
+
                 var sub = recipe.subgroup;
-                if (sub != null && sub.expanded) {
+
+                if (sub is { expanded: true }) {
                     flatGroups.Add(sub);
-                    BuildFlatHierarchy(sub);
+
+                    BuildFlatHierarchy(sub, highlight); // Pass the current highlight color to the child rows
+
                     flatRecipes.Add(null);
                     flatGroups.Add(sub);
+
+                    rowHighlighting.Add(RowHighlighting.None);
                 }
                 else {
                     flatGroups.Add(null);
@@ -186,6 +233,26 @@ namespace YAFC {
 
         public void BuildHeader(ImGui gui) {
             grid.BuildHeader(gui);
+        }
+
+        private static SchemeColor GetHighlightingBackgroundColor(RowHighlighting highlighting) {
+            return highlighting switch {
+                RowHighlighting.Green => SchemeColor.TagColorGreenBackground,
+                RowHighlighting.Yellow => SchemeColor.TagColorYellowBackground,
+                RowHighlighting.Red => SchemeColor.TagColorRedBackground,
+                RowHighlighting.Blue => SchemeColor.TagColorBlueBackground,
+                _ => SchemeColor.None
+            };
+        }
+
+        private static SchemeColor GetHighlightingTextColor(RowHighlighting highlighting) {
+            return highlighting switch {
+                RowHighlighting.Green => SchemeColor.TagColorGreenText,
+                RowHighlighting.Yellow => SchemeColor.TagColorYellowText,
+                RowHighlighting.Red => SchemeColor.TagColorRedText,
+                RowHighlighting.Blue => SchemeColor.TagColorBlueText,
+                _ => SchemeColor.None
+            };
         }
     }
 }

--- a/YAFC/Workspace/ProductionTable/ProductionTableFlatHierarchy.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableFlatHierarchy.cs
@@ -143,12 +143,18 @@ namespace YAFC {
                 // TODO: See https://github.com/have-fun-was-taken/yafc-ce/issues/91
                 //       and https://github.com/have-fun-was-taken/yafc-ce/pull/86#discussion_r1550369353
                 if (nextRowIsHighlighted) {
-                    nextRowBackgroundColor = GetHighlightingBackgroundColor(rowHighlighting[i], recipe is RecipeRow {enabled: true});
+                    nextRowBackgroundColor = GetHighlightingBackgroundColor(rowHighlighting[i], recipe is RecipeRow { enabled: true });
                     nextRowTextColor = GetHighlightingTextColor(rowHighlighting[i]);
                 }
                 else {
                     nextRowBackgroundColor = bgColor;
                     nextRowTextColor = SchemeColor.BackgroundText;
+                }
+
+                bool isError = recipe is RecipeRow r && r.parameters.warningFlags >= WarningFlags.EntityNotSpecified;
+                if (isError) {
+                    nextRowBackgroundColor = SchemeColor.Error;
+                    nextRowTextColor = SchemeColor.PureForeground;
                 }
 
                 if (recipe != null) {
@@ -178,7 +184,7 @@ namespace YAFC {
                             MoveFlatHierarchy(gui.GetDraggingObject<TRow>(), recipe);
                         }
 
-                        if (nextRowIsHighlighted) {
+                        if (nextRowIsHighlighted || isError) {
                             rect.X += depWidth;
                             rect.Width -= depWidth;
                             gui.DrawRectangle(rect, nextRowBackgroundColor);

--- a/YAFC/Workspace/ProductionTable/ProductionTableFlatHierarchy.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableFlatHierarchy.cs
@@ -270,10 +270,10 @@ namespace YAFC {
         /// <returns></returns>
         private static SchemeColor GetHighlightingBackgroundColor(RowHighlighting highlighting) {
             return highlighting switch {
-                RowHighlighting.Green => SchemeColor.TagColorGreenBackground,
-                RowHighlighting.Yellow => SchemeColor.TagColorYellowBackground,
-                RowHighlighting.Red => SchemeColor.TagColorRedBackground,
-                RowHighlighting.Blue => SchemeColor.TagColorBlueBackground,
+                RowHighlighting.Green => SchemeColor.TagColorGreen,
+                RowHighlighting.Yellow => SchemeColor.TagColorYellow,
+                RowHighlighting.Red => SchemeColor.TagColorRed,
+                RowHighlighting.Blue => SchemeColor.TagColorBlue,
                 _ => SchemeColor.None
             };
         }

--- a/YAFC/Workspace/ProductionTable/ProductionTableFlatHierarchy.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableFlatHierarchy.cs
@@ -143,7 +143,7 @@ namespace YAFC {
                 // TODO: See https://github.com/have-fun-was-taken/yafc-ce/issues/91
                 //       and https://github.com/have-fun-was-taken/yafc-ce/pull/86#discussion_r1550369353
                 if (nextRowIsHighlighted) {
-                    nextRowBackgroundColor = GetHighlightingBackgroundColor(rowHighlighting[i]);
+                    nextRowBackgroundColor = GetHighlightingBackgroundColor(rowHighlighting[i], recipe is RecipeRow {enabled: true});
                     nextRowTextColor = GetHighlightingTextColor(rowHighlighting[i]);
                 }
                 else {
@@ -267,13 +267,16 @@ namespace YAFC {
         /// <param name="highlighting">
         /// Represents the highlighting state for which the corresponding color needs to be determined.
         /// </param>
+        /// <param name="isEnabled">
+        /// If the row is not enabled, a fainter color is used.
+        /// </param>
         /// <returns></returns>
-        private static SchemeColor GetHighlightingBackgroundColor(RowHighlighting highlighting) {
+        private static SchemeColor GetHighlightingBackgroundColor(RowHighlighting highlighting, bool isEnabled) {
             return highlighting switch {
-                RowHighlighting.Green => SchemeColor.TagColorGreen,
-                RowHighlighting.Yellow => SchemeColor.TagColorYellow,
-                RowHighlighting.Red => SchemeColor.TagColorRed,
-                RowHighlighting.Blue => SchemeColor.TagColorBlue,
+                RowHighlighting.Green => isEnabled ? SchemeColor.TagColorGreen : SchemeColor.TagColorGreenAlt,
+                RowHighlighting.Yellow => isEnabled ? SchemeColor.TagColorYellow : SchemeColor.TagColorYellowAlt,
+                RowHighlighting.Red => isEnabled ? SchemeColor.TagColorRed : SchemeColor.TagColorRedAlt,
+                RowHighlighting.Blue => isEnabled ? SchemeColor.TagColorBlue : SchemeColor.TagColorBlueAlt,
                 _ => SchemeColor.None
             };
         }

--- a/YAFC/Workspace/ProductionTable/ProductionTableFlatHierarchy.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableFlatHierarchy.cs
@@ -140,6 +140,8 @@ namespace YAFC {
 
                 nextRowIsHighlighted = (typeof(TRow) == typeof(RecipeRow)) && (rowHighlighting[i] != RowHighlighting.None);
 
+                // TODO: See https://github.com/have-fun-was-taken/yafc-ce/issues/91
+                //       and https://github.com/have-fun-was-taken/yafc-ce/pull/86#discussion_r1550369353
                 if (nextRowIsHighlighted) {
                     nextRowBackgroundColor = GetHighlightingBackgroundColor(rowHighlighting[i]);
                     nextRowTextColor = GetHighlightingTextColor(rowHighlighting[i]);
@@ -241,9 +243,11 @@ namespace YAFC {
 
                     BuildFlatHierarchy(sub, highlight); // Pass the current highlight color to the child rows
 
+                    // The flattened hierarchy contains empty rows for the nested table. But since this
+                    // is a rendering issue, it is not necessary to add them to the actual data structure.
+                    // TODO: Investigate why this is needed and how to clean it up.
                     flatRecipes.Add(null);
                     flatGroups.Add(sub);
-
                     rowHighlighting.Add(RowHighlighting.None);
                 }
                 else {

--- a/YAFC/Workspace/ProductionTable/ProductionTableFlatHierarchy.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableFlatHierarchy.cs
@@ -162,7 +162,7 @@ namespace YAFC {
                     if (item != null) {
                         if (item.elements.Count == 0) {
                             using (gui.EnterGroup(new Padding(0.5f + depWidth, 0.5f, 0.5f, 0.5f))) {
-                                gui.BuildText(emptyGroupMessage, wrap: true); // set color if nested row is empty
+                                gui.BuildText(emptyGroupMessage, wrap: true); // set color if the nested row is empty
                             }
                         }
 
@@ -176,7 +176,7 @@ namespace YAFC {
                 else {
                     if (gui.isBuilding) {
                         float top = depthStart.Pop();
-                        // set color bgColor if row is nested table and not collapsed
+                        // set color bgColor if the row is a nested table and is not collapsed
                         gui.DrawRectangle(new Rect(depWidth, top, grid.width - depWidth, gui.statePosition.Bottom - top), bgColor, RectangleBorder.Thin);
                     }
                     SwapBgColor(ref bgColor);

--- a/YAFC/Workspace/ProductionTable/ProductionTableView.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableView.cs
@@ -48,7 +48,7 @@ namespace YAFC {
                     bool isError = row.parameters.warningFlags >= WarningFlags.EntityNotSpecified;
                     bool hover;
                     if (isError) {
-                        hover = gui.BuildRedButton(Icon.Error) == ButtonEvent.MouseOver;
+                        hover = gui.BuildRedButton(Icon.Error, invertedColors: true) == ButtonEvent.MouseOver;
                     }
                     else {
                         using (gui.EnterGroup(ImGuiUtils.DefaultIconPadding)) {
@@ -890,7 +890,7 @@ goodsHaveNoProduction:;
             if (!flatHierarchyBuilder.nextRowIsHighlighted) {
                 textColor = SchemeColor.None;
             }
-            else if (recipe is {enabled: false}) {
+            else if (recipe is { enabled: false }) {
                 textColor = SchemeColor.BackgroundTextFaint;
             }
 

--- a/YAFC/Workspace/ProductionTable/ProductionTableView.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableView.cs
@@ -154,6 +154,11 @@ namespace YAFC {
                 }
 
                 gui.textColor = recipe.hierarchyEnabled ? SchemeColor.BackgroundText : SchemeColor.BackgroundTextFaint;
+
+                if (view.flatHierarchyBuilder.nextRowIsHighlighted) {
+                    gui.textColor = view.flatHierarchyBuilder.nextRowTextColor;
+                }
+
                 gui.BuildText(recipe.recipe.locName, wrap: true);
             }
 
@@ -875,7 +880,9 @@ goodsHaveNoProduction:;
                 iconColor = goods.IsSourceResource() ? SchemeColor.Green : SchemeColor.None;
             }
 
-            if (gui.BuildFactorioObjectWithAmount(goods, amount, goods?.flowUnitOfMeasure ?? UnitOfMeasure.None, iconColor)) {
+            SchemeColor textColor = flatHierarchyBuilder.nextRowIsHighlighted ? flatHierarchyBuilder.nextRowTextColor : SchemeColor.None;
+
+            if (gui.BuildFactorioObjectWithAmount(goods, amount, goods?.flowUnitOfMeasure ?? UnitOfMeasure.None, iconColor, textColor)) {
                 OpenProductDropdown(gui, gui.lastRect, goods, amount, link, dropdownType, recipe, context, variants);
             }
         }

--- a/YAFC/Workspace/ProductionTable/ProductionTableView.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableView.cs
@@ -153,7 +153,10 @@ namespace YAFC {
                     });
                 }
 
-                if (view.flatHierarchyBuilder.nextRowIsHighlighted) {
+                if (!recipe.enabled) {
+                    gui.textColor = SchemeColor.BackgroundTextFaint;
+                }
+                else if (view.flatHierarchyBuilder.nextRowIsHighlighted) {
                     gui.textColor = view.flatHierarchyBuilder.nextRowTextColor;
                 }
                 else {
@@ -883,7 +886,13 @@ goodsHaveNoProduction:;
 
             // TODO: See https://github.com/have-fun-was-taken/yafc-ce/issues/91
             //       and https://github.com/have-fun-was-taken/yafc-ce/pull/86#discussion_r1550377021
-            SchemeColor textColor = flatHierarchyBuilder.nextRowIsHighlighted ? flatHierarchyBuilder.nextRowTextColor : SchemeColor.None;
+            SchemeColor textColor = flatHierarchyBuilder.nextRowTextColor;
+            if (!flatHierarchyBuilder.nextRowIsHighlighted) {
+                textColor = SchemeColor.None;
+            }
+            else if (recipe is {enabled: false}) {
+                textColor = SchemeColor.BackgroundTextFaint;
+            }
 
             if (gui.BuildFactorioObjectWithAmount(goods, amount, goods?.flowUnitOfMeasure ?? UnitOfMeasure.None, iconColor, textColor)) {
                 OpenProductDropdown(gui, gui.lastRect, goods, amount, link, dropdownType, recipe, context, variants);

--- a/YAFC/Workspace/ProductionTable/ProductionTableView.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableView.cs
@@ -153,10 +153,11 @@ namespace YAFC {
                     });
                 }
 
-                gui.textColor = recipe.hierarchyEnabled ? SchemeColor.BackgroundText : SchemeColor.BackgroundTextFaint;
-
                 if (view.flatHierarchyBuilder.nextRowIsHighlighted) {
                     gui.textColor = view.flatHierarchyBuilder.nextRowTextColor;
+                }
+                else {
+                    gui.textColor = recipe.hierarchyEnabled ? SchemeColor.BackgroundText : SchemeColor.BackgroundTextFaint;
                 }
 
                 gui.BuildText(recipe.recipe.locName, wrap: true);

--- a/YAFC/Workspace/ProductionTable/ProductionTableView.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableView.cs
@@ -880,6 +880,8 @@ goodsHaveNoProduction:;
                 iconColor = goods.IsSourceResource() ? SchemeColor.Green : SchemeColor.None;
             }
 
+            // TODO: See https://github.com/have-fun-was-taken/yafc-ce/issues/91
+            //       and https://github.com/have-fun-was-taken/yafc-ce/pull/86#discussion_r1550377021
             SchemeColor textColor = flatHierarchyBuilder.nextRowIsHighlighted ? flatHierarchyBuilder.nextRowTextColor : SchemeColor.None;
 
             if (gui.BuildFactorioObjectWithAmount(goods, amount, goods?.flowUnitOfMeasure ?? UnitOfMeasure.None, iconColor, textColor)) {

--- a/YAFCmodel/Model/ProductionTableContent.cs
+++ b/YAFCmodel/Model/ProductionTableContent.cs
@@ -181,6 +181,15 @@ namespace YAFC.Model {
         public bool hierarchyEnabled { get; internal set; }
         public int tag { get; set; }
 
+        public RowHighlighting highlighting =>
+            tag switch {
+                1 => RowHighlighting.Green,
+                2 => RowHighlighting.Yellow,
+                3 => RowHighlighting.Red,
+                4 => RowHighlighting.Blue,
+                _ => RowHighlighting.None
+            };
+
         [Obsolete("Deprecated", true)]
         public Item module {
             set {
@@ -301,6 +310,14 @@ namespace YAFC.Model {
                 useModules.GetModulesInfo(recipeParams, recipe, entity, fuel, ref effects, ref used, filler);
             }
         }
+    }
+
+    public enum RowHighlighting {
+        None,
+        Green,
+        Yellow,
+        Red,
+        Blue
     }
 
     public enum LinkAlgorithm {

--- a/YAFCui/Core/Structs.cs
+++ b/YAFCui/Core/Structs.cs
@@ -44,7 +44,16 @@
         Green,
         GreenAlt,
         GreenText,
-        GreenTextFaint
+        GreenTextFaint,
+        // Tagged row colors
+        TagColorGreenBackground,
+        TagColorGreenText,
+        TagColorYellowBackground,
+        TagColorYellowText,
+        TagColorRedBackground,
+        TagColorRedText,
+        TagColorBlueBackground,
+        TagColorBlueText
     }
 
     public enum RectangleBorder {

--- a/YAFCui/Core/Structs.cs
+++ b/YAFCui/Core/Structs.cs
@@ -46,14 +46,22 @@
         GreenText,
         GreenTextFaint,
         // Tagged row colors
-        TagColorGreenBackground,
+        TagColorGreen,
+        TagColorGreenAlt,
         TagColorGreenText,
-        TagColorYellowBackground,
+        TagColorGreenTextFaint,
+        TagColorYellow,
+        TagColorYellowAlt,
         TagColorYellowText,
-        TagColorRedBackground,
+        TagColorYellowTextFaint,
+        TagColorRed,
+        TagColorRedAlt,
         TagColorRedText,
-        TagColorBlueBackground,
-        TagColorBlueText
+        TagColorRedTextFaint,
+        TagColorBlue,
+        TagColorBlueAlt,
+        TagColorBlueText,
+        TagColorBlueTextFaint
     }
 
     public enum RectangleBorder {

--- a/YAFCui/ImGui/ImGuiUtils.cs
+++ b/YAFCui/ImGui/ImGuiUtils.cs
@@ -171,7 +171,7 @@ namespace YAFC.UI {
             return evt;
         }
 
-        public static ButtonEvent BuildRedButton(this ImGui gui, Icon icon, float size = 1.5f) {
+        public static ButtonEvent BuildRedButton(this ImGui gui, Icon icon, float size = 1.5f, bool invertedColors = false) {
             Rect iconRect;
             using (gui.EnterGroup(new Padding(0.3f))) {
                 iconRect = gui.AllocateRect(size, size, RectAlignment.Middle);
@@ -179,7 +179,13 @@ namespace YAFC.UI {
 
             var evt = gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.Error);
             if (gui.isBuilding) {
-                gui.DrawIcon(iconRect, icon, gui.IsMouseOver(gui.lastRect) ? SchemeColor.ErrorText : SchemeColor.Error);
+                SchemeColor color = invertedColors ? SchemeColor.ErrorText : SchemeColor.Error;
+
+                if (gui.IsMouseOver(gui.lastRect)) {
+                    color = invertedColors ? SchemeColor.Error : SchemeColor.ErrorText;
+                }
+
+                gui.DrawIcon(iconRect, icon, color);
             }
 
             return evt;

--- a/YAFCui/Rendering/RenderingUtils.cs
+++ b/YAFCui/Rendering/RenderingUtils.cs
@@ -35,11 +35,11 @@ namespace YAFC.UI {
             ColorFromHex(0xbd33a4), ColorFromHex(0x8b008b), Black, BlackTransparent, // Magenta group
             ColorFromHex(0x6abf69), ColorFromHex(0x388e3c), Black, BlackTransparent, // Green group
 
-            // Row highlighting colors (background, text)
-            ColorFromHex(0xe8ffe8), ColorFromHex(0x56ad65), // Green
-            ColorFromHex(0xffffe8), ColorFromHex(0x8c8756), // Yellow
-            ColorFromHex(0xffe8e8), ColorFromHex(0xaa5555), // Red
-            ColorFromHex(0xe8efff), ColorFromHex(0x526ea5)  // Blue
+            // Row highlighting colors (background, background alt, text, text alt)
+            ColorFromHex(0xe8ffe8), ColorFromHex(0x0), ColorFromHex(0x56ad65), ColorFromHex(0x0), // Green
+            ColorFromHex(0xffffe8), ColorFromHex(0x0), ColorFromHex(0x8c8756), ColorFromHex(0x0), // Yellow
+            ColorFromHex(0xffe8e8), ColorFromHex(0x0), ColorFromHex(0xaa5555), ColorFromHex(0x0), // Red
+            ColorFromHex(0xe8efff), ColorFromHex(0x0), ColorFromHex(0x526ea5), ColorFromHex(0x0), // Blue
         };
 
         private static readonly SDL.SDL_Color[] DarkModeScheme = {
@@ -54,11 +54,11 @@ namespace YAFC.UI {
             ColorFromHex(0x8b008b), ColorFromHex(0xbd33a4), Black, BlackTransparent, // Magenta group
             ColorFromHex(0x00600f), ColorFromHex(0x00701a), Black, BlackTransparent, // Green group
 
-            // Row highlighting colors (background, text)
-            ColorFromHex(0x001500), ColorFromHex(0x4a4a4a), // Green
-            ColorFromHex(0xffffe8), ColorFromHex(0xaaa668), // Yellow
-            ColorFromHex(0xffe8e8), ColorFromHex(0xaa5555), // Red
-            ColorFromHex(0xe8efff), ColorFromHex(0x526ea5)  // Blue
+            // Row highlighting colors (background, background alt, text, text alt)
+            ColorFromHex(0x050f0c), ColorFromHex(0x0), ColorFromHex(0x18463c), ColorFromHex(0x0), // Green
+            ColorFromHex(0x191807), ColorFromHex(0x0), ColorFromHex(0x454320), ColorFromHex(0x0), // Yellow
+            ColorFromHex(0x190808), ColorFromHex(0x0), ColorFromHex(0x822222), ColorFromHex(0x0), // Red
+            ColorFromHex(0x080819), ColorFromHex(0x0), ColorFromHex(0x222299), ColorFromHex(0x0)  // Blue
         };
 
         private static SDL.SDL_Color[] SchemeColors = LightModeScheme;

--- a/YAFCui/Rendering/RenderingUtils.cs
+++ b/YAFCui/Rendering/RenderingUtils.cs
@@ -34,6 +34,12 @@ namespace YAFC.UI {
             ColorFromHex(0xe4e4e4), ColorFromHex(0xc4c4c4), Black, BlackTransparent, // Grey group
             ColorFromHex(0xbd33a4), ColorFromHex(0x8b008b), Black, BlackTransparent, // Magenta group
             ColorFromHex(0x6abf69), ColorFromHex(0x388e3c), Black, BlackTransparent, // Green group
+
+            // Row highlighting colors (background, text)
+            ColorFromHex(0xe8ffe8), ColorFromHex(0x56ad65), // Green
+            ColorFromHex(0xffffe8), ColorFromHex(0x8c8756), // Yellow
+            ColorFromHex(0xffe8e8), ColorFromHex(0xaa5555), // Red
+            ColorFromHex(0xe8efff), ColorFromHex(0x526ea5)  // Blue
         };
 
         private static readonly SDL.SDL_Color[] DarkModeScheme = {
@@ -47,6 +53,12 @@ namespace YAFC.UI {
             ColorFromHex(0x343434), ColorFromHex(0x545454), White, WhiteTransparent, // Grey group
             ColorFromHex(0x8b008b), ColorFromHex(0xbd33a4), Black, BlackTransparent, // Magenta group
             ColorFromHex(0x00600f), ColorFromHex(0x00701a), Black, BlackTransparent, // Green group
+
+            // Row highlighting colors (background, text)
+            ColorFromHex(0x001500), ColorFromHex(0x4a4a4a), // Green
+            ColorFromHex(0xffffe8), ColorFromHex(0xaaa668), // Yellow
+            ColorFromHex(0xffe8e8), ColorFromHex(0xaa5555), // Red
+            ColorFromHex(0xe8efff), ColorFromHex(0x526ea5)  // Blue
         };
 
         private static SDL.SDL_Color[] SchemeColors = LightModeScheme;

--- a/YAFCui/Rendering/RenderingUtils.cs
+++ b/YAFCui/Rendering/RenderingUtils.cs
@@ -36,10 +36,10 @@ namespace YAFC.UI {
             ColorFromHex(0x6abf69), ColorFromHex(0x388e3c), Black, BlackTransparent, // Green group
 
             // Row highlighting colors (background, background alt, text, text alt)
-            ColorFromHex(0xe8ffe8), ColorFromHex(0x0), ColorFromHex(0x56ad65), ColorFromHex(0x0), // Green
-            ColorFromHex(0xffffe8), ColorFromHex(0x0), ColorFromHex(0x8c8756), ColorFromHex(0x0), // Yellow
-            ColorFromHex(0xffe8e8), ColorFromHex(0x0), ColorFromHex(0xaa5555), ColorFromHex(0x0), // Red
-            ColorFromHex(0xe8efff), ColorFromHex(0x0), ColorFromHex(0x526ea5), ColorFromHex(0x0), // Blue
+            ColorFromHex(0xe8ffe8), ColorFromHex(0xefffef), ColorFromHex(0x56ad65), ColorFromHex(0x0), // Green
+            ColorFromHex(0xffffe8), ColorFromHex(0xffffef), ColorFromHex(0x8c8756), ColorFromHex(0x0), // Yellow
+            ColorFromHex(0xffe8e8), ColorFromHex(0xffefef), ColorFromHex(0xaa5555), ColorFromHex(0x0), // Red
+            ColorFromHex(0xe8efff), ColorFromHex(0xeff4ff), ColorFromHex(0x526ea5), ColorFromHex(0x0), // Blue
         };
 
         private static readonly SDL.SDL_Color[] DarkModeScheme = {
@@ -55,10 +55,10 @@ namespace YAFC.UI {
             ColorFromHex(0x00600f), ColorFromHex(0x00701a), Black, BlackTransparent, // Green group
 
             // Row highlighting colors (background, background alt, text, text alt)
-            ColorFromHex(0x050f0c), ColorFromHex(0x0), ColorFromHex(0x18463c), ColorFromHex(0x0), // Green
-            ColorFromHex(0x191807), ColorFromHex(0x0), ColorFromHex(0x454320), ColorFromHex(0x0), // Yellow
-            ColorFromHex(0x190808), ColorFromHex(0x0), ColorFromHex(0x822222), ColorFromHex(0x0), // Red
-            ColorFromHex(0x080819), ColorFromHex(0x0), ColorFromHex(0x222299), ColorFromHex(0x0)  // Blue
+            ColorFromHex(0x0d261f), ColorFromHex(0x050f0c), ColorFromHex(0x226355), ColorFromHex(0x0), // Green
+            ColorFromHex(0x28260b), ColorFromHex(0x191807), ColorFromHex(0x5b582a), ColorFromHex(0x0), // Yellow
+            ColorFromHex(0x270c0c), ColorFromHex(0x190808), ColorFromHex(0x922626), ColorFromHex(0x0), // Red
+            ColorFromHex(0x0c0c27), ColorFromHex(0x080819), ColorFromHex(0x2626ab), ColorFromHex(0x0)  // Blue
         };
 
         private static SDL.SDL_Color[] SchemeColors = LightModeScheme;

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,8 @@ Version: 0.6.3
 Date: TBA
     Changes:
         - Allow selecting multiple object with CTRL-click in places it makes sense.
+        - Tagged recipe rows are now colored in the color of the tag.
+        - Rows with errors are now more visibile.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 0.6.2
 Date: March 2024


### PR DESCRIPTION
When choosing one of the first four tags, the corresponding row and its children are highlighted in the tag's color. However, if a child row possesses a different tag, it is highlighted in the color corresponding to that specific tag instead.

I tried to stay true to the original code with minimal refactoring. Considering the somewhat state-based rendering approach, it became imperative to designate rows for highlighting to ensure accurate colorization during subsequent passes. This explains the approach taken in the code within ProductionTableFlatHierarchy.cs.

At the moment, I'm not quite satisfied with all the hardcoded color stuff in YAFCui/Core/Structs.cs and YAFCui/Rendering/RenderingUtils.cs. However, given the substantial effort required for refactoring, I refrained from doing so at this time.

I tagged you for review, @veger, because you implemented the color coding for overproduction, and I want to ensure that we don't encounter any regressions :-)

Closes #59 