### PR TITLE
Undo namespace renames that are used in project files.

### DIFF
--- a/Yafc.Model/Model/AutoPlanner.cs
+++ b/Yafc.Model/Model/AutoPlanner.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Google.OrTools.LinearSolver;
+using Yafc.Model;
 using Yafc.UI;
 
 namespace Yafc.Model {
@@ -23,7 +24,9 @@ namespace Yafc.Model {
         public HashSet<Recipe> downstream = new HashSet<Recipe>();
         public HashSet<Recipe> upstream = new HashSet<Recipe>();
     }
+}
 
+namespace YAFC.Model {
     public class AutoPlanner : ProjectPageContents {
         public AutoPlanner(ModelObject page) : base(page) { }
 

--- a/Yafc.Model/Model/ProductionSummary.cs
+++ b/Yafc.Model/Model/ProductionSummary.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
+using Yafc.Model;
 using Yafc.UI;
 using YAFC.Model;
 
@@ -164,7 +165,9 @@ namespace Yafc.Model {
         }
         public Goods goods { get; }
     }
+}
 
+namespace YAFC.Model {
     public class ProductionSummary : ProjectPageContents, IComparer<(Goods goods, float amount)> {
         public ProductionSummary(ModelObject page) : base(page) {
             group = new ProductionSummaryGroup(this);


### PR DESCRIPTION
When renaming the namespaces, i noticed 2 classes end up in the json used to save project files. Namely `ProductionTable` and `ProductionSummary`. 

By mistake, i kept `ProductionTable` and `Summary` in the old namespace. On future inspection, `AutoPlanner` can in theory also ends in the json (althou this class seems to be unused?)

Just to be save, i've put `ProductionSummary` and `AutoPlanner` back in the old namespace. This keeps project files using the production summary compatible between releases of YaFC.

The real fix would be to change the save/load function to support both the new and old namespace. I'll get to that later, but this is a quick fix for now.