### PR TITLE
fix: Missing namespace

### DIFF
--- a/Yafc/Workspace/AutoPlannerView.cs
+++ b/Yafc/Workspace/AutoPlannerView.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Yafc.Model;
 using Yafc.UI;
+using YAFC.Model;
 
 namespace Yafc {
     public class AutoPlannerView : ProjectPageView<AutoPlanner> {


### PR DESCRIPTION
Well, my mistake :(

Missed one using statement and YaFC wouldn't even compile. Idk how i missed that. Anyway this PR fixes it.