### PR TITLE
Fixes #82 crash on startup when no project is previously selected.

### DIFF
--- a/YAFC/Windows/WelcomeScreen.cs
+++ b/YAFC/Windows/WelcomeScreen.cs
@@ -280,10 +280,18 @@ namespace YAFC {
         }
 
         private void SetProject(ProjectDefinition project) {
-            expensive = project.expensive;
-            modsPath = project.modsPath ?? "";
-            path = project.path ?? "";
-            dataPath = project.dataPath ?? "";
+            if (project != null) {
+                expensive = project.expensive;
+                modsPath = project.modsPath ?? "";
+                path = project.path ?? "";
+                dataPath = project.dataPath ?? "";
+            }
+            else {
+                expensive = false;
+                modsPath = "";
+                path = "";
+                dataPath = "";
+            }
             if (dataPath == "" && RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
                 string possibleDataPath = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ProgramFilesX86), "Steam/steamApps/common/Factorio/data");
                 if (FactorioValid(possibleDataPath)) {


### PR DESCRIPTION
Fixes #82 

This bug was introduced in https://github.com/have-fun-was-taken/yafc-ce/commit/8f1e04e5be9bd9f63452fd736d1ccf167b14bc0d by changing `struct RecentProject` to `class ProjectDefinition`. By making this type a reference, the default value is now null, instead of an object with all fields set to default, which leads to crashes when it is dereferenced.

This fix makes the SetProject() function accept null as an arugment and then configures all variables as they would have been before. This continues to run the intialization code. Alternatively, we could skip the call to SetProject() entirely -- with my limited understanding of the code base, I don't know if that's safe or not. I don't feel strongly about the approach, happy to do either.

https://github.com/have-fun-was-taken/yafc-ce/pull/89 also fixes this by skipping the call to SetProject() if project is null, but I think it makes sense to decouple this quick bug fix from the rest of the feature work there.