### PR TITLE
Add fuel consumption recipe for products

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -72,6 +72,7 @@ dotnet_style_prefer_conditional_expression_over_return = false:none
 ###############################
 # Style Definitions
 dotnet_naming_style.pascal_case_style.capitalization             = pascal_case
+dotnet_naming_style.camel_case_style.capitalization              = camel_case
 # Use PascalCase for constant fields
 dotnet_naming_rule.constant_fields_should_be_pascal_case.severity = suggestion
 dotnet_naming_rule.constant_fields_should_be_pascal_case.symbols  = constant_fields
@@ -79,6 +80,11 @@ dotnet_naming_rule.constant_fields_should_be_pascal_case.style    = pascal_case_
 dotnet_naming_symbols.constant_fields.applicable_kinds            = field
 dotnet_naming_symbols.constant_fields.applicable_accessibilities  = *
 dotnet_naming_symbols.constant_fields.required_modifiers          = const
+# Use camcel case for local variable
+dotnet_naming_rule.use_camel_case_rule.symbols = use_camel_case
+dotnet_naming_rule.use_camel_case_rule.style = camel_case_style
+dotnet_naming_rule.use_camel_case_rule.severity = suggestion
+dotnet_naming_symbols.use_camel_case.applicable_kinds = parameter,local,local_function
 ###############################
 # C# Coding Conventions       #
 ###############################

--- a/Yafc.Model/Data/DataUtils.cs
+++ b/Yafc.Model/Data/DataUtils.cs
@@ -45,6 +45,7 @@ namespace Yafc.Model {
 
             return x.RecipeWaste().CompareTo(y.RecipeWaste());
         });
+        public static readonly FactorioObjectComparer<Recipe> AlreadySortedRecipe = new FactorioObjectComparer<Recipe>(DefaultRecipeOrdering.Compare);
         public static readonly FactorioObjectComparer<EntityCrafter> CrafterOrdering = new FactorioObjectComparer<EntityCrafter>((x, y) => {
             if (x.energy.type != y.energy.type) {
                 return x.energy.type.CompareTo(y.energy.type);

--- a/Yafc.UI/Rendering/Font.cs
+++ b/Yafc.UI/Rendering/Font.cs
@@ -6,6 +6,7 @@ namespace Yafc.UI {
     public class Font {
         public static Font header;
         public static Font subheader;
+        public static Font productionTableHeader;
         public static Font text;
 
         public readonly float size;

--- a/Yafc/Program.cs
+++ b/Yafc/Program.cs
@@ -25,6 +25,7 @@ namespace Yafc {
             Font.header = new Font(overriddenFontFile ?? new FontFile("Data/Roboto-Light.ttf"), 2f);
             var regular = overriddenFontFile ?? new FontFile("Data/Roboto-Regular.ttf");
             Font.subheader = new Font(regular, 1.5f);
+            Font.productionTableHeader = new Font(regular, 1.23f);
             Font.text = new Font(regular, 1f);
 
             ProjectDefinition cliProject = CommandLineParser.Parse(args);

--- a/Yafc/Widgets/ImmediateWidgets.cs
+++ b/Yafc/Widgets/ImmediateWidgets.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Numerics;
 using SDL2;
 using Yafc.Model;
@@ -115,15 +116,15 @@ namespace Yafc {
         public static bool BuildInlineObjectList<T>(this ImGui gui, IEnumerable<T> list, IComparer<T> ordering, string header, out T selected, int maxCount = 10,
             Predicate<T> checkMark = null, Func<T, string> extra = null) where T : FactorioObject {
             gui.BuildText(header, Font.subheader);
-            List<T> sortedList = new List<T>(list);
-            sortedList.Sort(ordering ?? DataUtils.DefaultOrdering);
+            IEnumerable<T> sortedList;
+            if (ordering == DataUtils.AlreadySortedRecipe) {
+                sortedList = list.AsEnumerable();
+            }
+            else {
+                sortedList = list.OrderBy(e => e, ordering ?? DataUtils.DefaultOrdering);
+            }
             selected = null;
-            int count = 0;
-            foreach (var elem in sortedList) {
-                if (count++ >= maxCount) {
-                    break;
-                }
-
+            foreach (var elem in sortedList.Take(maxCount)) {
                 string extraText = extra?.Invoke(elem);
                 if (gui.BuildFactorioObjectButtonWithText(elem, extraText)) {
                     selected = elem;

--- a/Yafc/Widgets/ImmediateWidgets.cs
+++ b/Yafc/Widgets/ImmediateWidgets.cs
@@ -115,7 +115,7 @@ namespace Yafc {
 
         public static bool BuildInlineObjectList<T>(this ImGui gui, IEnumerable<T> list, IComparer<T> ordering, string header, out T selected, int maxCount = 10,
             Predicate<T> checkMark = null, Func<T, string> extra = null) where T : FactorioObject {
-            gui.BuildText(header, Font.subheader);
+            gui.BuildText(header, Font.productionTableHeader);
             IEnumerable<T> sortedList;
             if (ordering == DataUtils.AlreadySortedRecipe) {
                 sortedList = list.AsEnumerable();
@@ -157,10 +157,6 @@ namespace Yafc {
                     else {
                         SelectSingleObjectPanel.Select(list, header, select, ordering, allowNone);
                     }
-                }
-
-                if (multiple && list.Count > 1) {
-                    gui.BuildText("Hint: ctrl+click to add multiple", wrap: true, color: SchemeColor.BackgroundTextFaint);
                 }
             }
         }

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -756,8 +756,10 @@ goodsHaveNoProduction:;
                     }
                 }
 
+                int numberOfShownRecipes = 0;
                 if (type != ProductDropdownType.Product && goods != null && allProduction.Length > 0) {
                     gui.BuildInlineObjectListAndButton(allProduction, comparer, addRecipe, "Add production recipe", 6, true, recipeExists);
+                    numberOfShownRecipes += allProduction.Length;
                     if (link == null) {
                         Rect iconRect = new Rect(gui.lastRect.Right - 2f, gui.lastRect.Top, 2f, 2f);
                         gui.DrawIcon(iconRect.Expand(-0.2f), Icon.OpenNew, gui.textColor);
@@ -773,14 +775,21 @@ goodsHaveNoProduction:;
 
                 if (type != ProductDropdownType.Fuel && goods != null && type != ProductDropdownType.Ingredient && goods.usages.Length > 0) {
                     gui.BuildInlineObjectListAndButton(goods.usages, DataUtils.DefaultRecipeOrdering, addRecipe, "Add consumption recipe", type == ProductDropdownType.Product ? 6 : 3, true, recipeExists);
+                    numberOfShownRecipes += goods.usages.Length;
                 }
 
                 if (type != ProductDropdownType.Fuel && goods != null && type != ProductDropdownType.Ingredient && fuelUseList.Length > 0) {
                     gui.BuildInlineObjectListAndButton(fuelUseList, DataUtils.AlreadySortedRecipe, (x) => { selectedFuel = goods; addRecipe(x); }, "Add fuel usage", type == ProductDropdownType.Product ? 6 : 3, true, recipeExists);
+                    numberOfShownRecipes += fuelUseList.Length;
                 }
 
                 if (type == ProductDropdownType.Product && goods != null && allProduction.Length > 0) {
                     gui.BuildInlineObjectListAndButton(allProduction, comparer, addRecipe, "Add production recipe", 1, true, recipeExists);
+                    numberOfShownRecipes += allProduction.Length;
+                }
+
+                if (numberOfShownRecipes > 1) {
+                    gui.BuildText("Hint: ctrl+click to add multiple", wrap: true, color: SchemeColor.BackgroundTextFaint);
                 }
 
                 if (link != null && gui.BuildCheckBox("Allow overproduction", link.algorithm == LinkAlgorithm.AllowOverProduction, out bool newValue)) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -3,6 +3,7 @@ Version: 0.6.5
 Date: soon
     Changes:
         - Add a help message and proper handling for command line arguments
+        - Add fuel consumption recipe for products
 ----------------------------------------------------------------------------------------------------------------------
 Version: 0.6.4
 Date: April 16th 2024


### PR DESCRIPTION
Fixes #76

![example](https://github.com/have-fun-was-taken/yafc-ce/assets/4461459/4c7653c4-4711-4e1f-bead-1abeba96403d)

This adds the option for products that are usable as fuel, to select a recipe based on that fuel consumption. YaFC will then attempt to add said recipe using the selected fuel.

I had to do some performance optimization since the electric power, or biomass, tends to select most py recipes (!), i saw over 8000 of them in my debugger. It now pre-sorts the list when the popup is opened, not each time you move the mouse over.