### PR TITLE
Color the icon background with the error color or lacking production

### DIFF
--- a/YAFC/Workspace/ProductionTable/ProductionTableView.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableView.cs
@@ -822,8 +822,8 @@ goodsHaveNoProduction:;
         private void DrawDesiredProduct(ImGui gui, ProductionLink element) {
             gui.allocator = RectAllocator.Stretch;
             gui.spacing = 0f;
+            SchemeColor iconColor = SchemeColor.Primary;
 
-            SchemeColor iconColor;
             if (element.flags.HasFlags(ProductionLink.Flags.LinkNotMatched)) {
                 if (element.linkFlow > element.amount) {
                     // Actual overproduction occurred for this product
@@ -834,9 +834,7 @@ goodsHaveNoProduction:;
                     iconColor = SchemeColor.Error;
                 }
             }
-            else {
-                iconColor = SchemeColor.Primary;
-            }
+
             var evt = gui.BuildFactorioObjectWithEditableAmount(element.goods, element.amount, element.goods.flowUnitOfMeasure, out float newAmount, iconColor);
             if (evt == GoodsWithAmountEvent.ButtonClick) {
                 OpenProductDropdown(gui, gui.lastRect, element.goods, element.amount, element, ProductDropdownType.DesiredProduct, null, element.owner);

--- a/YAFC/Workspace/ProductionTable/ProductionTableView.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableView.cs
@@ -825,7 +825,7 @@ goodsHaveNoProduction:;
             SchemeColor iconColor = SchemeColor.Primary;
 
             if (element.flags.HasFlags(ProductionLink.Flags.LinkNotMatched)) {
-                if (element.linkFlow > element.amount) {
+                if (element.linkFlow > element.amount && CheckPossibleOverproducing(element)) {
                     // Actual overproduction occurred for this product
                     iconColor = SchemeColor.Magenta;
                 }
@@ -857,7 +857,7 @@ goodsHaveNoProduction:;
                     // The link has production and consumption sides, but either the production and consumption is not matched, or 'child was not matched'
                     iconColor = SchemeColor.Error;
                 }
-                else if (link.algorithm == LinkAlgorithm.AllowOverProduction && dropdownType == ProductDropdownType.Product && (link.flags & ProductionLink.Flags.LinkNotMatched) != 0) {
+                else if (dropdownType == ProductDropdownType.Product && CheckPossibleOverproducing(link)) {
                     // Actual overproduction occurred in the recipe
                     iconColor = SchemeColor.Magenta;
                 }
@@ -878,6 +878,14 @@ goodsHaveNoProduction:;
             if (gui.BuildFactorioObjectWithAmount(goods, amount, goods?.flowUnitOfMeasure ?? UnitOfMeasure.None, iconColor)) {
                 OpenProductDropdown(gui, gui.lastRect, goods, amount, link, dropdownType, recipe, context, variants);
             }
+        }
+
+        /// <summary>
+        /// Checks some criteria that are necessary but not sufficient to consider something overproduced.
+        /// </summary>
+        /// <returns></returns>
+        private static bool CheckPossibleOverproducing(ProductionLink link) {
+            return link.algorithm == LinkAlgorithm.AllowOverProduction && link.flags.HasFlag(ProductionLink.Flags.LinkNotMatched);
         }
 
         private void BuildTableProducts(ImGui gui, ProductionTable table, ProductionTable context, ref ImGuiUtils.InlineGridBuilder grid) {

--- a/YAFC/Workspace/ProductionTable/ProductionTableView.cs
+++ b/YAFC/Workspace/ProductionTable/ProductionTableView.cs
@@ -825,8 +825,14 @@ goodsHaveNoProduction:;
 
             SchemeColor iconColor;
             if (element.flags.HasFlags(ProductionLink.Flags.LinkNotMatched)) {
-                // Actual overproduction occurred for this product
-                iconColor = SchemeColor.Magenta;
+                if (element.linkFlow > element.amount) {
+                    // Actual overproduction occurred for this product
+                    iconColor = SchemeColor.Magenta;
+                }
+                else {
+                    // There is not enough production (most likely none at all, otherwise the analyzer will have a deadlock)
+                    iconColor = SchemeColor.Error;
+                }
             }
             else {
                 iconColor = SchemeColor.Primary;

--- a/YAFCmodel/Model/ProductionTable.cs
+++ b/YAFCmodel/Model/ProductionTable.cs
@@ -194,7 +194,7 @@ match:
                 }
             }
 
-            foreach (var link in links) {
+            foreach (ProductionLink link in links) {
                 (double prod, double cons) flowParams;
                 if (!link.flags.HasFlagAny(ProductionLink.Flags.LinkNotMatched)) {
                     _ = flowDict.Remove(link.goods, out flowParams);

--- a/YAFCmodel/Model/ProductionTableContent.cs
+++ b/YAFCmodel/Model/ProductionTableContent.cs
@@ -309,6 +309,9 @@ namespace YAFC.Model {
         AllowOverConsumption,
     }
 
+    /// <summary>
+    /// Link is goods whose production and consumption is attempted to be balanced by YAFC across the sheet.
+    /// </summary>
     public class ProductionLink : ModelObject<ProductionTable> {
         [Flags]
         public enum Flags {
@@ -316,6 +319,9 @@ namespace YAFC.Model {
             LinkRecursiveNotMatched = 1 << 1,
             HasConsumption = 1 << 2,
             HasProduction = 1 << 3,
+            /// <summary>
+            /// The production and consumption of the child link are not matched.
+            /// </summary>
             ChildNotMatched = 1 << 4,
             HasProductionAndConsumption = HasProduction | HasConsumption,
         }
@@ -326,9 +332,14 @@ namespace YAFC.Model {
 
         // computed variables
         public Flags flags { get; internal set; }
+        /// <summary>
+        /// Probably the total production of the goods in the link. TODO: Needs to be investigated if it is indeed so.
+        /// </summary>
         public float linkFlow { get; internal set; }
         public float notMatchedFlow { get; internal set; }
-        /// <summary>List of recipes belonging to this production link</summary>
+        /// <summary>
+        /// List of recipes belonging to this production link
+        /// </summary>
         [SkipSerialization] public List<RecipeRow> capturedRecipes { get; } = new List<RecipeRow>();
         internal int solverIndex;
         public float dualValue { get; internal set; }


### PR DESCRIPTION
I found `linkFlow` which seems to show to surplus/lack of flow within the link. By matching this to the (desired) `amount` we can detect an error (lack) of flow.

Some tests showed it working, but I am not 100% sure this is what `linkFlow` should be used for. So some additional testing for side effects wouldn't hurt...

Fixes #87 