### PR TITLE
More .NET 8 code cleanup

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -95,7 +95,7 @@ csharp_style_var_when_type_is_apparent = false:suggestion
 # For all else, we prefer non-var but don't enforce it 
 csharp_style_var_elsewhere = false:none
 # Expression-bodied members
-csharp_style_expression_bodied_methods = false:suggestion
+csharp_style_expression_bodied_methods = true:suggestion
 csharp_style_expression_bodied_constructors = false:suggestion
 csharp_style_expression_bodied_operators = false:suggestion
 csharp_style_expression_bodied_properties = true:suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -97,7 +97,7 @@ csharp_style_var_elsewhere = false:none
 # Expression-bodied members
 csharp_style_expression_bodied_methods = true:suggestion
 csharp_style_expression_bodied_constructors = true:suggestion
-csharp_style_expression_bodied_operators = false:suggestion
+csharp_style_expression_bodied_operators = true:suggestion
 csharp_style_expression_bodied_properties = true:suggestion
 csharp_style_expression_bodied_indexers = true:suggestion
 csharp_style_expression_bodied_accessors = true:suggestion

--- a/.editorconfig
+++ b/.editorconfig
@@ -96,7 +96,7 @@ csharp_style_var_when_type_is_apparent = false:suggestion
 csharp_style_var_elsewhere = false:none
 # Expression-bodied members
 csharp_style_expression_bodied_methods = true:suggestion
-csharp_style_expression_bodied_constructors = false:suggestion
+csharp_style_expression_bodied_constructors = true:suggestion
 csharp_style_expression_bodied_operators = false:suggestion
 csharp_style_expression_bodied_properties = true:suggestion
 csharp_style_expression_bodied_indexers = true:suggestion

--- a/Yafc.Model.Tests/Analysis/Milestones.cs
+++ b/Yafc.Model.Tests/Analysis/Milestones.cs
@@ -2,6 +2,7 @@
 using System.Reflection;
 using Xunit;
 
+#pragma warning disable CA1861 // "CA1861: Avoid constant arrays as arguments." Disabled because it tried to fix constant arrays in InlineData.
 namespace Yafc.Model.Tests {
     public class MilestonesTests {
         private static Bits createBits(ulong value) {

--- a/Yafc.Model.Tests/Analysis/Milestones.cs
+++ b/Yafc.Model.Tests/Analysis/Milestones.cs
@@ -1,5 +1,4 @@
-﻿using System.Collections.Generic;
-using System.Reflection;
+﻿using System.Reflection;
 using Xunit;
 
 #pragma warning disable CA1861 // "CA1861: Avoid constant arrays as arguments." Disabled because it tried to fix constant arrays in InlineData.

--- a/Yafc.Model.Tests/Analysis/Milestones.cs
+++ b/Yafc.Model.Tests/Analysis/Milestones.cs
@@ -19,7 +19,7 @@ namespace Yafc.Model.Tests {
         private static Milestones setupMilestones(ulong result, ulong mask, out FactorioObject factorioObj) {
             factorioObj = new Technology();
             Mapping<FactorioObject, Bits> milestoneResult = new Mapping<FactorioObject, Bits>(
-                new FactorioIdRange<FactorioObject>(0, 1, new List<FactorioObject>() { factorioObj })) {
+                new FactorioIdRange<FactorioObject>(0, 1, [factorioObj])) {
                 [factorioObj] = createBits(result)
             };
 
@@ -29,7 +29,7 @@ namespace Yafc.Model.Tests {
             var milestoneResultField = milestonesType.GetField("milestoneResult", BindingFlags.NonPublic | BindingFlags.Instance);
 
             Milestones milestones = new Milestones() {
-                currentMilestones = new FactorioObject[] { factorioObj }
+                currentMilestones = [factorioObj]
             };
 
             milestoneResultField.SetValue(milestones, milestoneResult);

--- a/Yafc.Model/Analysis/Analysis.cs
+++ b/Yafc.Model/Analysis/Analysis.cs
@@ -5,7 +5,7 @@ namespace Yafc.Model {
     public abstract class Analysis {
         public abstract void Compute(Project project, ErrorCollector warnings);
 
-        private static readonly List<Analysis> analyses = new List<Analysis>();
+        private static readonly List<Analysis> analyses = [];
         public static void RegisterAnalysis(Analysis analysis, params Analysis[] dependencies) // TODO don't ignore dependencies
         {
             analyses.Add(analysis);

--- a/Yafc.Model/Analysis/CostAnalysis.cs
+++ b/Yafc.Model/Analysis/CostAnalysis.cs
@@ -376,7 +376,7 @@ namespace Yafc.Model {
 
             _ = sb.Append(costPrefix).Append(" ¥").Append(DataUtils.FormatAmount(compareCost, UnitOfMeasure.None));
             if (compareCostNow > compareCost && !float.IsPositiveInfinity(compareCostNow)) {
-                _ = sb.Append(" (Currently ¥").Append(DataUtils.FormatAmount(compareCostNow, UnitOfMeasure.None)).Append(")");
+                _ = sb.Append(" (Currently ¥").Append(DataUtils.FormatAmount(compareCostNow, UnitOfMeasure.None)).Append(')');
             }
 
             return sb.ToString();

--- a/Yafc.Model/Analysis/CostAnalysis.cs
+++ b/Yafc.Model/Analysis/CostAnalysis.cs
@@ -48,7 +48,7 @@ namespace Yafc.Model {
             var variables = Database.goods.CreateMapping<Variable>();
             var constraints = Database.recipes.CreateMapping<Constraint>();
 
-            Dictionary<Goods, float> sciencePackUsage = new Dictionary<Goods, float>();
+            Dictionary<Goods, float> sciencePackUsage = [];
             if (!onlyCurrentMilestones && project.preferences.targetTechnology != null) {
                 itemAmountPrefix = "Estimated amount for " + project.preferences.targetTechnology.locName + ": ";
                 foreach (var spUsage in TechnologyScienceAnalysis.Instance.allSciencePacks[project.preferences.targetTechnology]) {
@@ -335,7 +335,7 @@ namespace Yafc.Model {
                 }
             }
 
-            importantItems = Database.goods.all.Where(x => x.usages.Length > 1).OrderByDescending(x => flow[x] * cost[x] * x.usages.Count(y => ShouldInclude(y) && recipeWastePercentage[y] == 0f)).ToArray();
+            importantItems = [.. Database.goods.all.Where(x => x.usages.Length > 1).OrderByDescending(x => flow[x] * cost[x] * x.usages.Count(y => ShouldInclude(y) && recipeWastePercentage[y] == 0f))];
 
             solver.Dispose();
         }

--- a/Yafc.Model/Analysis/CostAnalysis.cs
+++ b/Yafc.Model/Analysis/CostAnalysis.cs
@@ -382,7 +382,7 @@ namespace Yafc.Model {
             return sb.ToString();
         }
 
-        public float GetBuildingHours(Recipe recipe, float flow) {
+        public static float GetBuildingHours(Recipe recipe, float flow) {
             return recipe.time * flow * (1000f / 3600f);
         }
 

--- a/Yafc.Model/Analysis/CostAnalysis.cs
+++ b/Yafc.Model/Analysis/CostAnalysis.cs
@@ -6,7 +6,7 @@ using System.Text;
 using Google.OrTools.LinearSolver;
 
 namespace Yafc.Model {
-    public class CostAnalysis : Analysis {
+    public class CostAnalysis(bool onlyCurrentMilestones) : Analysis {
         public static readonly CostAnalysis Instance = new CostAnalysis(false);
         public static readonly CostAnalysis InstanceAtMilestones = new CostAnalysis(true);
         public static CostAnalysis Get(bool atCurrentMilestones) {
@@ -32,12 +32,8 @@ namespace Yafc.Model {
         public Mapping<FactorioObject, float> flow;
         public Mapping<Recipe, float> recipeWastePercentage;
         public Goods[] importantItems;
-        private readonly bool onlyCurrentMilestones;
+        private readonly bool onlyCurrentMilestones = onlyCurrentMilestones;
         private string itemAmountPrefix;
-
-        public CostAnalysis(bool onlyCurrentMilestones) {
-            this.onlyCurrentMilestones = onlyCurrentMilestones;
-        }
 
         private bool ShouldInclude(FactorioObject obj) {
             return onlyCurrentMilestones ? obj.IsAutomatableWithCurrentMilestones() : obj.IsAutomatable();

--- a/Yafc.Model/Analysis/Dependencies.cs
+++ b/Yafc.Model/Analysis/Dependencies.cs
@@ -37,11 +37,11 @@ namespace Yafc.Model {
             dependencyList = Database.objects.CreateMapping<DependencyList[]>();
             reverseDependencies = Database.objects.CreateMapping<List<FactorioId>>();
             foreach (var obj in Database.objects.all) {
-                reverseDependencies[obj] = new List<FactorioId>();
+                reverseDependencies[obj] = [];
             }
 
             DependencyCollector collector = new DependencyCollector();
-            List<FactorioObject> temp = new List<FactorioObject>();
+            List<FactorioObject> temp = [];
             foreach (var obj in Database.objects.all) {
                 obj.GetDependencies(collector, temp);
                 var packed = collector.Pack();
@@ -58,7 +58,7 @@ namespace Yafc.Model {
         }
 
         private class DependencyCollector : IDependencyCollector {
-            private readonly List<DependencyList> list = new List<DependencyList>();
+            private readonly List<DependencyList> list = [];
 
             public void Add(FactorioId[] raw, DependencyList.Flags flags) {
                 list.Add(new DependencyList { elements = raw, flags = flags });

--- a/Yafc.Model/Analysis/Milestones.cs
+++ b/Yafc.Model/Analysis/Milestones.cs
@@ -155,7 +155,7 @@ namespace Yafc.Model {
                 if (i > 0) {
                     var milestone = currentMilestones[i - 1];
                     if (milestone == null) {
-                        milestonesNotReachable = new List<FactorioObject>();
+                        milestonesNotReachable = [];
                         foreach (var pack in Database.allSciencePacks) {
                             if (Array.IndexOf(currentMilestones, pack) == -1) {
                                 currentMilestones[nextMilestoneIndex++] = pack;

--- a/Yafc.Model/Blueprints/Blueprint.cs
+++ b/Yafc.Model/Blueprints/Blueprint.cs
@@ -55,8 +55,8 @@ namespace Yafc.Blueprints {
 
         public string item { get; set; } = "blueprint";
         public string label { get; set; }
-        public List<BlueprintEntity> entities { get; } = new List<BlueprintEntity>();
-        public List<BlueprintIcon> icons { get; } = new List<BlueprintIcon>();
+        public List<BlueprintEntity> entities { get; } = [];
+        public List<BlueprintIcon> icons { get; } = [];
         public int version { get; set; } = VERSION;
     }
 
@@ -96,7 +96,7 @@ namespace Yafc.Blueprints {
         public string recipe { get; set; }
         [JsonPropertyName("control_behavior")] public BlueprintControlBehavior controlBehavior { get; set; }
         public BlueprintConnection connections { get; set; }
-        [JsonPropertyName("request_filters")] public List<BlueprintRequestFilter> requestFilters { get; } = new List<BlueprintRequestFilter>();
+        [JsonPropertyName("request_filters")] public List<BlueprintRequestFilter> requestFilters { get; } = [];
         public Dictionary<string, int> items { get; set; }
 
         public void Connect(BlueprintEntity other, bool red = true, bool secondPort = false, bool targetSecond = false) {
@@ -134,8 +134,8 @@ namespace Yafc.Blueprints {
 
     [Serializable]
     public class BlueprintConnectionPoint {
-        public List<BlueprintConnectionData> red { get; } = new List<BlueprintConnectionData>();
-        public List<BlueprintConnectionData> green { get; } = new List<BlueprintConnectionData>();
+        public List<BlueprintConnectionData> red { get; } = [];
+        public List<BlueprintConnectionData> green { get; } = [];
     }
 
     [Serializable]
@@ -152,7 +152,7 @@ namespace Yafc.Blueprints {
 
     [Serializable]
     public class BlueprintControlBehavior {
-        public List<BlueprintControlFilter> filters { get; } = new List<BlueprintControlFilter>();
+        public List<BlueprintControlFilter> filters { get; } = [];
     }
 
     [Serializable]

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -529,9 +529,9 @@ namespace Yafc.Model {
         public Recipe[] limitation_blacklist { get; internal set; }
     }
 
-    public struct TemperatureRange {
-        public int min;
-        public int max;
+    public struct TemperatureRange(int min, int max) {
+        public int min = min;
+        public int max = max;
 
         public static readonly TemperatureRange Any = new TemperatureRange(int.MinValue, int.MaxValue);
         public bool IsAny() {
@@ -540,11 +540,6 @@ namespace Yafc.Model {
 
         public bool IsSingle() {
             return min == max;
-        }
-
-        public TemperatureRange(int min, int max) {
-            this.min = min;
-            this.max = max;
         }
 
         public TemperatureRange(int single) : this(single, single) { }

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -92,7 +92,7 @@ namespace Yafc.Model {
         public EntityCrafter[] crafters { get; internal set; }
         public Ingredient[] ingredients { get; internal set; }
         public Product[] products { get; internal set; }
-        public Item[] modules { get; internal set; } = Array.Empty<Item>();
+        public Item[] modules { get; internal set; } = [];
         public Entity sourceEntity { get; internal set; }
         public Goods mainProduct { get; internal set; }
         public float time { get; internal set; }
@@ -378,7 +378,7 @@ namespace Yafc.Model {
     }
 
     public class Entity : FactorioObject {
-        public Product[] loot { get; internal set; } = Array.Empty<Product>();
+        public Product[] loot { get; internal set; } = [];
         public bool mapGenerated { get; internal set; }
         public float mapGenDensity { get; internal set; }
         public float power { get; internal set; }
@@ -482,8 +482,8 @@ namespace Yafc.Model {
     public class Technology : RecipeOrTechnology // Technology is very similar to recipe
     {
         public float count { get; internal set; } // TODO support formula count
-        public Technology[] prerequisites { get; internal set; } = Array.Empty<Technology>();
-        public Recipe[] unlockRecipes { get; internal set; } = Array.Empty<Recipe>();
+        public Technology[] prerequisites { get; internal set; } = [];
+        public Recipe[] unlockRecipes { get; internal set; } = [];
         internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.Technologies;
         public override string type => "Technology";
 

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -534,17 +534,17 @@ namespace Yafc.Model {
         public int max = max;
 
         public static readonly TemperatureRange Any = new TemperatureRange(int.MinValue, int.MaxValue);
-        public bool IsAny() {
+        public readonly bool IsAny() {
             return min == int.MinValue && max == int.MaxValue;
         }
 
-        public bool IsSingle() {
+        public readonly bool IsSingle() {
             return min == max;
         }
 
         public TemperatureRange(int single) : this(single, single) { }
 
-        public override string ToString() {
+        public override readonly string ToString() {
             if (min == max) {
                 return min + "°";
             }
@@ -552,7 +552,7 @@ namespace Yafc.Model {
             return min + "°-" + max + "°";
         }
 
-        public bool Contains(int value) {
+        public readonly bool Contains(int value) {
             return min <= value && max >= value;
         }
     }

--- a/Yafc.Model/Data/DataUtils.cs
+++ b/Yafc.Model/Data/DataUtils.cs
@@ -340,7 +340,7 @@ namespace Yafc.Model {
             }
         }
 
-        private const char no = (char)0;
+        private const char NO = (char)0;
         public static readonly (char suffix, float multiplier, string format)[] FormatSpec =
         [
             ('μ', 1e6f,  "0.##"),
@@ -348,12 +348,12 @@ namespace Yafc.Model {
             ('μ', 1e6f,  "0.#"),
             ('μ', 1e6f,  "0"),
             ('μ', 1e6f,  "0"), // skipping m (milli-) because too similar to M (mega-)
-            (no,  1e0f,  "0.####"),
-            (no,  1e0f,  "0.###"),
-            (no,  1e0f,  "0.##"),
-            (no,  1e0f,  "0.##"), // [1-10]
-            (no,  1e0f,  "0.#"),
-            (no,  1e0f,  "0"),
+            (NO,  1e0f,  "0.####"),
+            (NO,  1e0f,  "0.###"),
+            (NO,  1e0f,  "0.##"),
+            (NO,  1e0f,  "0.##"), // [1-10]
+            (NO,  1e0f,  "0.#"),
+            (NO,  1e0f,  "0"),
             ('k', 1e-3f, "0.##"),
             ('k', 1e-3f, "0.#"),
             ('k', 1e-3f, "0"),
@@ -374,16 +374,16 @@ namespace Yafc.Model {
             ('μ', 1e6f,  "0.00000"),
             ('μ', 1e6f,  "0.0000"),
             ('μ', 1e6f,  "0.0000"), // skipping m (milli-) because too similar to M (mega-)
-            (no,  1e0f,  "0.00000000"),
-            (no,  1e0f,  "0.0000000"),
-            (no,  1e0f,  "0.000000"),
-            (no,  1e0f,  "0.000000"), // [1-10]
-            (no,  1e0f,  "00.00000"),
-            (no,  1e0f,  "000.0000"),
-            (no,  1e0f,  "0 000.000"),
-            (no,  1e0f,  "00 000.00"),
-            (no,  1e0f,  "000 000.0"),
-            (no,  1e0f,  "0 000 000"),
+            (NO,  1e0f,  "0.00000000"),
+            (NO,  1e0f,  "0.0000000"),
+            (NO,  1e0f,  "0.000000"),
+            (NO,  1e0f,  "0.000000"), // [1-10]
+            (NO,  1e0f,  "00.00000"),
+            (NO,  1e0f,  "000.0000"),
+            (NO,  1e0f,  "0 000.000"),
+            (NO,  1e0f,  "00 000.00"),
+            (NO,  1e0f,  "000 000.0"),
+            (NO,  1e0f,  "0 000 000"),
         ];
 
         private static readonly StringBuilder amountBuilder = new StringBuilder();
@@ -449,7 +449,7 @@ namespace Yafc.Model {
             int idx = MathUtils.Clamp(MathUtils.Floor(MathF.Log10(amount)) + 8, 0, formatSpec.Length - 1);
             var val = formatSpec[idx];
             _ = amountBuilder.Append((amount * val.multiplier).ToString(val.format));
-            if (val.suffix != no) {
+            if (val.suffix != NO) {
                 _ = amountBuilder.Append(val.suffix);
             }
 

--- a/Yafc.Model/Data/DataUtils.cs
+++ b/Yafc.Model/Data/DataUtils.cs
@@ -78,6 +78,10 @@ namespace Yafc.Model {
         public static string modsPath { get; internal set; }
         public static bool expensiveRecipes { get; internal set; }
         public static string[] allMods { get; internal set; }
+        public static Icon NoFuelIcon { get; internal set; }
+        public static Icon WarningIcon { get; internal set; }
+        public static Icon HandIcon { get; internal set; }
+
         public static readonly Random random = new Random();
 
         public static bool SelectSingle<T>(this T[] list, out T element) where T : FactorioObject {
@@ -281,10 +285,6 @@ namespace Yafc.Model {
         public static FactorioObjectComparer<Recipe> GetRecipeComparerFor(Goods goods) {
             return new FactorioObjectComparer<Recipe>((x, y) => (x.Cost(true) / x.GetProduction(goods)).CompareTo(y.Cost(true) / y.GetProduction(goods)));
         }
-
-        public static Icon NoFuelIcon;
-        public static Icon WarningIcon;
-        public static Icon HandIcon;
 
         public static T AutoSelect<T>(this IEnumerable<T> list, IComparer<T> comparer = default) {
             if (comparer == null) {

--- a/Yafc.Model/Data/DataUtils.cs
+++ b/Yafc.Model/Data/DataUtils.cs
@@ -161,7 +161,7 @@ namespace Yafc.Model {
             }
         }
 
-        public static Solver CreateSolver(string name) {
+        public static Solver CreateSolver() {
             Solver solver = Solver.CreateSolver("GLOP_LINEAR_PROGRAMMING");
             // Relax solver parameters as returning imprecise solution is better than no solution at all
             // It is not like we need 8 digits of precision after all, most computations in YAFC are done in singles

--- a/Yafc.Model/Data/DataUtils.cs
+++ b/Yafc.Model/Data/DataUtils.cs
@@ -219,7 +219,7 @@ namespace Yafc.Model {
         }
 
         public class FavoritesComparer<T>(Project project, IComparer<T> def) : IComparer<T> where T : FactorioObject {
-            private readonly Dictionary<T, int> bumps = new Dictionary<T, int>();
+            private readonly Dictionary<T, int> bumps = [];
             private readonly IComparer<T> def = def;
             private readonly HashSet<FactorioObject> userFavorites = project.preferences.favorites;
 
@@ -342,7 +342,7 @@ namespace Yafc.Model {
 
         private const char no = (char)0;
         public static readonly (char suffix, float multiplier, string format)[] FormatSpec =
-        {
+        [
             ('μ', 1e6f,  "0.##"),
             ('μ', 1e6f,  "0.##"),
             ('μ', 1e6f,  "0.#"),
@@ -365,10 +365,10 @@ namespace Yafc.Model {
             ('G', 1e-9f, "0"),
             ('T', 1e-12f, "0.##"),
             ('T', 1e-12f, "0.#"),
-        };
+        ];
 
         public static readonly (char suffix, float multiplier, string format)[] PreciseFormat =
-        {
+        [
             ('μ', 1e6f,  "0.000000"),
             ('μ', 1e6f,  "0.000000"),
             ('μ', 1e6f,  "0.00000"),
@@ -384,7 +384,7 @@ namespace Yafc.Model {
             (no,  1e0f,  "00 000.00"),
             (no,  1e0f,  "000 000.0"),
             (no,  1e0f,  "0 000 000"),
-        };
+        ];
 
         private static readonly StringBuilder amountBuilder = new StringBuilder();
         public static bool HasFlags<T>(this T enumeration, T flags) where T : unmanaged, Enum {

--- a/Yafc.Model/Data/DataUtils.cs
+++ b/Yafc.Model/Data/DataUtils.cs
@@ -131,11 +131,9 @@ namespace Yafc.Model {
             }
         }
 
-        public class FactorioObjectComparer<T> : IComparer<T> where T : FactorioObject {
-            private readonly Comparison<T> similarComparison;
-            public FactorioObjectComparer(Comparison<T> similarComparison) {
-                this.similarComparison = similarComparison;
-            }
+        public class FactorioObjectComparer<T>(Comparison<T> similarComparison) : IComparer<T> where T : FactorioObject {
+            private readonly Comparison<T> similarComparison = similarComparison;
+
             public int Compare(T x, T y) {
                 if (x == null) {
                     return y == null ? 0 : 1;
@@ -220,14 +218,10 @@ namespace Yafc.Model {
             cstr.SetCoefficient(var, amount);
         }
 
-        public class FavoritesComparer<T> : IComparer<T> where T : FactorioObject {
+        public class FavoritesComparer<T>(Project project, IComparer<T> def) : IComparer<T> where T : FactorioObject {
             private readonly Dictionary<T, int> bumps = new Dictionary<T, int>();
-            private readonly IComparer<T> def;
-            private readonly HashSet<FactorioObject> userFavorites;
-            public FavoritesComparer(Project project, IComparer<T> def) {
-                this.def = def;
-                userFavorites = project.preferences.favorites;
-            }
+            private readonly IComparer<T> def = def;
+            private readonly HashSet<FactorioObject> userFavorites = project.preferences.favorites;
 
             public void AddToFavorite(T x, int amount = 1) {
                 if (x == null) {

--- a/Yafc.Model/Data/Database.cs
+++ b/Yafc.Model/Data/Database.cs
@@ -200,9 +200,9 @@ namespace Yafc.Model {
                 index = -1;
             }
 
-            public KeyValuePair<TKey, TValue> Current => new KeyValuePair<TKey, TValue>(keys[index], values[index]);
-            object IEnumerator.Current => Current;
-            public void Dispose() { }
+            public readonly KeyValuePair<TKey, TValue> Current => new KeyValuePair<TKey, TValue>(keys[index], values[index]);
+            readonly object IEnumerator.Current => Current;
+            public readonly void Dispose() { }
         }
     }
 

--- a/Yafc.Model/Data/Database.cs
+++ b/Yafc.Model/Data/Database.cs
@@ -105,14 +105,9 @@ namespace Yafc.Model {
     }
 
     // Mapping[TKey, TValue] is almost like a dictionary where TKey is FactorioObject but it is an array wrapper and therefore very fast. This is preferable way to add custom properties to FactorioObjects
-    public readonly struct Mapping<TKey, TValue> : IDictionary<TKey, TValue> where TKey : FactorioObject {
-        private readonly int offset;
-        private readonly FactorioIdRange<TKey> source;
-        public Mapping(FactorioIdRange<TKey> source) {
-            this.source = source;
-            Values = new TValue[source.count];
-            offset = source.start;
-        }
+    public readonly struct Mapping<TKey, TValue>(FactorioIdRange<TKey> source) : IDictionary<TKey, TValue> where TKey : FactorioObject {
+        private readonly int offset = source.start;
+        private readonly FactorioIdRange<TKey> source = source;
 
         public void Add(TKey key, TValue value) {
             this[key] = value;
@@ -159,7 +154,7 @@ namespace Yafc.Model {
         public int Count => Values.Length;
         public bool IsReadOnly => false;
         public TKey[] Keys => source.all;
-        public TValue[] Values { get; }
+        public TValue[] Values { get; } = new TValue[source.count];
         ICollection<TKey> IDictionary<TKey, TValue>.Keys => Keys;
         ICollection<TValue> IDictionary<TKey, TValue>.Values => Values;
         IEnumerator<KeyValuePair<TKey, TValue>> IEnumerable<KeyValuePair<TKey, TValue>>.GetEnumerator() {

--- a/Yafc.Model/Data/Database.cs
+++ b/Yafc.Model/Data/Database.cs
@@ -35,7 +35,7 @@ namespace Yafc.Model {
         public static FactorioObject FindClosestVariant(string id) {
             string baseId;
             int temperature;
-            int splitter = id.IndexOf("@", StringComparison.Ordinal);
+            int splitter = id.IndexOf('@');
             if (splitter >= 0) {
                 baseId = id[..splitter];
                 _ = int.TryParse(id[(splitter + 1)..], out temperature);

--- a/Yafc.Model/Data/PageReference.cs
+++ b/Yafc.Model/Data/PageReference.cs
@@ -1,16 +1,12 @@
 ﻿using System;
 
 namespace Yafc.Model {
-    public sealed class PageReference {
+    public sealed class PageReference(Guid guid) {
         public PageReference(ProjectPage page) : this(page.guid) {
             _page = page;
         }
 
-        public PageReference(Guid guid) {
-            this.guid = guid;
-        }
-
-        public Guid guid { get; }
+        public Guid guid { get; } = guid;
         private ProjectPage _page;
 
         public ProjectPage page {

--- a/Yafc.Model/Data/SortedList.cs
+++ b/Yafc.Model/Data/SortedList.cs
@@ -7,7 +7,7 @@ namespace Yafc.Model {
     public class SortedList<T>(IComparer<T> comparer) : ICollection<T>, IReadOnlyList<T>, IList<T> {
         private readonly IComparer<T> comparer = comparer;
         private int version;
-        private T[] data = Array.Empty<T>();
+        private T[] data = [];
         IEnumerator<T> IEnumerable<T>.GetEnumerator() {
             return GetEnumerator();
         }

--- a/Yafc.Model/Data/SortedList.cs
+++ b/Yafc.Model/Data/SortedList.cs
@@ -39,7 +39,7 @@ namespace Yafc.Model {
                 return true;
             }
 
-            private void Throw() {
+            private static void Throw() {
                 throw new InvalidOperationException("Collection was modified, enumeration cannot continue");
             }
 

--- a/Yafc.Model/Data/SortedList.cs
+++ b/Yafc.Model/Data/SortedList.cs
@@ -49,8 +49,9 @@ namespace Yafc.Model {
             }
 
             public T Current { get; private set; } = default;
-            object IEnumerator.Current => Current;
-            public void Dispose() { }
+
+            readonly object IEnumerator.Current => Current;
+            public readonly void Dispose() { }
         }
 
 

--- a/Yafc.Model/Data/SortedList.cs
+++ b/Yafc.Model/Data/SortedList.cs
@@ -4,12 +4,8 @@ using System.Collections.Generic;
 
 namespace Yafc.Model {
     // Simple set with array as backing storage with O(ln(n)) search, O(n) insertion and iteration
-    public class SortedList<T> : ICollection<T>, IReadOnlyList<T>, IList<T> {
-        private readonly IComparer<T> comparer;
-        public SortedList(IComparer<T> comparer) {
-            this.comparer = comparer;
-        }
-
+    public class SortedList<T>(IComparer<T> comparer) : ICollection<T>, IReadOnlyList<T>, IList<T> {
+        private readonly IComparer<T> comparer = comparer;
         private int version;
         private T[] data = Array.Empty<T>();
         IEnumerator<T> IEnumerable<T>.GetEnumerator() {
@@ -24,17 +20,10 @@ namespace Yafc.Model {
             return new Enumerator(this);
         }
 
-        public struct Enumerator : IEnumerator<T> {
-            private readonly SortedList<T> list;
-            private int index;
-            private int version;
-
-            public Enumerator(SortedList<T> list) {
-                this.list = list;
-                version = list.version;
-                index = -1;
-                Current = default;
-            }
+        public struct Enumerator(SortedList<T> list) : IEnumerator<T> {
+            private readonly SortedList<T> list = list;
+            private int index = -1;
+            private int version = list.version;
 
             public bool MoveNext() {
                 if (list.version != version) {
@@ -59,7 +48,7 @@ namespace Yafc.Model {
                 version = list.version;
             }
 
-            public T Current { get; private set; }
+            public T Current { get; private set; } = default;
             object IEnumerator.Current => Current;
             public void Dispose() { }
         }

--- a/Yafc.Model/Math/Bits.cs
+++ b/Yafc.Model/Math/Bits.cs
@@ -11,7 +11,7 @@ namespace Yafc.Model {
                 _length = value;
             }
         }
-        private ulong[] data = Array.Empty<ulong>();
+        private ulong[] data = [];
 
         public bool this[int i] {
             get {

--- a/Yafc.Model/Math/Graph.cs
+++ b/Yafc.Model/Math/Graph.cs
@@ -46,7 +46,7 @@ namespace Yafc.Model {
             internal int state;
             internal int extra;
             private int arcCount;
-            private Node[] arcs = Array.Empty<Node>();
+            private Node[] arcs = [];
             public Node(Graph<T> graph, T userData) {
                 this.userData = userData;
                 this.graph = graph;

--- a/Yafc.Model/Math/Graph.cs
+++ b/Yafc.Model/Math/Graph.cs
@@ -4,8 +4,8 @@ using System.Collections.Generic;
 
 namespace Yafc.Model {
     public class Graph<T> : IEnumerable<Graph<T>.Node> {
-        private readonly Dictionary<T, Node> nodes = new Dictionary<T, Node>();
-        private readonly List<Node> allNodes = new List<Node>();
+        private readonly Dictionary<T, Node> nodes = [];
+        private readonly List<Node> allNodes = [];
 
         private Node GetNode(T src) {
             if (nodes.TryGetValue(src, out var node)) {
@@ -86,7 +86,7 @@ namespace Yafc.Model {
         }
 
         public Dictionary<T, TValue> Aggregate<TValue>(Func<T, TValue> create, Action<TValue, T, TValue> connection) {
-            Dictionary<T, TValue> aggregation = new Dictionary<T, TValue>();
+            Dictionary<T, TValue> aggregation = [];
             foreach (var node in allNodes) {
                 _ = AggregateInternal(node, create, connection, aggregation);
             }
@@ -113,8 +113,8 @@ namespace Yafc.Model {
                 node.state = -1;
             }
 
-            Dictionary<T, (T, T[])> remap = new Dictionary<T, (T, T[])>();
-            List<Node> stack = new List<Node>();
+            Dictionary<T, (T, T[])> remap = [];
+            List<Node> stack = [];
             int index = 0;
             foreach (var node in allNodes) {
                 if (node.state == -1) {

--- a/Yafc.Model/Model/AutoPlanner.cs
+++ b/Yafc.Model/Model/AutoPlanner.cs
@@ -21,16 +21,16 @@ namespace Yafc.Model {
         public Recipe recipe;
         public int tier;
         public float recipesPerSecond;
-        public HashSet<Recipe> downstream = new HashSet<Recipe>();
-        public HashSet<Recipe> upstream = new HashSet<Recipe>();
+        public HashSet<Recipe> downstream = [];
+        public HashSet<Recipe> upstream = [];
     }
 }
 
 namespace YAFC.Model {
     public class AutoPlanner(ModelObject page) : ProjectPageContents(page) {
-        public List<AutoPlannerGoal> goals { get; } = new List<AutoPlannerGoal>();
-        public HashSet<Recipe> done { get; } = new HashSet<Recipe>();
-        public HashSet<Goods> roots { get; } = new HashSet<Goods>();
+        public List<AutoPlannerGoal> goals { get; } = [];
+        public HashSet<Recipe> done { get; } = [];
+        public HashSet<Goods> roots { get; } = [];
 
         public AutoPlannerRecipe[][] tiers { get; private set; }
 
@@ -55,7 +55,7 @@ namespace YAFC.Model {
             processingStack.Enqueue(null); // depth marker;
             int depth = 0;
 
-            List<Recipe> allRecipes = new List<Recipe>();
+            List<Recipe> allRecipes = [];
             while (processingStack.Count > 1) {
                 var item = processingStack.Dequeue();
                 if (item == null) {
@@ -143,10 +143,10 @@ namespace YAFC.Model {
                 _ = set.Add(item);
                 set.UnionWith(subset);
             });
-            Dictionary<Recipe, HashSet<Recipe>> downstream = new Dictionary<Recipe, HashSet<Recipe>>();
-            Dictionary<Recipe, HashSet<Recipe>> upstream = new Dictionary<Recipe, HashSet<Recipe>>();
+            Dictionary<Recipe, HashSet<Recipe>> downstream = [];
+            Dictionary<Recipe, HashSet<Recipe>> upstream = [];
             foreach (var ((single, list), dependencies) in allDependencies) {
-                HashSet<Recipe> deps = new HashSet<Recipe>();
+                HashSet<Recipe> deps = [];
                 foreach (var (singleDep, listDep) in dependencies) {
                     var elem = singleDep;
                     if (listDep != null) {
@@ -158,7 +158,7 @@ namespace YAFC.Model {
                     }
 
                     if (!upstream.TryGetValue(elem, out var set)) {
-                        set = new HashSet<Recipe>();
+                        set = [];
                         if (listDep != null) {
                             foreach (var recipe in listDep) {
                                 upstream[recipe] = set;
@@ -188,9 +188,9 @@ namespace YAFC.Model {
             }
 
             HashSet<(Recipe, Recipe[])> remainingNodes = new HashSet<(Recipe, Recipe[])>(subgraph.Select(x => x.userData));
-            List<(Recipe, Recipe[])> nodesToClear = new List<(Recipe, Recipe[])>();
-            List<AutoPlannerRecipe[]> tiers = new List<AutoPlannerRecipe[]>();
-            List<Recipe> currentTier = new List<Recipe>();
+            List<(Recipe, Recipe[])> nodesToClear = [];
+            List<AutoPlannerRecipe[]> tiers = [];
+            List<Recipe> currentTier = [];
             while (remainingNodes.Count > 0) {
                 currentTier.Clear();
                 // First attempt to create tier: Immediately accessible recipe
@@ -239,7 +239,7 @@ nope:;
             solver.Dispose();
             await Ui.EnterMainThread();
 
-            this.tiers = tiers.ToArray();
+            this.tiers = [.. tiers];
             return null;
         }
 

--- a/Yafc.Model/Model/AutoPlanner.cs
+++ b/Yafc.Model/Model/AutoPlanner.cs
@@ -27,9 +27,7 @@ namespace Yafc.Model {
 }
 
 namespace YAFC.Model {
-    public class AutoPlanner : ProjectPageContents {
-        public AutoPlanner(ModelObject page) : base(page) { }
-
+    public class AutoPlanner(ModelObject page) : ProjectPageContents(page) {
         public List<AutoPlannerGoal> goals { get; } = new List<AutoPlannerGoal>();
         public HashSet<Recipe> done { get; } = new HashSet<Recipe>();
         public HashSet<Goods> roots { get; } = new HashSet<Goods>();

--- a/Yafc.Model/Model/ProductionSummary.cs
+++ b/Yafc.Model/Model/ProductionSummary.cs
@@ -7,7 +7,7 @@ using YAFC.Model;
 
 namespace Yafc.Model {
     public class ProductionSummaryGroup(ModelObject owner) : ModelObject<ModelObject>(owner), IElementGroup<ProductionSummaryEntry> {
-        public List<ProductionSummaryEntry> elements { get; } = new List<ProductionSummaryEntry>();
+        public List<ProductionSummaryEntry> elements { get; } = [];
         [NoUndo]
         public bool expanded { get; set; }
         public string name { get; set; }
@@ -51,7 +51,7 @@ namespace Yafc.Model {
         public PageReference page { get; set; }
         public ProductionSummaryGroup subgroup { get; set; }
         public bool visible { get; private set; } = true;
-        [SkipSerialization] public Dictionary<Goods, float> flow { get; } = new Dictionary<Goods, float>();
+        [SkipSerialization] public Dictionary<Goods, float> flow { get; } = [];
         private bool needRefreshFlow = true;
 
         public Icon icon {
@@ -167,11 +167,11 @@ namespace YAFC.Model {
             group = new ProductionSummaryGroup(this);
         }
         public ProductionSummaryGroup group { get; }
-        public List<ProductionSummaryColumn> columns { get; } = new List<ProductionSummaryColumn>();
-        [SkipSerialization] public List<(Goods goods, float amount)> sortedFlow { get; } = new List<(Goods goods, float amount)>();
+        public List<ProductionSummaryColumn> columns { get; } = [];
+        [SkipSerialization] public List<(Goods goods, float amount)> sortedFlow { get; } = [];
 
-        private readonly Dictionary<Goods, float> totalFlow = new Dictionary<Goods, float>();
-        [SkipSerialization] public HashSet<Goods> columnsExist { get; } = new HashSet<Goods>();
+        private readonly Dictionary<Goods, float> totalFlow = [];
+        [SkipSerialization] public HashSet<Goods> columnsExist { get; } = [];
 
         public override void InitNew() {
             columns.Add(new ProductionSummaryColumn(this, Database.electricity));
@@ -183,7 +183,7 @@ namespace YAFC.Model {
         }
 
         public override async Task<string> Solve(ProjectPage page) {
-            List<Task> taskList = new List<Task>();
+            List<Task> taskList = [];
             foreach (var element in group.elements) {
                 _ = element.CollectSolvingTasks(taskList);
             }

--- a/Yafc.Model/Model/ProductionSummary.cs
+++ b/Yafc.Model/Model/ProductionSummary.cs
@@ -6,8 +6,7 @@ using Yafc.UI;
 using YAFC.Model;
 
 namespace Yafc.Model {
-    public class ProductionSummaryGroup : ModelObject<ModelObject>, IElementGroup<ProductionSummaryEntry> {
-        public ProductionSummaryGroup(ModelObject owner) : base(owner) { }
+    public class ProductionSummaryGroup(ModelObject owner) : ModelObject<ModelObject>(owner), IElementGroup<ProductionSummaryEntry> {
         public List<ProductionSummaryEntry> elements { get; } = new List<ProductionSummaryEntry>();
         [NoUndo]
         public bool expanded { get; set; }
@@ -34,9 +33,7 @@ namespace Yafc.Model {
         }
     }
 
-    public class ProductionSummaryEntry : ModelObject<ProductionSummaryGroup>, IGroupedElement<ProductionSummaryGroup> {
-        public ProductionSummaryEntry(ProductionSummaryGroup owner) : base(owner) { }
-
+    public class ProductionSummaryEntry(ProductionSummaryGroup owner) : ModelObject<ProductionSummaryGroup>(owner), IGroupedElement<ProductionSummaryGroup> {
         protected internal override void AfterDeserialize() {
             // Must be either page reference, or subgroup, not both
             if (subgroup == null && page == null) {
@@ -159,11 +156,8 @@ namespace Yafc.Model {
         }
     }
 
-    public class ProductionSummaryColumn : ModelObject<ProductionSummary> {
-        public ProductionSummaryColumn(ProductionSummary owner, Goods goods) : base(owner) {
-            this.goods = goods ?? throw new ArgumentNullException(nameof(goods), "Object does not exist");
-        }
-        public Goods goods { get; }
+    public class ProductionSummaryColumn(ProductionSummary owner, Goods goods) : ModelObject<ProductionSummary>(owner) {
+        public Goods goods { get; } = goods ?? throw new ArgumentNullException(nameof(goods), "Object does not exist");
     }
 }
 

--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -14,13 +14,13 @@ namespace YAFC.Model {
     }
 
     public class ProductionTable : ProjectPageContents, IComparer<ProductionTableFlow>, IElementGroup<RecipeRow> {
-        [SkipSerialization] public Dictionary<Goods, ProductionLink> linkMap { get; } = new Dictionary<Goods, ProductionLink>();
+        [SkipSerialization] public Dictionary<Goods, ProductionLink> linkMap { get; } = [];
         List<RecipeRow> IElementGroup<RecipeRow>.elements => recipes;
         [NoUndo]
         public bool expanded { get; set; } = true;
-        public List<ProductionLink> links { get; } = new List<ProductionLink>();
-        public List<RecipeRow> recipes { get; } = new List<RecipeRow>();
-        public ProductionTableFlow[] flow { get; private set; } = Array.Empty<ProductionTableFlow>();
+        public List<ProductionLink> links { get; } = [];
+        public List<RecipeRow> recipes { get; } = [];
+        public ProductionTableFlow[] flow { get; private set; } = [];
         public ModuleFillerParameters modules { get; set; }
         public bool containsDesiredProducts { get; private set; }
 
@@ -76,7 +76,7 @@ namespace YAFC.Model {
             recipe.hierarchyEnabled = false;
             var subgroup = recipe.subgroup;
             if (subgroup != null) {
-                subgroup.flow = Array.Empty<ProductionTableFlow>();
+                subgroup.flow = [];
                 foreach (var link in subgroup.links) {
                     link.flags = 0;
                     link.linkFlow = 0;
@@ -160,7 +160,7 @@ match:
         }
 
         private void CalculateFlow(RecipeRow include) {
-            Dictionary<Goods, (double prod, double cons)> flowDict = new Dictionary<Goods, (double prod, double cons)>();
+            Dictionary<Goods, (double prod, double cons)> flowDict = [];
             if (include != null) {
                 AddFlow(include, flowDict);
             }
@@ -226,8 +226,8 @@ match:
             var solver = DataUtils.CreateSolver("ProductionTableSolver");
             var objective = solver.Objective();
             objective.SetMinimization();
-            List<RecipeRow> allRecipes = new List<RecipeRow>();
-            List<ProductionLink> allLinks = new List<ProductionLink>();
+            List<RecipeRow> allRecipes = [];
+            List<ProductionLink> allLinks = [];
             Setup(allRecipes, allLinks);
             Variable[] vars = new Variable[allRecipes.Count];
             float[] objCoefs = new float[allRecipes.Count];
@@ -362,7 +362,7 @@ match:
                 await Ui.EnterMainThread();
 
                 if (result is Solver.ResultStatus.OPTIMAL or Solver.ResultStatus.FEASIBLE) {
-                    List<ProductionLink> linkList = new List<ProductionLink>();
+                    List<ProductionLink> linkList = [];
                     for (int i = 0; i < allLinks.Count; i++) {
                         var (posSlack, negSlack) = slackVars[i];
                         if (posSlack != null && posSlack.BasisStatus() != Solver.BasisStatus.AT_LOWER_BOUND) {
@@ -495,9 +495,9 @@ match:
 
         private (List<ProductionLink> merges, List<ProductionLink> splits) GetInfeasibilityCandidates(List<RecipeRow> recipes) {
             Graph<ProductionLink> graph = new Graph<ProductionLink>();
-            List<ProductionLink> sources = new List<ProductionLink>();
-            List<ProductionLink> targets = new List<ProductionLink>();
-            List<ProductionLink> splits = new List<ProductionLink>();
+            List<ProductionLink> sources = [];
+            List<ProductionLink> targets = [];
+            List<ProductionLink> splits = [];
 
             foreach (var recipe in recipes) {
                 FindAllRecipeLinks(recipe, sources, targets);

--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -70,7 +70,7 @@ namespace YAFC.Model {
             }
         }
 
-        private void ClearDisabledRecipeContents(RecipeRow recipe) {
+        private static void ClearDisabledRecipeContents(RecipeRow recipe) {
             recipe.recipesPerSecond = 0;
             recipe.parameters.Clear();
             recipe.hierarchyEnabled = false;
@@ -130,7 +130,7 @@ match:
             return false;
         }
 
-        private void AddFlow(RecipeRow recipe, Dictionary<Goods, (double prod, double cons)> summer) {
+        private static void AddFlow(RecipeRow recipe, Dictionary<Goods, (double prod, double cons)> summer) {
             foreach (var product in recipe.recipe.products) {
                 _ = summer.TryGetValue(product.goods, out var prev);
                 double amount = recipe.recipesPerSecond * product.GetAmount(recipe.parameters.productivity);
@@ -469,7 +469,7 @@ match:
             return builtCountExceeded;
         }
 
-        private void FindAllRecipeLinks(RecipeRow recipe, List<ProductionLink> sources, List<ProductionLink> targets) {
+        private static void FindAllRecipeLinks(RecipeRow recipe, List<ProductionLink> sources, List<ProductionLink> targets) {
             sources.Clear();
             targets.Clear();
             foreach (var link in recipe.links.products) {
@@ -493,7 +493,7 @@ match:
             }
         }
 
-        private (List<ProductionLink> merges, List<ProductionLink> splits) GetInfeasibilityCandidates(List<RecipeRow> recipes) {
+        private static (List<ProductionLink> merges, List<ProductionLink> splits) GetInfeasibilityCandidates(List<RecipeRow> recipes) {
             Graph<ProductionLink> graph = new Graph<ProductionLink>();
             List<ProductionLink> sources = [];
             List<ProductionLink> targets = [];

--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -223,7 +223,7 @@ match:
         }
 
         public override async Task<string> Solve(ProjectPage page) {
-            var productionTableSolver = DataUtils.CreateSolver();
+            using var productionTableSolver = DataUtils.CreateSolver();
             var objective = productionTableSolver.Objective();
             objective.SetMinimization();
             List<RecipeRow> allRecipes = [];
@@ -410,7 +410,6 @@ match:
                     }
                 }
                 else {
-                    productionTableSolver.Dispose();
                     if (result == Solver.ResultStatus.INFEASIBLE) {
                         return "YAFC failed to solve the model and to find deadlock loops. As a result, the model was not updated.";
                     }
@@ -446,7 +445,6 @@ match:
             bool builtCountExceeded = CheckBuiltCountExceeded();
 
             CalculateFlow(null);
-            productionTableSolver.Dispose();
             return builtCountExceeded ? "This model requires more buildings than are currently built" : null;
         }
 

--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -7,16 +7,10 @@ using Yafc.Model;
 using Yafc.UI;
 
 namespace YAFC.Model {
-    public struct ProductionTableFlow {
-        public Goods goods;
-        public float amount;
-        public ProductionLink link;
-
-        public ProductionTableFlow(Goods goods, float amount, ProductionLink link) {
-            this.goods = goods;
-            this.amount = amount;
-            this.link = link;
-        }
+    public struct ProductionTableFlow(Goods goods, float amount, ProductionLink link) {
+        public Goods goods = goods;
+        public float amount = amount;
+        public ProductionLink link = link;
     }
 
     public class ProductionTable : ProjectPageContents, IComparer<ProductionTableFlow>, IElementGroup<RecipeRow> {

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -8,8 +8,8 @@ namespace Yafc.Model {
         public float speed;
         public float productivity;
         public float consumption;
-        public float speedMod => MathF.Max(1f + speed, 0.2f);
-        public float energyUsageMod => MathF.Max(1f + consumption, 0.2f);
+        public readonly float speedMod => MathF.Max(1f + speed, 0.2f);
+        public readonly float energyUsageMod => MathF.Max(1f + consumption, 0.2f);
         public void AddModules(ModuleSpecification module, float count, AllowedEffects allowedEffects) {
             if (allowedEffects.HasFlags(AllowedEffects.Speed)) {
                 speed += module.speed * count;
@@ -33,7 +33,7 @@ namespace Yafc.Model {
             consumption += module.consumption * count;
         }
 
-        public int GetModuleSoftLimit(ModuleSpecification module, int hardLimit) {
+        public readonly int GetModuleSoftLimit(ModuleSpecification module, int hardLimit) {
             if (module == null) {
                 return 0;
             }

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -67,8 +67,8 @@ namespace Yafc.Model {
     [Serializable]
     public class ModuleTemplate(ModelObject owner) : ModelObject<ModelObject>(owner) {
         public EntityBeacon beacon { get; set; }
-        public List<RecipeRowCustomModule> list { get; } = new List<RecipeRowCustomModule>();
-        public List<RecipeRowCustomModule> beaconList { get; } = new List<RecipeRowCustomModule>();
+        public List<RecipeRowCustomModule> list { get; } = [];
+        public List<RecipeRowCustomModule> beaconList { get; } = [];
 
         public bool IsCompatibleWith(RecipeRow row) {
             if (row.entity == null) {
@@ -97,7 +97,7 @@ namespace Yafc.Model {
         }
 
 
-        private static readonly List<(Item module, int count, bool beacon)> buffer = new List<(Item module, int count, bool beacon)>();
+        private static readonly List<(Item module, int count, bool beacon)> buffer = [];
         public void GetModulesInfo(RecipeParameters recipeParams, Recipe recipe, EntityCrafter entity, Goods fuel, ref ModuleEffects effects, ref RecipeParameters.UsedModule used, ModuleFillerParameters filler) {
             int beaconedModules = 0;
             Item nonBeacon = null;
@@ -136,7 +136,7 @@ namespace Yafc.Model {
                 filler?.AutoFillBeacons(recipeParams, recipe, entity, fuel, ref effects, ref used);
             }
 
-            used.modules = buffer.ToArray();
+            used.modules = [.. buffer];
         }
 
         public int CalcBeaconCount() {
@@ -215,7 +215,7 @@ namespace Yafc.Model {
         }
 
         public ProductionTable subgroup { get; set; }
-        public HashSet<FactorioObject> variants { get; } = new HashSet<FactorioObject>();
+        public HashSet<FactorioObject> variants { get; } = [];
         [SkipSerialization] public ProductionTable linkRoot => subgroup ?? owner;
 
         // Computed variables
@@ -357,7 +357,7 @@ namespace Yafc.Model {
         /// <summary>
         /// List of recipes belonging to this production link
         /// </summary>
-        [SkipSerialization] public List<RecipeRow> capturedRecipes { get; } = new List<RecipeRow>();
+        [SkipSerialization] public List<RecipeRow> capturedRecipes { get; } = [];
         internal int solverIndex;
         public float dualValue { get; internal set; }
     }

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -65,11 +65,10 @@ namespace Yafc.Model {
     }
 
     [Serializable]
-    public class ModuleTemplate : ModelObject<ModelObject> {
+    public class ModuleTemplate(ModelObject owner) : ModelObject<ModelObject>(owner) {
         public EntityBeacon beacon { get; set; }
         public List<RecipeRowCustomModule> list { get; } = new List<RecipeRowCustomModule>();
         public List<RecipeRowCustomModule> beaconList { get; } = new List<RecipeRowCustomModule>();
-        public ModuleTemplate(ModelObject owner) : base(owner) { }
 
         public bool IsCompatibleWith(RecipeRow row) {
             if (row.entity == null) {
@@ -330,7 +329,7 @@ namespace Yafc.Model {
     /// <summary>
     /// Link is goods whose production and consumption is attempted to be balanced by YAFC across the sheet.
     /// </summary>
-    public class ProductionLink : ModelObject<ProductionTable> {
+    public class ProductionLink(ProductionTable group, Goods goods) : ModelObject<ProductionTable>(group) {
         [Flags]
         public enum Flags {
             LinkNotMatched = 1 << 0,
@@ -344,7 +343,7 @@ namespace Yafc.Model {
             HasProductionAndConsumption = HasProduction | HasConsumption,
         }
 
-        public Goods goods { get; }
+        public Goods goods { get; } = goods ?? throw new ArgumentNullException(nameof(goods), "Linked product does not exist");
         public float amount { get; set; }
         public LinkAlgorithm algorithm { get; set; }
 
@@ -361,9 +360,5 @@ namespace Yafc.Model {
         [SkipSerialization] public List<RecipeRow> capturedRecipes { get; } = new List<RecipeRow>();
         internal int solverIndex;
         public float dualValue { get; internal set; }
-
-        public ProductionLink(ProductionTable group, Goods goods) : base(group) {
-            this.goods = goods ?? throw new ArgumentNullException(nameof(goods), "Linked product does not exist");
-        }
     }
 }

--- a/Yafc.Model/Model/Project.cs
+++ b/Yafc.Model/Model/Project.cs
@@ -154,7 +154,7 @@ namespace Yafc.Model {
         }
     }
 
-    public class ProjectSettings : ModelObject<Project> {
+    public class ProjectSettings(Project project) : ModelObject<Project>(project) {
         public List<FactorioObject> milestones { get; } = new List<FactorioObject>();
         public SortedList<FactorioObject, ProjectPerItemFlags> itemFlags { get; } = new SortedList<FactorioObject, ProjectPerItemFlags>(DataUtils.DeterministicComparer);
         public float miningProductivity { get; set; }
@@ -179,17 +179,15 @@ namespace Yafc.Model {
             return itemFlags.TryGetValue(obj, out var val) ? val : 0;
         }
 
-        public ProjectSettings(Project project) : base(project) { }
         public float GetReactorBonusMultiplier() {
             return 4f - (2f / reactorSizeX) - (2f / reactorSizeY);
         }
     }
 
-    public class ProjectPreferences : ModelObject<Project> {
+    public class ProjectPreferences(Project owner) : ModelObject<Project>(owner) {
         public int time { get; set; } = 1;
         public float itemUnit { get; set; }
         public float fluidUnit { get; set; }
-        public ProjectPreferences(Project owner) : base(owner) { }
         public EntityBelt defaultBelt { get; set; }
         public EntityInserter defaultInserter { get; set; }
         public int inserterCapacity { get; set; } = 1;

--- a/Yafc.Model/Model/Project.cs
+++ b/Yafc.Model/Model/Project.cs
@@ -15,11 +15,11 @@ namespace Yafc.Model {
         public ProjectSettings settings { get; }
         public ProjectPreferences preferences { get; }
 
-        public List<ProjectModuleTemplate> sharedModuleTemplates { get; } = new List<ProjectModuleTemplate>();
+        public List<ProjectModuleTemplate> sharedModuleTemplates { get; } = [];
         public string yafcVersion { get; set; }
-        public List<ProjectPage> pages { get; } = new List<ProjectPage>();
-        public List<Guid> displayPages { get; } = new List<Guid>();
-        private readonly Dictionary<Guid, ProjectPage> pagesByGuid = new Dictionary<Guid, ProjectPage>();
+        public List<ProjectPage> pages { get; } = [];
+        public List<Guid> displayPages { get; } = [];
+        private readonly Dictionary<Guid, ProjectPage> pagesByGuid = [];
         public int hiddenPages { get; private set; }
         public new UndoSystem undo => base.undo;
         private uint lastSavedVersion;
@@ -155,7 +155,7 @@ namespace Yafc.Model {
     }
 
     public class ProjectSettings(Project project) : ModelObject<Project>(project) {
-        public List<FactorioObject> milestones { get; } = new List<FactorioObject>();
+        public List<FactorioObject> milestones { get; } = [];
         public SortedList<FactorioObject, ProjectPerItemFlags> itemFlags { get; } = new SortedList<FactorioObject, ProjectPerItemFlags>(DataUtils.DeterministicComparer);
         public float miningProductivity { get; set; }
         public int reactorSizeX { get; set; } = 2;
@@ -191,8 +191,8 @@ namespace Yafc.Model {
         public EntityBelt defaultBelt { get; set; }
         public EntityInserter defaultInserter { get; set; }
         public int inserterCapacity { get; set; } = 1;
-        public HashSet<FactorioObject> sourceResources { get; } = new HashSet<FactorioObject>();
-        public HashSet<FactorioObject> favorites { get; } = new HashSet<FactorioObject>();
+        public HashSet<FactorioObject> sourceResources { get; } = [];
+        public HashSet<FactorioObject> favorites { get; } = [];
         /// <summary> Target technology for cost analysis - required item counts are estimated for researching this. If null, the is to research all finite technologies. </summary>
         public Technology targetTechnology { get; set; }
 

--- a/Yafc.Model/Model/ProjectModuleTemplate.cs
+++ b/Yafc.Model/Model/ProjectModuleTemplate.cs
@@ -9,6 +9,6 @@ namespace Yafc.Model {
         public ModuleTemplate template { get; }
         public FactorioObject icon { get; set; }
         public string name { get; set; }
-        public List<Entity> filterEntities { get; } = new List<Entity>();
+        public List<Entity> filterEntities { get; } = [];
     }
 }

--- a/Yafc.Model/Model/ProjectPage.cs
+++ b/Yafc.Model/Model/ProjectPage.cs
@@ -105,8 +105,7 @@ namespace Yafc.Model {
         }
     }
 
-    public abstract class ProjectPageContents : ModelObject<ModelObject> {
-        protected ProjectPageContents(ModelObject page) : base(page) { }
+    public abstract class ProjectPageContents(ModelObject page) : ModelObject<ModelObject>(page) {
         public virtual void InitNew() { }
         public abstract Task<string> Solve(ProjectPage page);
 

--- a/Yafc.Model/Model/SolverHelper.cs
+++ b/Yafc.Model/Model/SolverHelper.cs
@@ -3,12 +3,12 @@ using Google.OrTools.LinearSolver;
 
 namespace Yafc.Model {
     public class SolverHelper<TVariable, TConstraint>(bool maximize) {
-        private readonly Dictionary<(TVariable var, TConstraint constr), float> values = new Dictionary<(TVariable, TConstraint), float>();
-        private readonly List<(TVariable var, float min, float max, float coef)> variables = new List<(TVariable var, float min, float max, float coef)>();
-        private readonly List<(TConstraint constr, float min, float max)> constraints = new List<(TConstraint constr, float min, float max)>();
+        private readonly Dictionary<(TVariable var, TConstraint constr), float> values = [];
+        private readonly List<(TVariable var, float min, float max, float coef)> variables = [];
+        private readonly List<(TConstraint constr, float min, float max)> constraints = [];
         private readonly bool maximize = maximize;
 
-        private readonly Dictionary<TVariable, float> results = new Dictionary<TVariable, float>();
+        private readonly Dictionary<TVariable, float> results = [];
 
         public float this[TVariable var, TConstraint constr] {
             get => values.TryGetValue((var, constr), out float val) ? val : 0;

--- a/Yafc.Model/Model/SolverHelper.cs
+++ b/Yafc.Model/Model/SolverHelper.cs
@@ -2,17 +2,13 @@
 using Google.OrTools.LinearSolver;
 
 namespace Yafc.Model {
-    public class SolverHelper<TVariable, TConstraint> {
+    public class SolverHelper<TVariable, TConstraint>(bool maximize) {
         private readonly Dictionary<(TVariable var, TConstraint constr), float> values = new Dictionary<(TVariable, TConstraint), float>();
         private readonly List<(TVariable var, float min, float max, float coef)> variables = new List<(TVariable var, float min, float max, float coef)>();
         private readonly List<(TConstraint constr, float min, float max)> constraints = new List<(TConstraint constr, float min, float max)>();
-        private readonly bool maximize;
+        private readonly bool maximize = maximize;
 
         private readonly Dictionary<TVariable, float> results = new Dictionary<TVariable, float>();
-
-        public SolverHelper(bool maximize) {
-            this.maximize = maximize;
-        }
 
         public float this[TVariable var, TConstraint constr] {
             get => values.TryGetValue((var, constr), out float val) ? val : 0;

--- a/Yafc.Model/Model/SolverHelper.cs
+++ b/Yafc.Model/Model/SolverHelper.cs
@@ -31,8 +31,8 @@ namespace Yafc.Model {
             constraints.Clear();
         }
 
-        public Solver.ResultStatus Solve(string name) {
-            var solver = DataUtils.CreateSolver(name);
+        public Solver.ResultStatus Solve() {
+            var solver = DataUtils.CreateSolver();
             results.Clear();
             Dictionary<TVariable, Variable> realMapVars = new Dictionary<TVariable, Variable>(variables.Count);
             Dictionary<TConstraint, Constraint> realMapConstrs = new Dictionary<TConstraint, Constraint>(constraints.Count);

--- a/Yafc.Model/Serialization/ErrorCollector.cs
+++ b/Yafc.Model/Serialization/ErrorCollector.cs
@@ -18,7 +18,7 @@ namespace Yafc.Model {
         public ErrorSeverity severity { get; private set; }
         public void Error(string message, ErrorSeverity severity) {
             var key = (message, severity);
-            allErrors ??= new Dictionary<(string, ErrorSeverity), int>();
+            allErrors ??= [];
             if (severity > this.severity) {
                 this.severity = severity;
             }

--- a/Yafc.Model/Serialization/ModelObject.cs
+++ b/Yafc.Model/Serialization/ModelObject.cs
@@ -69,16 +69,12 @@ namespace Yafc.Model {
         protected virtual void ReadExtraUndoInformation(UndoSnapshotReader reader) { }
         public bool justChanged => undo.HasChangesPending(this);
     }
-    public abstract class ModelObject<TOwner> : ModelObject where TOwner : ModelObject {
-        [SkipSerialization] public TOwner owner { get; protected set; }
+    public abstract class ModelObject<TOwner>(TOwner owner) : ModelObject(owner?.undo) where TOwner : ModelObject {
+        [SkipSerialization] public TOwner owner { get; protected set; } = owner ?? throw new ArgumentNullException(nameof(owner));
 
         public override ModelObject ownerObject {
             get => owner;
             internal set => owner = (TOwner)value;
-        }
-
-        protected ModelObject(TOwner owner) : base(owner?.undo) {
-            this.owner = owner ?? throw new ArgumentNullException(nameof(owner));
         }
     }
 }

--- a/Yafc.Model/Serialization/SerializationMap.cs
+++ b/Yafc.Model/Serialization/SerializationMap.cs
@@ -27,7 +27,7 @@ namespace Yafc.Model {
         public abstract void ReadUndo(object target, UndoSnapshotReader reader);
 
 
-        private static readonly Dictionary<Type, SerializationMap> undoBuilders = new Dictionary<Type, SerializationMap>();
+        private static readonly Dictionary<Type, SerializationMap> undoBuilders = [];
 
         public static SerializationMap GetSerializationMap(Type type) {
             if (undoBuilders.TryGetValue(type, out var builder)) {
@@ -107,13 +107,13 @@ namespace Yafc.Model {
         }
 
         static SerializationMap() {
-            List<PropertySerializer<T>> list = new List<PropertySerializer<T>>();
+            List<PropertySerializer<T>> list = [];
 
             bool isModel = typeof(ModelObject).IsAssignableFrom(typeof(T));
 
             constructor = typeof(T).GetConstructors(BindingFlags.Public | BindingFlags.Instance)[0];
             var constructorParameters = constructor.GetParameters();
-            List<PropertyInfo> processedProperties = new List<PropertyInfo>();
+            List<PropertyInfo> processedProperties = [];
             if (constructorParameters.Length > 0) {
                 int firstReadOnlyArg = 0;
                 if (isModel) {
@@ -325,7 +325,7 @@ namespace Yafc.Model {
     }
 
     public class DeserializationContext {
-        private readonly List<ModelObject> allObjects = new List<ModelObject>();
+        private readonly List<ModelObject> allObjects = [];
         private readonly ErrorCollector collector;
 
         public DeserializationContext(ErrorCollector errorCollector) {

--- a/Yafc.Model/Serialization/UndoSystem.cs
+++ b/Yafc.Model/Serialization/UndoSystem.cs
@@ -8,8 +8,8 @@ namespace Yafc.Model {
     public class UndoSystem {
         public uint version { get; private set; } = 2;
         private bool undoBatchVisualOnly = true;
-        private readonly List<UndoSnapshot> currentUndoBatch = new List<UndoSnapshot>();
-        private readonly List<ModelObject> changedList = new List<ModelObject>();
+        private readonly List<UndoSnapshot> currentUndoBatch = [];
+        private readonly List<ModelObject> changedList = [];
         private readonly Stack<UndoBatch> undo = new Stack<UndoBatch>();
         private readonly Stack<UndoBatch> redo = new Stack<UndoBatch>();
         private bool suspended;
@@ -151,7 +151,7 @@ namespace Yafc.Model {
 
     public class UndoSnapshotBuilder {
         private readonly MemoryStream stream = new MemoryStream();
-        private readonly List<object> managedRefs = new List<object>();
+        private readonly List<object> managedRefs = [];
         public readonly BinaryWriter writer;
         private ModelObject currentTarget;
 

--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -76,7 +76,11 @@ namespace Yafc.Parser {
 
         private void AddTemperatureToFluidIcon(Fluid fluid) {
             string iconStr = fluid.temperature + "d";
-            fluid.iconSpec = fluid.iconSpec.Concat(iconStr.Take(4).Select((x, n) => new FactorioIconPart { path = "__.__/" + x, y = -16, x = (n * 7) - 12, scale = 0.28f })).ToArray();
+            fluid.iconSpec =
+            [
+                .. fluid.iconSpec,
+                .. iconStr.Take(4).Select((x, n) => new FactorioIconPart { path = "__.__/" + x, y = -16, x = (n * 7) - 12, scale = 0.28f }),
+            ];
         }
 
         public Project LoadData(string projectPath, LuaTable data, LuaTable prototypes, IProgress<(string, string)> progress, ErrorCollector errorCollector, bool renderIcons) {
@@ -86,7 +90,7 @@ namespace Yafc.Parser {
                 DeserializePrototypes(raw, (string)prototypeName, DeserializeItem, progress);
             }
 
-            Item[] universalModulesArray = universalModules.ToArray();
+            Item[] universalModulesArray = [.. universalModules];
             IEnumerable<Item> FilteredModules(Recipe item) {
                 // When the blacklist is available, filter out modules that are in this blacklist
                 Func<Item, bool> AllowedModulesFilter(Recipe key) {

--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -74,7 +74,7 @@ namespace Yafc.Parser {
             }
         }
 
-        private void AddTemperatureToFluidIcon(Fluid fluid) {
+        private static void AddTemperatureToFluidIcon(Fluid fluid) {
             string iconStr = fluid.temperature + "d";
             fluid.iconSpec =
             [
@@ -262,7 +262,7 @@ namespace Yafc.Parser {
             return IconCollection.AddIcon(targetSurface);
         }
 
-        private void DeserializePrototypes(LuaTable data, string type, Action<LuaTable> deserializer, IProgress<(string, string)> progress) {
+        private static void DeserializePrototypes(LuaTable data, string type, Action<LuaTable> deserializer, IProgress<(string, string)> progress) {
             object table = data[type];
             progress.Report(("Building objects", type));
             if (table is not LuaTable luaTable) {
@@ -276,7 +276,7 @@ namespace Yafc.Parser {
             }
         }
 
-        private float ParseEnergy(string energy) {
+        private static float ParseEnergy(string energy) {
             int len = energy.Length - 2;
             if (len < 0f) {
                 return 0f;

--- a/Yafc.Parser/FactorioDataSource.cs
+++ b/Yafc.Parser/FactorioDataSource.cs
@@ -9,9 +9,8 @@ using Yafc.Model;
 
 namespace Yafc.Parser {
     public static partial class FactorioDataSource {
-        /*
-         * If you're wondering why this class is partial, 
-         * please check the implementation comment of ModInfo.
+        /* If you're wondering why this class is partial, 
+         * please check the implementation comment of ModInfo. 
          */
 
         internal static Dictionary<string, ModInfo> allMods = [];

--- a/Yafc.Parser/FactorioDataSource.cs
+++ b/Yafc.Parser/FactorioDataSource.cs
@@ -322,7 +322,7 @@ namespace Yafc.Parser {
             public Version parsedFactorioVersion { get; set; }
             public string[] dependencies { get; set; } = defaultDependencies;
             private (string mod, bool optional)[] parsedDependencies;
-            private string[] incompatibilities = Array.Empty<string>();
+            private string[] incompatibilities = [];
 
             public ZipArchive zipArchive;
             public string folder;

--- a/Yafc.Parser/FactorioDataSource.cs
+++ b/Yafc.Parser/FactorioDataSource.cs
@@ -30,7 +30,10 @@ namespace Yafc.Parser {
 
         private static readonly char[] fileSplittersLua = ['.', '/', '\\'];
         private static readonly char[] fileSplittersNormal = ['/', '\\'];
+#pragma warning disable CA2211 // Non-constant fields should not be visible.
+        // Suppressed because the only place where it's read is when there is an exception.
         public static string currentLoadingMod;
+#pragma warning restore CA2211 // Non-constant fields should not be visible
 
         public static (string mod, string path) ResolveModPath(string currentMod, string fullPath, bool isLuaRequire = false) {
             string mod = currentMod;

--- a/Yafc.Parser/FactorioDataSource.cs
+++ b/Yafc.Parser/FactorioDataSource.cs
@@ -218,7 +218,7 @@ namespace Yafc.Parser {
                 while (modsToLoad.Count > 0) {
                     currentLoadBatch.Clear();
                     foreach (string mod in sortedMods) {
-                        if (allMods[mod].CanLoad(allMods, modsToLoad)) {
+                        if (allMods[mod].CanLoad(modsToLoad)) {
                             currentLoadBatch.Add(mod);
                         }
                     }
@@ -388,7 +388,7 @@ namespace Yafc.Parser {
                 return true;
             }
 
-            public bool CanLoad(Dictionary<string, ModInfo> mods, HashSet<string> notLoadedMods) {
+            public bool CanLoad(HashSet<string> notLoadedMods) {
                 foreach (var (mod, _) in parsedDependencies) {
                     if (notLoadedMods.Contains(mod)) {
                         return false;

--- a/Yafc.Parser/FactorioDataSource.cs
+++ b/Yafc.Parser/FactorioDataSource.cs
@@ -207,12 +207,12 @@ namespace Yafc.Parser {
                 currentLoadingMod = null;
                 progress.Report(("Initializing", "Creating Lua context"));
 
-                HashSet<string> modsToLoad = allMods.Keys.ToHashSet();
+                HashSet<string> modsToLoad = [.. allMods.Keys];
                 string[] modLoadOrder = new string[modsToLoad.Count];
                 modLoadOrder[0] = "core";
                 _ = modsToLoad.Remove("core");
                 int index = 1;
-                List<string> sortedMods = modsToLoad.ToList();
+                List<string> sortedMods = [.. modsToLoad];
                 sortedMods.Sort((a, b) => string.Compare(a, b, StringComparison.OrdinalIgnoreCase));
                 List<string> currentLoadBatch = [];
                 while (modsToLoad.Count > 0) {
@@ -357,9 +357,9 @@ namespace Yafc.Parser {
                     }
                 }
 
-                parsedDependencies = dependencyList.ToArray();
+                parsedDependencies = [.. dependencyList];
                 if (incompatibilities != null) {
-                    this.incompatibilities = incompatibilities.ToArray();
+                    this.incompatibilities = [.. incompatibilities];
                 }
             }
 

--- a/Yafc.Parser/FactorioDataSource.cs
+++ b/Yafc.Parser/FactorioDataSource.cs
@@ -388,9 +388,9 @@ namespace Yafc.Parser {
                 return true;
             }
 
-            public bool CanLoad(Dictionary<string, ModInfo> mods, HashSet<string> nonLoadedMods) {
+            public bool CanLoad(Dictionary<string, ModInfo> mods, HashSet<string> notLoadedMods) {
                 foreach (var (mod, _) in parsedDependencies) {
-                    if (nonLoadedMods.Contains(mod)) {
+                    if (notLoadedMods.Contains(mod)) {
                         return false;
                     }
                 }

--- a/Yafc.Parser/LuaContext.cs
+++ b/Yafc.Parser/LuaContext.cs
@@ -164,7 +164,7 @@ namespace Yafc.Parser {
             }
         }
 
-        private int ParseTracebackEntry(string s, out int endOfName) {
+        private static int ParseTracebackEntry(string s, out int endOfName) {
             endOfName = 0;
             if (s.StartsWith("[string \"", StringComparison.Ordinal)) {
                 int endOfNum = s.IndexOf(' ', 9);
@@ -334,7 +334,7 @@ namespace Yafc.Parser {
             Pop(2);
         }
 
-        private string GetDirectoryName(string s) {
+        private static string GetDirectoryName(string s) {
             int lastSlash = s.LastIndexOf('/');
             return lastSlash >= 0 ? s[..(lastSlash + 1)] : "";
         }

--- a/Yafc.Parser/LuaContext.cs
+++ b/Yafc.Parser/LuaContext.cs
@@ -181,7 +181,7 @@ namespace Yafc.Parser {
             string message = GetString(1);
             luaL_traceback(L, L, message, 0);
             string actualTraceback = GetString(-1);
-            string[] split = actualTraceback.Split("\n\t").ToArray();
+            string[] split = [.. actualTraceback.Split("\n\t")];
             for (int i = 0; i < split.Length; i++) {
                 int chunkId = ParseTracebackEntry(split[i], out int endOfName);
                 if (chunkId >= 0) {

--- a/Yafc.Parser/LuaContext.cs
+++ b/Yafc.Parser/LuaContext.cs
@@ -7,8 +7,7 @@ using System.Text;
 using Yafc.Model;
 
 namespace Yafc.Parser {
-    public class LuaException : Exception {
-        public LuaException(string luaMessage) : base(luaMessage) { }
+    public class LuaException(string luaMessage) : Exception(luaMessage) {
     }
     internal partial class LuaContext : IDisposable {
         private enum Result {

--- a/Yafc.UI/Core/DrawingSurface.cs
+++ b/Yafc.UI/Core/DrawingSurface.cs
@@ -3,10 +3,10 @@ using System.Numerics;
 using SDL2;
 
 namespace Yafc.UI {
-    public readonly struct TextureHandle {
-        public readonly IntPtr handle;
-        public readonly DrawingSurface surface;
-        public readonly int version;
+    public readonly struct TextureHandle(DrawingSurface surface, IntPtr handle) {
+        public readonly IntPtr handle = handle;
+        public readonly DrawingSurface surface = surface;
+        public readonly int version = surface.rendererVersion;
         public bool valid => surface != null && surface.rendererVersion == version;
 
         public TextureHandle Destroy() {
@@ -16,15 +16,9 @@ namespace Yafc.UI {
 
             return default;
         }
-
-        public TextureHandle(DrawingSurface surface, IntPtr handle) {
-            this.handle = handle;
-            this.surface = surface;
-            version = surface.rendererVersion;
-        }
     }
 
-    public abstract class DrawingSurface : IDisposable {
+    public abstract class DrawingSurface(float pixelsPerUnit) : IDisposable {
         private IntPtr rendererHandle;
 
         public IntPtr renderer {
@@ -37,11 +31,7 @@ namespace Yafc.UI {
 
         public int rendererVersion { get; private set; }
 
-        public float pixelsPerUnit { get; set; }
-
-        protected DrawingSurface(float pixelsPerUnit) {
-            this.pixelsPerUnit = pixelsPerUnit;
-        }
+        public float pixelsPerUnit { get; set; } = pixelsPerUnit;
 
         internal static RenderingUtils.BlitMapping[] blitMapping;
 
@@ -120,12 +110,8 @@ namespace Yafc.UI {
         }
     }
 
-    public abstract class SoftwareDrawingSurface : DrawingSurface {
-        public IntPtr surface { get; protected set; }
-
-        protected SoftwareDrawingSurface(IntPtr surface, float pixelsPerUnit) : base(pixelsPerUnit) {
-            this.surface = surface;
-        }
+    public abstract class SoftwareDrawingSurface(IntPtr surface, float pixelsPerUnit) : DrawingSurface(pixelsPerUnit) {
+        public IntPtr surface { get; protected set; } = surface;
 
         public override SDL.SDL_Rect SetClip(SDL.SDL_Rect clip) {
             _ = SDL.SDL_SetClipRect(surface, ref clip);

--- a/Yafc.UI/Core/DrawingSurface.cs
+++ b/Yafc.UI/Core/DrawingSurface.cs
@@ -51,9 +51,7 @@ namespace Yafc.UI {
             return new TextureHandle(this, texture);
         }
 
-        public void EndRenderToTexture() {
-            _ = SDL.SDL_SetRenderTarget(renderer, IntPtr.Zero);
-        }
+        public void EndRenderToTexture() => _ = SDL.SDL_SetRenderTarget(renderer, IntPtr.Zero);
 
         public virtual SDL.SDL_Rect SetClip(SDL.SDL_Rect clip) {
             var prev = clipRect;
@@ -62,9 +60,7 @@ namespace Yafc.UI {
             return prev;
         }
 
-        public virtual void Present() {
-            SDL.SDL_RenderPresent(renderer);
-        }
+        public virtual void Present() => SDL.SDL_RenderPresent(renderer);
 
         public void Clear(SDL.SDL_Rect clipRect) {
             this.clipRect = clipRect;
@@ -75,9 +71,7 @@ namespace Yafc.UI {
             _ = SDL.SDL_RenderClear(renderer);
         }
 
-        public TextureHandle CreateTextureFromSurface(IntPtr surface) {
-            return new TextureHandle(this, SDL.SDL_CreateTextureFromSurface(renderer, surface));
-        }
+        public TextureHandle CreateTextureFromSurface(IntPtr surface) => new TextureHandle(this, SDL.SDL_CreateTextureFromSurface(renderer, surface));
 
         public TextureHandle CreateTexture(uint format, int access, int w, int h) {
             return new TextureHandle(this, SDL.SDL_CreateTexture(renderer, format, access, w, h));
@@ -169,8 +163,6 @@ namespace Yafc.UI {
 
         public override Window window => null;
 
-        public void SavePng(string filename) {
-            _ = SDL_image.IMG_SavePNG(surface, filename);
-        }
+        public void SavePng(string filename) => _ = SDL_image.IMG_SavePNG(surface, filename);
     }
 }

--- a/Yafc.UI/Core/IconCollection.cs
+++ b/Yafc.UI/Core/IconCollection.cs
@@ -7,7 +7,7 @@ namespace Yafc.UI {
         public const int IconSize = 32;
         public static SDL.SDL_Rect IconRect = new SDL.SDL_Rect { w = IconSize, h = IconSize };
 
-        private static readonly List<IntPtr> icons = new List<IntPtr>();
+        private static readonly List<IntPtr> icons = [];
 
         static IconCollection() {
             icons.Add(IntPtr.Zero);

--- a/Yafc.UI/Core/IconCollection.cs
+++ b/Yafc.UI/Core/IconCollection.cs
@@ -41,9 +41,7 @@ namespace Yafc.UI {
             return id;
         }
 
-        public static IntPtr GetIconSurface(Icon icon) {
-            return icons[(int)icon];
-        }
+        public static IntPtr GetIconSurface(Icon icon) => icons[(int)icon];
 
         public static void ClearCustomIcons() {
             int firstCustomIconId = (int)Icon.FirstCustom;

--- a/Yafc.UI/Core/InputSystem.cs
+++ b/Yafc.UI/Core/InputSystem.cs
@@ -31,7 +31,7 @@ namespace Yafc.UI {
         public int mouseDownButton { get; private set; } = -1;
 
         public IKeyboardFocus currentKeyboardFocus => activeKeyboardFocus ?? defaultKeyboardFocus;
-        private readonly List<(SendOrPostCallback, object)> mouseUpCallbacks = new List<(SendOrPostCallback, object)>();
+        private readonly List<(SendOrPostCallback, object)> mouseUpCallbacks = [];
 
         public Vector2 mouseDownPosition { get; private set; }
         public Vector2 mousePosition { get; private set; }

--- a/Yafc.UI/Core/InputSystem.cs
+++ b/Yafc.UI/Core/InputSystem.cs
@@ -66,9 +66,7 @@ namespace Yafc.UI {
             activeMouseFocus?.FocusChanged(true);
         }
 
-        public void SetDefaultKeyboardFocus(IKeyboardFocus focus) {
-            defaultKeyboardFocus = focus;
-        }
+        public void SetDefaultKeyboardFocus(IKeyboardFocus focus) => defaultKeyboardFocus = focus;
 
         public bool control => (keyMod & SDL.SDL_Keymod.KMOD_CTRL) != 0;
         public bool shift => (keyMod & SDL.SDL_Keymod.KMOD_SHIFT) != 0;
@@ -93,9 +91,7 @@ namespace Yafc.UI {
             }
         }
 
-        internal void MouseScroll(int delta) {
-            HitTest()?.MouseScroll(delta);
-        }
+        internal void MouseScroll(int delta) => HitTest()?.MouseScroll(delta);
 
         internal void MouseMove(int rawX, int rawY) {
             if (mouseOverWindow == null || mouseOverWindow.closed) {
@@ -119,13 +115,9 @@ namespace Yafc.UI {
             }
         }
 
-        internal void MouseEnterWindow(Window window) {
-            mouseOverWindow = window;
-        }
+        internal void MouseEnterWindow(Window window) => mouseOverWindow = window;
 
-        public IPanel HitTest() {
-            return mouseOverWindow == null || mouseOverWindow.closed ? null : mouseOverWindow.HitTest(mousePosition);
-        }
+        public IPanel HitTest() => mouseOverWindow == null || mouseOverWindow.closed ? null : mouseOverWindow.HitTest(mousePosition);
 
         internal void Update() {
             var currentHovering = HitTest();

--- a/Yafc.UI/Core/MathUtils.cs
+++ b/Yafc.UI/Core/MathUtils.cs
@@ -26,17 +26,11 @@ namespace Yafc.UI {
             return value;
         }
 
-        public static int Round(float value) {
-            return (int)MathF.Round(value);
-        }
+        public static int Round(float value) => (int)MathF.Round(value);
 
-        public static int Floor(float value) {
-            return (int)MathF.Floor(value);
-        }
+        public static int Floor(float value) => (int)MathF.Floor(value);
 
-        public static int Ceil(float value) {
-            return (int)MathF.Ceiling(value);
-        }
+        public static int Ceil(float value) => (int)MathF.Ceiling(value);
 
         public static byte FloatToByte(float f) {
             if (f <= 0) {

--- a/Yafc.UI/Core/Rect.cs
+++ b/Yafc.UI/Core/Rect.cs
@@ -111,25 +111,15 @@ namespace Yafc.UI {
             }
         }
 
-        public static Rect operator +(in Rect source, Vector2 offset) {
-            return new Rect(source.Position + offset, source.Size);
-        }
+        public static Rect operator +(in Rect source, Vector2 offset) => new Rect(source.Position + offset, source.Size);
 
-        public static Rect operator -(in Rect source, Vector2 offset) {
-            return new Rect(source.Position - offset, source.Size);
-        }
+        public static Rect operator -(in Rect source, Vector2 offset) => new Rect(source.Position - offset, source.Size);
 
-        public static Rect operator *(in Rect source, float multiplier) {
-            return new Rect(source.Position * multiplier, source.Size * multiplier);
-        }
+        public static Rect operator *(in Rect source, float multiplier) => new Rect(source.Position * multiplier, source.Size * multiplier);
 
-        public static bool operator ==(in Rect a, in Rect b) {
-            return a.X == b.X && a.Y == b.Y && a.Width == b.Width && a.Height == b.Height;
-        }
+        public static bool operator ==(in Rect a, in Rect b) => a.X == b.X && a.Y == b.Y && a.Width == b.Width && a.Height == b.Height;
 
-        public static bool operator !=(in Rect a, in Rect b) {
-            return !(a == b);
-        }
+        public static bool operator !=(in Rect a, in Rect b) => !(a == b);
 
         public override string ToString() => "(" + X + "-" + Right + ")-(" + Y + "-" + Bottom + ")";
 

--- a/Yafc.UI/Core/Rect.cs
+++ b/Yafc.UI/Core/Rect.cs
@@ -43,17 +43,11 @@ namespace Yafc.UI {
             Height = height;
         }
 
-        public static Rect SideRect(float left, float right, float top, float bottom) {
-            return new Rect(left, top, right - left, bottom - top);
-        }
+        public static Rect SideRect(float left, float right, float top, float bottom) => new Rect(left, top, right - left, bottom - top);
 
-        public static Rect SideRect(Vector2 topLeft, Vector2 bottomRight) {
-            return SideRect(topLeft.X, bottomRight.X, topLeft.Y, bottomRight.Y);
-        }
+        public static Rect SideRect(Vector2 topLeft, Vector2 bottomRight) => SideRect(topLeft.X, bottomRight.X, topLeft.Y, bottomRight.Y);
 
-        public static Rect Union(Rect a, Rect b) {
-            return SideRect(MathF.Min(a.X, a.X), MathF.Max(a.Right, b.Right), MathF.Min(a.Y, b.Y), MathF.Max(a.Bottom, b.Bottom));
-        }
+        public static Rect Union(Rect a, Rect b) => SideRect(MathF.Min(a.X, a.X), MathF.Max(a.Right, b.Right), MathF.Min(a.Y, b.Y), MathF.Max(a.Bottom, b.Bottom));
 
         public Vector2 Size {
             get => new Vector2(Width, Height);
@@ -71,13 +65,9 @@ namespace Yafc.UI {
             }
         }
 
-        public readonly Rect RightPart(float width) {
-            return new Rect(Right - width, Y, width, Height);
-        }
+        public readonly Rect RightPart(float width) => new Rect(Right - width, Y, width, Height);
 
-        public readonly Rect LeftPart(float width) {
-            return new Rect(X, Y, width, Height);
-        }
+        public readonly Rect LeftPart(float width) => new Rect(X, Y, width, Height);
 
         public Vector2 TopLeft => new Vector2(X, Y);
         public Vector2 TopRight => new Vector2(Right, Y);
@@ -85,17 +75,11 @@ namespace Yafc.UI {
         public Vector2 BottomLeft => new Vector2(X, Bottom);
         public Vector2 Center => new Vector2(X + (Width * 0.5f), Y + (Height * 0.5f));
 
-        public readonly bool Contains(Vector2 position) {
-            return position.X >= X && position.Y >= Y && position.X <= Right && position.Y <= Bottom;
-        }
+        public readonly bool Contains(Vector2 position) => position.X >= X && position.Y >= Y && position.X <= Right && position.Y <= Bottom;
 
-        public readonly bool IntersectsWith(Rect other) {
-            return X < other.Right && Right > other.X && Y < other.Bottom && Bottom > other.Y;
-        }
+        public readonly bool IntersectsWith(Rect other) => X < other.Right && Right > other.X && Y < other.Bottom && Bottom > other.Y;
 
-        public readonly bool Contains(Rect rect) {
-            return X <= rect.X && Y <= rect.Y && Right >= rect.Right && Bottom >= rect.Bottom;
-        }
+        public readonly bool Contains(Rect rect) => X <= rect.X && Y <= rect.Y && Right >= rect.Right && Bottom >= rect.Bottom;
 
         public static Rect Intersect(Rect a, Rect b) {
             float left = MathF.Max(a.X, b.X);
@@ -113,13 +97,9 @@ namespace Yafc.UI {
             return SideRect(left, right, top, bottom);
         }
 
-        public readonly bool Equals(Rect other) {
-            return this == other;
-        }
+        public readonly bool Equals(Rect other) => this == other;
 
-        public override bool Equals(object obj) {
-            return obj is Rect other && Equals(other);
-        }
+        public override bool Equals(object obj) => obj is Rect other && Equals(other);
 
         public override int GetHashCode() {
             unchecked {
@@ -151,16 +131,10 @@ namespace Yafc.UI {
             return !(a == b);
         }
 
-        public override string ToString() {
-            return "(" + X + "-" + Right + ")-(" + Y + "-" + Bottom + ")";
-        }
+        public override string ToString() => "(" + X + "-" + Right + ")-(" + Y + "-" + Bottom + ")";
 
-        public readonly Rect Expand(float amount) {
-            return new Rect(X - amount, Y - amount, Width + (2 * amount), Height + (2 * amount));
-        }
+        public readonly Rect Expand(float amount) => new Rect(X - amount, Y - amount, Width + (2 * amount), Height + (2 * amount));
 
-        public static Rect Square(Vector2 center, float side) {
-            return new Rect(center.X - (side * 0.5f), center.Y - (side * 0.5f), side, side);
-        }
+        public static Rect Square(Vector2 center, float side) => new Rect(center.X - (side * 0.5f), center.Y - (side * 0.5f), side, side);
     }
 }

--- a/Yafc.UI/Core/SearchQuery.cs
+++ b/Yafc.UI/Core/SearchQuery.cs
@@ -1,15 +1,10 @@
 ﻿using System;
 
 namespace Yafc.UI {
-    public readonly struct SearchQuery {
-        public readonly string query;
-        public readonly string[] tokens;
+    public readonly struct SearchQuery(string query) {
+        public readonly string query = query;
+        public readonly string[] tokens = string.IsNullOrWhiteSpace(query) ? [] : query.Split(' ', StringSplitOptions.RemoveEmptyEntries);
         public readonly bool empty => tokens == null || tokens.Length == 0;
-
-        public SearchQuery(string query) {
-            this.query = query;
-            tokens = string.IsNullOrWhiteSpace(query) ? [] : query.Split(' ', StringSplitOptions.RemoveEmptyEntries);
-        }
 
         public bool Match(string text) {
             if (empty) {

--- a/Yafc.UI/Core/SearchQuery.cs
+++ b/Yafc.UI/Core/SearchQuery.cs
@@ -8,7 +8,7 @@ namespace Yafc.UI {
 
         public SearchQuery(string query) {
             this.query = query;
-            tokens = string.IsNullOrWhiteSpace(query) ? Array.Empty<string>() : query.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            tokens = string.IsNullOrWhiteSpace(query) ? [] : query.Split(' ', StringSplitOptions.RemoveEmptyEntries);
         }
 
         public bool Match(string text) {

--- a/Yafc.UI/Core/Structs.cs
+++ b/Yafc.UI/Core/Structs.cs
@@ -122,9 +122,7 @@
     public readonly struct Padding {
         public readonly float left, right, top, bottom;
 
-        public Padding(float allOffsets) {
-            top = bottom = left = right = allOffsets;
-        }
+        public Padding(float allOffsets) => top = bottom = left = right = allOffsets;
 
         public Padding(float leftRight, float topBottom) {
             left = right = leftRight;

--- a/Yafc.UI/Core/TaskWindow.cs
+++ b/Yafc.UI/Core/TaskWindow.cs
@@ -9,9 +9,7 @@ namespace Yafc.UI {
             tcs = new TaskCompletionSource<T>();
         }
 
-        public TaskAwaiter<T> GetAwaiter() {
-            return tcs.Task.GetAwaiter();
-        }
+        public TaskAwaiter<T> GetAwaiter() => tcs.Task.GetAwaiter();
 
         protected void CloseWithResult(T result) {
             _ = (tcs?.TrySetResult(result));

--- a/Yafc.UI/Core/TaskWindow.cs
+++ b/Yafc.UI/Core/TaskWindow.cs
@@ -5,9 +5,7 @@ namespace Yafc.UI {
     public abstract class TaskWindow<T> : WindowUtility {
         private TaskCompletionSource<T> tcs;
 
-        protected TaskWindow() : base(new Padding(1f)) {
-            tcs = new TaskCompletionSource<T>();
-        }
+        protected TaskWindow() : base(new Padding(1f)) => tcs = new TaskCompletionSource<T>();
 
         public TaskAwaiter<T> GetAwaiter() => tcs.Task.GetAwaiter();
 

--- a/Yafc.UI/Core/Ui.cs
+++ b/Yafc.UI/Core/Ui.cs
@@ -11,9 +11,7 @@ namespace Yafc.UI {
         public static bool quit { get; private set; }
 
         private static readonly Dictionary<uint, Window> windows = [];
-        internal static void RegisterWindow(uint id, Window window) {
-            windows[id] = window;
-        }
+        internal static void RegisterWindow(uint id, Window window) => windows[id] = window;
 
         [DllImport("SHCore.dll", SetLastError = true)]
         private static extern bool SetProcessDpiAwareness(int awareness);
@@ -39,17 +37,13 @@ namespace Yafc.UI {
         public static long time { get; private set; }
         private static readonly Stopwatch timeWatch = Stopwatch.StartNew();
 
-        public static bool IsMainThread() {
-            return Thread.CurrentThread.ManagedThreadId == mainThreadId;
-        }
+        public static bool IsMainThread() => Thread.CurrentThread.ManagedThreadId == mainThreadId;
 
         private static int mainThreadId;
         private static uint asyncCallbacksAdded;
         private static readonly Queue<(SendOrPostCallback, object)> CallbacksQueued = new Queue<(SendOrPostCallback, object)>();
 
-        public static void VisitLink(string url) {
-            _ = Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
-        }
+        public static void VisitLink(string url) => _ = Process.Start(new ProcessStartInfo(url) { UseShellExecute = true });
 
         public static void MainLoop() {
             while (!quit) {
@@ -189,13 +183,9 @@ namespace Yafc.UI {
             }
         }
 
-        public static EnterThreadPoolAwaitable ExitMainThread() {
-            return default;
-        }
+        public static EnterThreadPoolAwaitable ExitMainThread() => default;
 
-        public static EnterMainThreadAwaitable EnterMainThread() {
-            return default;
-        }
+        public static EnterMainThreadAwaitable EnterMainThread() => default;
 
         public static void Quit() {
             quit = true;

--- a/Yafc.UI/Core/Ui.cs
+++ b/Yafc.UI/Core/Ui.cs
@@ -10,7 +10,7 @@ namespace Yafc.UI {
     public static class Ui {
         public static bool quit { get; private set; }
 
-        private static readonly Dictionary<uint, Window> windows = new Dictionary<uint, Window>();
+        private static readonly Dictionary<uint, Window> windows = [];
         internal static void RegisterWindow(uint id, Window window) {
             windows[id] = window;
         }

--- a/Yafc.UI/Core/UiSyncronizhationContext.cs
+++ b/Yafc.UI/Core/UiSyncronizhationContext.cs
@@ -4,9 +4,7 @@ using System.Threading;
 
 namespace Yafc.UI {
     public class UiSynchronizationContext : SynchronizationContext {
-        public override void Post(SendOrPostCallback d, object state) {
-            Ui.DispatchInMainThread(d, state);
-        }
+        public override void Post(SendOrPostCallback d, object state) => Ui.DispatchInMainThread(d, state);
 
         private class SendCommand {
             public SendOrPostCallback d;
@@ -41,29 +39,21 @@ namespace Yafc.UI {
     }
 
     public readonly struct EnterThreadPoolAwaitable : INotifyCompletion {
-        public EnterThreadPoolAwaitable GetAwaiter() {
-            return this;
-        }
+        public EnterThreadPoolAwaitable GetAwaiter() => this;
 
         public void GetResult() { }
         public bool IsCompleted => !Ui.IsMainThread();
-        public void OnCompleted(Action continuation) {
-            _ = ThreadPool.QueueUserWorkItem(ThreadPoolPost, continuation);
-        }
+        public void OnCompleted(Action continuation) => _ = ThreadPool.QueueUserWorkItem(ThreadPoolPost, continuation);
 
         private static readonly WaitCallback ThreadPoolPost = a => ((Action)a)();
     }
 
     public readonly struct EnterMainThreadAwaitable : INotifyCompletion {
-        public EnterMainThreadAwaitable GetAwaiter() {
-            return this;
-        }
+        public EnterMainThreadAwaitable GetAwaiter() => this;
 
         public void GetResult() { }
         public bool IsCompleted => Ui.IsMainThread();
-        public void OnCompleted(Action continuation) {
-            Ui.DispatchInMainThread(MainThreadPost, continuation);
-        }
+        public void OnCompleted(Action continuation) => Ui.DispatchInMainThread(MainThreadPost, continuation);
 
         private static readonly SendOrPostCallback MainThreadPost = a => ((Action)a)();
     }

--- a/Yafc.UI/Core/Window.cs
+++ b/Yafc.UI/Core/Window.cs
@@ -73,9 +73,7 @@ namespace Yafc.UI {
             return desiredUnitsToPixels;
         }
 
-        internal virtual void WindowResize() {
-            rootGui.Rebuild();
-        }
+        internal virtual void WindowResize() => rootGui.Rebuild();
 
         internal void WindowMoved() {
             int index = SDL.SDL_GetWindowDisplayIndex(window);
@@ -119,13 +117,9 @@ namespace Yafc.UI {
             rootGui.InternalPresent(surface, fullRect, fullRect);
         }
 
-        public IPanel HitTest(Vector2 position) {
-            return rootGui.HitTest(position);
-        }
+        public IPanel HitTest(Vector2 position) => rootGui.HitTest(position);
 
-        public void Rebuild() {
-            rootGui.Rebuild();
-        }
+        public void Rebuild() => rootGui.Rebuild();
 
         public void Repaint() {
             if (closed) {
@@ -213,12 +207,8 @@ namespace Yafc.UI {
         }
 
         protected abstract void BuildContents(ImGui gui);
-        public virtual void Dispose() {
-            rootGui.Dispose();
-        }
+        public virtual void Dispose() => rootGui.Dispose();
 
-        internal ImGui.DragOverlay GetDragOverlay() {
-            return draggingOverlay ??= new ImGui.DragOverlay();
-        }
+        internal ImGui.DragOverlay GetDragOverlay() => draggingOverlay ??= new ImGui.DragOverlay();
     }
 }

--- a/Yafc.UI/Core/Window.cs
+++ b/Yafc.UI/Core/Window.cs
@@ -30,9 +30,7 @@ namespace Yafc.UI {
         public Vector2 size => contentSize;
 
         public virtual bool preventQuit => false;
-        internal Window(Padding padding) {
-            rootGui = new ImGui(Build, padding);
-        }
+        internal Window(Padding padding) => rootGui = new ImGui(Build, padding);
 
         internal void Create() {
             SDL.SDL_SetWindowIcon(window, GetIcon());

--- a/Yafc.UI/Core/WindowMain.cs
+++ b/Yafc.UI/Core/WindowMain.cs
@@ -61,9 +61,7 @@ namespace Yafc.UI {
             _ = SDL.SDL_SetTextureColorMod(circleTexture, colorMod, colorMod, colorMod);
         }
 
-        internal override void DrawIcon(SDL.SDL_Rect position, Icon icon, SchemeColor color) {
-            atlas.DrawIcon(renderer, icon, position, color.ToSdlColor());
-        }
+        internal override void DrawIcon(SDL.SDL_Rect position, Icon icon, SchemeColor color) => atlas.DrawIcon(renderer, icon, position, color.ToSdlColor());
 
         internal override void DrawBorder(SDL.SDL_Rect position, RectangleBorder border) {
             RenderingUtils.GetBorderParameters(pixelsPerUnit, border, out int top, out int side, out int bottom);

--- a/Yafc.UI/Core/WindowUtility.cs
+++ b/Yafc.UI/Core/WindowUtility.cs
@@ -84,9 +84,7 @@ namespace Yafc.UI {
             _ = SDL.SDL_SetRenderDrawBlendMode(renderer, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
         }
 
-        public void OnResize() {
-            InvalidateRenderer();
-        }
+        public void OnResize() => InvalidateRenderer();
 
         public override void Dispose() {
             base.Dispose();

--- a/Yafc.UI/Core/WindowUtility.cs
+++ b/Yafc.UI/Core/WindowUtility.cs
@@ -3,11 +3,9 @@ using SDL2;
 
 namespace Yafc.UI {
     // Utility window is not hardware-accelerated and auto-size (and not resizable)
-    public abstract class WindowUtility : Window {
+    public abstract class WindowUtility(Padding padding) : Window(padding) {
         private int windowWidth, windowHeight;
         private Window parent;
-
-        public WindowUtility(Padding padding) : base(padding) { }
 
         protected void Create(string title, float width, Window parent) {
             if (visible) {

--- a/Yafc.UI/ImGui/DropDownPanel.cs
+++ b/Yafc.UI/ImGui/DropDownPanel.cs
@@ -52,9 +52,7 @@ namespace Yafc.UI {
     public abstract class DropDownPanel : AttachedPanel, IMouseFocus {
         private bool focused;
         protected DropDownPanel(Padding padding, float width) : base(padding, width) { }
-        protected override bool ShouldBuild(ImGui source, Rect sourceRect, ImGui parent, Rect parentRect) {
-            return focused;
-        }
+        protected override bool ShouldBuild(ImGui source, Rect sourceRect, ImGui parent, Rect parentRect) => focused;
 
         public override void SetFocus(ImGui source, Rect rect) {
             InputSystem.Instance.SetMouseFocus(this);
@@ -93,9 +91,7 @@ namespace Yafc.UI {
 
         public delegate void Builder(ImGui gui, ref bool closed);
 
-        public void SetPadding(Padding padding) {
-            contents.initialPadding = padding;
-        }
+        public void SetPadding(Padding padding) => contents.initialPadding = padding;
 
         public void SetFocus(ImGui source, Rect rect, GuiBuilder builder, float width = 20f) {
             this.width = width;

--- a/Yafc.UI/ImGui/DropDownPanel.cs
+++ b/Yafc.UI/ImGui/DropDownPanel.cs
@@ -80,9 +80,7 @@ namespace Yafc.UI {
     public class SimpleDropDown : DropDownPanel {
         private GuiBuilder builder;
 
-        public SimpleDropDown() : base(new Padding(1f), 20f) {
-            contents.AddMessageHandler<ImGuiUtils.CloseDropdownEvent>(HandleDropdownClosed);
-        }
+        public SimpleDropDown() : base(new Padding(1f), 20f) => contents.AddMessageHandler<ImGuiUtils.CloseDropdownEvent>(HandleDropdownClosed);
 
         private bool HandleDropdownClosed(ImGuiUtils.CloseDropdownEvent _) {
             Close();
@@ -120,9 +118,7 @@ namespace Yafc.UI {
     }
 
     public abstract class Tooltip : AttachedPanel {
-        protected Tooltip(Padding padding, float width) : base(padding, width) {
-            contents.mouseCapture = false;
-        }
+        protected Tooltip(Padding padding, float width) : base(padding, width) => contents.mouseCapture = false;
         protected override bool ShouldBuild(ImGui source, Rect sourceRect, ImGui parent, Rect parentRect) {
             var window = source.window;
             if (InputSystem.Instance.mouseOverWindow != window) {

--- a/Yafc.UI/ImGui/IMGuiBuildCache.cs
+++ b/Yafc.UI/ImGui/IMGuiBuildCache.cs
@@ -30,10 +30,8 @@ namespace Yafc.UI {
                 }
             }
 
-            public bool CanSkip(object o) {
-                return o == obj && gui.action != ImGuiAction.Build && left == gui.state.left && right == gui.state.right && top == gui.state.top && finished &&
+            public bool CanSkip(object o) => o == obj && gui.action != ImGuiAction.Build && left == gui.state.left && right == gui.state.right && top == gui.state.top && finished &&
                        (gui.localClip.Top > state.bottom || gui.localClip.Bottom < top);
-            }
 
             public void Skip() {
                 gui.state = state;

--- a/Yafc.UI/ImGui/IMGuiBuildCache.cs
+++ b/Yafc.UI/ImGui/IMGuiBuildCache.cs
@@ -45,7 +45,7 @@ namespace Yafc.UI {
         private List<BuildGroup> buildGroups;
 
         public bool ShouldBuildGroup(object o, out BuildGroup group) {
-            buildGroups ??= new List<BuildGroup>();
+            buildGroups ??= [];
             buildGroupsIndex++;
             BuildGroup current;
             if (buildGroups.Count > buildGroupsIndex) {

--- a/Yafc.UI/ImGui/IMGuiBuildCache.cs
+++ b/Yafc.UI/ImGui/IMGuiBuildCache.cs
@@ -10,9 +10,7 @@ namespace Yafc.UI {
             private Rect lastRect;
             private bool finished;
 
-            public BuildGroup(ImGui gui) {
-                this.gui = gui;
-            }
+            public BuildGroup(ImGui gui) => this.gui = gui;
 
             public void Update(object obj) {
                 left = gui.state.left;

--- a/Yafc.UI/ImGui/ImGui.cs
+++ b/Yafc.UI/ImGui/ImGui.cs
@@ -150,7 +150,7 @@ namespace Yafc.UI {
             InternalPresent(surface, position, screenClip);
         }
 
-        private static readonly List<(SDL.SDL_Rect, RectangleBorder)> borders = new List<(SDL.SDL_Rect, RectangleBorder)>();
+        private static readonly List<(SDL.SDL_Rect, RectangleBorder)> borders = [];
         internal void InternalPresent(DrawingSurface surface, Rect position, Rect screenClip) {
             if (surface.window != null) {
                 window = surface.window;
@@ -330,7 +330,7 @@ namespace Yafc.UI {
         }
 
         public void AddMessageHandler<T>(Func<T, bool> handler) {
-            messageHandlers ??= new List<object>();
+            messageHandlers ??= [];
             messageHandlers.Add(handler);
         }
 

--- a/Yafc.UI/ImGui/ImGui.cs
+++ b/Yafc.UI/ImGui/ImGui.cs
@@ -100,9 +100,7 @@ namespace Yafc.UI {
             }
         }
 
-        public bool IsRebuildRequired() {
-            return rebuildRequested || Ui.time >= nextRebuildTimer;
-        }
+        public bool IsRebuildRequired() => rebuildRequested || Ui.time >= nextRebuildTimer;
 
         public void Rebuild() {
             rebuildRequested = true;
@@ -125,9 +123,7 @@ namespace Yafc.UI {
             }
         }
 
-        public void Repaint() {
-            window?.Repaint();
-        }
+        public void Repaint() => window?.Repaint();
 
         public Vector2 CalculateState(float width, float pixelsPerUnit) {
             if (IsRebuildRequired() || buildWidth != width || this.pixelsPerUnit != pixelsPerUnit) {
@@ -237,22 +233,16 @@ namespace Yafc.UI {
             return this;
         }
 
-        public int UnitsToPixels(float units) {
-            return (int)MathF.Round(units * pixelsPerUnit);
-        }
+        public int UnitsToPixels(float units) => (int)MathF.Round(units * pixelsPerUnit);
 
-        public float PixelsToUnits(int pixels) {
-            return pixels / pixelsPerUnit;
-        }
+        public float PixelsToUnits(int pixels) => pixels / pixelsPerUnit;
 
-        public SDL.SDL_Rect ToSdlRect(Rect rect, Vector2 offset = default) {
-            return new SDL.SDL_Rect {
-                x = UnitsToPixels(rect.X + offset.X),
-                y = UnitsToPixels(rect.Y + offset.Y),
-                w = UnitsToPixels(rect.Width),
-                h = UnitsToPixels(rect.Height)
-            };
-        }
+        public SDL.SDL_Rect ToSdlRect(Rect rect, Vector2 offset = default) => new SDL.SDL_Rect {
+            x = UnitsToPixels(rect.X + offset.X),
+            y = UnitsToPixels(rect.Y + offset.Y),
+            w = UnitsToPixels(rect.Width),
+            h = UnitsToPixels(rect.Height)
+        };
 
         private static void CheckMainThread() {
             if (!Ui.IsMainThread()) {

--- a/Yafc.UI/ImGui/ImGuiBuilding.cs
+++ b/Yafc.UI/ImGui/ImGuiBuilding.cs
@@ -22,10 +22,10 @@ namespace Yafc.UI {
             }
         }
 
-        private readonly List<DrawCommand<RectangleBorder>> rects = new List<DrawCommand<RectangleBorder>>();
-        private readonly List<DrawCommand<Icon>> icons = new List<DrawCommand<Icon>>();
-        private readonly List<DrawCommand<IRenderable>> renderables = new List<DrawCommand<IRenderable>>();
-        private readonly List<DrawCommand<IPanel>> panels = new List<DrawCommand<IPanel>>();
+        private readonly List<DrawCommand<RectangleBorder>> rects = [];
+        private readonly List<DrawCommand<Icon>> icons = [];
+        private readonly List<DrawCommand<IRenderable>> renderables = [];
+        private readonly List<DrawCommand<IPanel>> panels = [];
         public SchemeColor initialTextColor { get; set; } = SchemeColor.BackgroundText;
         public SchemeColor boxColor { get; set; } = SchemeColor.None;
         public RectangleBorder boxShadow { get; set; } = RectangleBorder.None;

--- a/Yafc.UI/ImGui/ImGuiBuilding.cs
+++ b/Yafc.UI/ImGui/ImGuiBuilding.cs
@@ -79,9 +79,7 @@ namespace Yafc.UI {
 
         public readonly ImGuiCache<TextCache, (FontFile.FontSize size, string text, uint wrapWidth)>.Cache textCache = new ImGuiCache<TextCache, (FontFile.FontSize size, string text, uint wrapWidth)>.Cache();
 
-        public FontFile.FontSize GetFontSize(Font font = null) {
-            return (font ?? Font.text).GetFontSize(pixelsPerUnit);
-        }
+        public FontFile.FontSize GetFontSize(Font font = null) => (font ?? Font.text).GetFontSize(pixelsPerUnit);
 
         public SchemeColor textColor {
             get => state.textColor;
@@ -326,21 +324,13 @@ namespace Yafc.UI {
             return false;
         }
 
-        public bool IsMouseOver(Rect rect) {
-            return rect == mouseOverRect;
-        }
+        public bool IsMouseOver(Rect rect) => rect == mouseOverRect;
 
-        public bool IsMouseDown(Rect rect, uint button = SDL.SDL_BUTTON_LEFT) {
-            return rect == mouseDownRect && mouseDownButton == button;
-        }
+        public bool IsMouseDown(Rect rect, uint button = SDL.SDL_BUTTON_LEFT) => rect == mouseDownRect && mouseDownButton == button;
 
-        public bool IsMouseOverOrDown(Rect rect, uint button = SDL.SDL_BUTTON_LEFT) {
-            return mouseOverRect == rect || (mouseDownRect == rect && mouseDownButton == button);
-        }
+        public bool IsMouseOverOrDown(Rect rect, uint button = SDL.SDL_BUTTON_LEFT) => mouseOverRect == rect || (mouseDownRect == rect && mouseDownButton == button);
 
-        public bool IsLastMouseDown(Rect rect) {
-            return rect == mouseDownRect;
-        }
+        public bool IsLastMouseDown(Rect rect) => rect == mouseDownRect;
 
         public void ClearFocus() {
             if (mouseDownRect != default) {

--- a/Yafc.UI/ImGui/ImGuiCache.cs
+++ b/Yafc.UI/ImGui/ImGuiCache.cs
@@ -60,9 +60,7 @@ namespace Yafc.UI {
             texRect = new SDL.SDL_Rect { w = surfaceParams.w, h = surfaceParams.h };
         }
 
-        protected override TextCache CreateForKey((FontFile.FontSize size, string text, uint wrapWidth) key) {
-            return new TextCache(key);
-        }
+        protected override TextCache CreateForKey((FontFile.FontSize size, string text, uint wrapWidth) key) => new TextCache(key);
 
         public override void Dispose() {
             if (surface != IntPtr.Zero) {

--- a/Yafc.UI/ImGui/ImGuiCache.cs
+++ b/Yafc.UI/ImGui/ImGuiCache.cs
@@ -8,8 +8,8 @@ namespace Yafc.UI {
         private static readonly T Constructor = (T)RuntimeHelpers.GetUninitializedObject(typeof(T));
 
         public class Cache : IDisposable {
-            private readonly Dictionary<TKey, T> activeCached = new Dictionary<TKey, T>();
-            private readonly HashSet<TKey> unused = new HashSet<TKey>();
+            private readonly Dictionary<TKey, T> activeCached = [];
+            private readonly HashSet<TKey> unused = [];
 
             public T GetCached(TKey key) {
                 if (activeCached.TryGetValue(key, out var value)) {

--- a/Yafc.UI/ImGui/ImGuiDrag.cs
+++ b/Yafc.UI/ImGui/ImGuiDrag.cs
@@ -42,9 +42,7 @@ namespace Yafc.UI {
             return false;
         }
 
-        public T GetDraggingObject<T>() {
-            return currentDraggingObject is T t ? t : default;
-        }
+        public T GetDraggingObject<T>() => currentDraggingObject is T t ? t : default;
 
         internal class DragOverlay {
             private readonly ImGui contents = new ImGui(null, default) { mouseCapture = false };
@@ -54,9 +52,7 @@ namespace Yafc.UI {
             private Rect realPosition;
 
 
-            public bool ShouldConsumeDrag(ImGui source, Vector2 point) {
-                return currentSource == source && realPosition.Contains(source.ToWindowPosition(point));
-            }
+            public bool ShouldConsumeDrag(ImGui source, Vector2 point) => currentSource == source && realPosition.Contains(source.ToWindowPosition(point));
 
             private void ExtractDrawCommandsFrom<T>(List<DrawCommand<T>> sourceList, List<DrawCommand<T>> targetList, Rect rect) {
                 targetList.Clear();

--- a/Yafc.UI/ImGui/ImGuiLayout.cs
+++ b/Yafc.UI/ImGui/ImGuiLayout.cs
@@ -19,13 +19,9 @@ namespace Yafc.UI {
             state.spacing = 0.5f;
         }
 
-        public void AllocateSpacing(float spacing) {
-            _ = AllocateRect(0f, 0f, spacing);
-        }
+        public void AllocateSpacing(float spacing) => _ = AllocateRect(0f, 0f, spacing);
 
-        public void AllocateSpacing() {
-            AllocateSpacing(state.spacing);
-        }
+        public void AllocateSpacing() => AllocateSpacing(state.spacing);
 
         public Rect AllocateRect(float width, float height, float spacing = float.NegativeInfinity) {
             var rect = state.AllocateRect(width, height, spacing);
@@ -47,16 +43,14 @@ namespace Yafc.UI {
             return AlignRect(bigRect, alignment, width, height);
         }
 
-        public static Rect AlignRect(Rect boundary, RectAlignment alignment, float width, float height) {
-            return alignment switch {
-                RectAlignment.Middle => new Rect(boundary.X + ((boundary.Width - width) * 0.5f), boundary.Y + ((boundary.Height - height) * 0.5f), width, height),
-                RectAlignment.MiddleLeft => new Rect(boundary.X, boundary.Y + ((boundary.Height - height) * 0.5f), width, height),
-                RectAlignment.MiddleRight => new Rect(boundary.X, boundary.Y + ((boundary.Height - height) * 0.5f), width, height),
-                RectAlignment.UpperCenter => new Rect(boundary.X + ((boundary.Width - width) * 0.5f), boundary.Y, width, height),
-                RectAlignment.MiddleFullRow => new Rect(boundary.X, boundary.Y + ((boundary.Height - height) * 0.5f), boundary.Width, height),
-                _ => boundary,
-            };
-        }
+        public static Rect AlignRect(Rect boundary, RectAlignment alignment, float width, float height) => alignment switch {
+            RectAlignment.Middle => new Rect(boundary.X + ((boundary.Width - width) * 0.5f), boundary.Y + ((boundary.Height - height) * 0.5f), width, height),
+            RectAlignment.MiddleLeft => new Rect(boundary.X, boundary.Y + ((boundary.Height - height) * 0.5f), width, height),
+            RectAlignment.MiddleRight => new Rect(boundary.X, boundary.Y + ((boundary.Height - height) * 0.5f), width, height),
+            RectAlignment.UpperCenter => new Rect(boundary.X + ((boundary.Width - width) * 0.5f), boundary.Y, width, height),
+            RectAlignment.MiddleFullRow => new Rect(boundary.X, boundary.Y + ((boundary.Height - height) * 0.5f), boundary.Width, height),
+            _ => boundary,
+        };
 
         public ImGui RemainingRow(float spacing = float.NegativeInfinity) {
             state.AllocateSpacing(spacing);
@@ -79,13 +73,9 @@ namespace Yafc.UI {
             return ctx;
         }
 
-        public Context EnterGroup(Padding padding, SchemeColor textColor = SchemeColor.None) {
-            return EnterGroup(padding, allocator, textColor);
-        }
+        public Context EnterGroup(Padding padding, SchemeColor textColor = SchemeColor.None) => EnterGroup(padding, allocator, textColor);
 
-        public Context EnterRow(float spacing = 0.5f, RectAllocator allocator = RectAllocator.LeftRow, SchemeColor textColor = SchemeColor.None) {
-            return EnterGroup(default, allocator, textColor, spacing);
-        }
+        public Context EnterRow(float spacing = 0.5f, RectAllocator allocator = RectAllocator.LeftRow, SchemeColor textColor = SchemeColor.None) => EnterGroup(default, allocator, textColor, spacing);
 
         public Context EnterFixedPositioning(float width, float height, Padding padding, SchemeColor textColor = SchemeColor.None) {
             Context context = new Context(this, padding);
@@ -240,9 +230,7 @@ namespace Yafc.UI {
                 SetManualRectRaw(rect, allocator);
             }
 
-            public void SetWidth(float width) {
-                gui.state.right = gui.state.left + width;
-            }
+            public void SetWidth(float width) => gui.state.right = gui.state.left + width;
 
             public void SetManualRectRaw(Rect rect, RectAllocator allocator = RectAllocator.FixedRect) {
                 ref var cstate = ref gui.state;

--- a/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
+++ b/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
@@ -319,9 +319,7 @@ namespace Yafc.UI {
             return true;
         }
 
-        public bool KeyUp(SDL.SDL_Keysym key) {
-            return true;
-        }
+        public bool KeyUp(SDL.SDL_Keysym key) => true;
 
         public void FocusChanged(bool focused) {
             if (!focused) {

--- a/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
+++ b/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
@@ -7,9 +7,7 @@ namespace Yafc.UI {
     internal class ImGuiTextInputHelper : IKeyboardFocus {
         private readonly ImGui gui;
 
-        public ImGuiTextInputHelper(ImGui gui) {
-            this.gui = gui;
-        }
+        public ImGuiTextInputHelper(ImGui gui) => this.gui = gui;
 
         private string prevText;
         private Rect prevRect;

--- a/Yafc.UI/ImGui/ImGuiUtils.cs
+++ b/Yafc.UI/ImGui/ImGuiUtils.cs
@@ -12,9 +12,7 @@ namespace Yafc.UI {
         public static readonly ButtonEvent MouseOver = new ButtonEvent(2);
         public static readonly ButtonEvent MouseDown = new ButtonEvent(3);
 
-        private ButtonEvent(int value) {
-            this.value = value;
-        }
+        private ButtonEvent(int value) => this.value = value;
 
         public static bool operator ==(ButtonEvent a, ButtonEvent b) {
             return a.value == b.value;

--- a/Yafc.UI/ImGui/ImGuiUtils.cs
+++ b/Yafc.UI/ImGui/ImGuiUtils.cs
@@ -24,17 +24,11 @@ namespace Yafc.UI {
             return a.value != b.value;
         }
 
-        public bool Equals(ButtonEvent other) {
-            return value == other.value;
-        }
+        public bool Equals(ButtonEvent other) => value == other.value;
 
-        public override bool Equals(object obj) {
-            return obj is ButtonEvent other && Equals(other);
-        }
+        public override bool Equals(object obj) => obj is ButtonEvent other && Equals(other);
 
-        public override int GetHashCode() {
-            return value;
-        }
+        public override int GetHashCode() => value;
 
         public static implicit operator bool(ButtonEvent b) {
             return b == Click;
@@ -69,9 +63,7 @@ namespace Yafc.UI {
             }
         }
 
-        public static string ScanToString(SDL.SDL_Scancode scancode) {
-            return SDL.SDL_GetKeyName(SDL.SDL_GetKeyFromScancode(scancode));
-        }
+        public static string ScanToString(SDL.SDL_Scancode scancode) => SDL.SDL_GetKeyName(SDL.SDL_GetKeyFromScancode(scancode));
 
         public static bool BuildLink(this ImGui gui, string text) {
             gui.BuildText(text, color: SchemeColor.Link);
@@ -144,9 +136,7 @@ namespace Yafc.UI {
             return gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.Grey);
         }
 
-        public static void CaptureException(this Task task) {
-            _ = task.ContinueWith(t => throw t.Exception, TaskContinuationOptions.OnlyOnFaulted);
-        }
+        public static void CaptureException(this Task task) => _ = task.ContinueWith(t => throw t.Exception, TaskContinuationOptions.OnlyOnFaulted);
 
         public static bool BuildMouseOverIcon(this ImGui gui, Icon icon, SchemeColor color = SchemeColor.BackgroundText) {
             if (gui.isBuilding && gui.IsMouseOver(gui.lastRect)) {
@@ -275,25 +265,15 @@ namespace Yafc.UI {
             return false;
         }
 
-        public static void ShowDropDown(this ImGui gui, Rect rect, GuiBuilder builder, Padding padding, float width = 20f) {
-            gui.window?.ShowDropDown(gui, rect, builder, padding, width);
-        }
+        public static void ShowDropDown(this ImGui gui, Rect rect, GuiBuilder builder, Padding padding, float width = 20f) => gui.window?.ShowDropDown(gui, rect, builder, padding, width);
 
-        public static void ShowDropDown(this ImGui gui, GuiBuilder builder, float width = 20f) {
-            gui.window?.ShowDropDown(gui, gui.lastRect, builder, new Padding(1f), width);
-        }
+        public static void ShowDropDown(this ImGui gui, GuiBuilder builder, float width = 20f) => gui.window?.ShowDropDown(gui, gui.lastRect, builder, new Padding(1f), width);
 
-        public static void ShowTooltip(this ImGui gui, Rect rect, GuiBuilder builder, float width = 20f) {
-            gui.window?.ShowTooltip(gui, rect, builder, width);
-        }
+        public static void ShowTooltip(this ImGui gui, Rect rect, GuiBuilder builder, float width = 20f) => gui.window?.ShowTooltip(gui, rect, builder, width);
 
-        public static void ShowTooltip(this ImGui gui, Rect rect, string text, float width = 20f) {
-            gui.window?.ShowTooltip(gui, rect, x => x.BuildText(text, wrap: true), width);
-        }
+        public static void ShowTooltip(this ImGui gui, Rect rect, string text, float width = 20f) => gui.window?.ShowTooltip(gui, rect, x => x.BuildText(text, wrap: true), width);
 
-        public static void ShowTooltip(this ImGui gui, GuiBuilder builder, float width = 20f) {
-            gui.window?.ShowTooltip(gui, gui.lastRect, builder, width);
-        }
+        public static void ShowTooltip(this ImGui gui, GuiBuilder builder, float width = 20f) => gui.window?.ShowTooltip(gui, gui.lastRect, builder, width);
 
         public struct InlineGridBuilder : IDisposable {
             private ImGui.Context savedContext;
@@ -330,22 +310,16 @@ namespace Yafc.UI {
                 savedContext.SetManualRect(new Rect((elementWidth + spacing) * currentRowIndex, 0f, elementWidth, 0f), RectAllocator.Stretch);
             }
 
-            public bool isEmpty() {
-                return gui == null;
-            }
+            public bool isEmpty() => gui == null;
 
-            public void Dispose() {
-                savedContext.Dispose();
-            }
+            public void Dispose() => savedContext.Dispose();
         }
 
-        public static InlineGridBuilder EnterInlineGrid(this ImGui gui, float elementWidth, float spacing = 0f, int maxElemCount = 0) {
-            return new InlineGridBuilder(gui, elementWidth, spacing, maxElemCount);
-        }
+        public static InlineGridBuilder EnterInlineGrid(this ImGui gui, float elementWidth, float spacing = 0f, int maxElemCount = 0) => new InlineGridBuilder(
+            gui, elementWidth, spacing, maxElemCount);
 
-        public static InlineGridBuilder EnterHorizontalSplit(this ImGui gui, int elementCount, float spacing = 0f) {
-            return new InlineGridBuilder(gui, ((gui.width + spacing) / elementCount) - spacing, spacing, elementCount);
-        }
+        public static InlineGridBuilder EnterHorizontalSplit(this ImGui gui, int elementCount, float spacing = 0f) => new InlineGridBuilder(
+            gui, ((gui.width + spacing) / elementCount) - spacing, spacing, elementCount);
 
         public static bool DoListReordering<T>(this ImGui gui, Rect moveHandle, Rect contents, T index, out T moveFrom, SchemeColor backgroundColor = SchemeColor.PureBackground, bool updateDraggingObject = true) {
             bool result = false;

--- a/Yafc.UI/ImGui/ImGuiUtils.cs
+++ b/Yafc.UI/ImGui/ImGuiUtils.cs
@@ -14,13 +14,9 @@ namespace Yafc.UI {
 
         private ButtonEvent(int value) => this.value = value;
 
-        public static bool operator ==(ButtonEvent a, ButtonEvent b) {
-            return a.value == b.value;
-        }
+        public static bool operator ==(ButtonEvent a, ButtonEvent b) => a.value == b.value;
 
-        public static bool operator !=(ButtonEvent a, ButtonEvent b) {
-            return a.value != b.value;
-        }
+        public static bool operator !=(ButtonEvent a, ButtonEvent b) => a.value != b.value;
 
         public bool Equals(ButtonEvent other) => value == other.value;
 
@@ -28,9 +24,7 @@ namespace Yafc.UI {
 
         public override int GetHashCode() => value;
 
-        public static implicit operator bool(ButtonEvent b) {
-            return b == Click;
-        }
+        public static implicit operator bool(ButtonEvent b) => b == Click;
     }
 
     public static class ImGuiUtils {

--- a/Yafc.UI/ImGui/ScrollArea.cs
+++ b/Yafc.UI/ImGui/ScrollArea.cs
@@ -4,9 +4,7 @@ using System.Numerics;
 using SDL2;
 
 namespace Yafc.UI {
-    public abstract class Scrollable : IKeyboardFocus {
-        private readonly bool vertical, horizontal, collapsible;
-
+    public abstract class Scrollable(bool vertical, bool horizontal, bool collapsible) : IKeyboardFocus {
         private Vector2 contentSize;
         private Vector2 maxScroll;
         private Vector2 _scroll;
@@ -17,12 +15,6 @@ namespace Yafc.UI {
         // Padding to add at the bottom of the scroll area to be able to scroll past the
         // last item; needs useBottomPadding to be set to true in method Build()
         private const float BottomPaddingInPixels = 100f;
-
-        protected Scrollable(bool vertical, bool horizontal, bool collapsible) {
-            this.vertical = vertical;
-            this.horizontal = horizontal;
-            this.collapsible = collapsible;
-        }
 
         protected abstract void PositionContent(ImGui gui, Rect viewport);
 
@@ -212,13 +204,7 @@ namespace Yafc.UI {
         }
     }
 
-    public class ScrollArea : ScrollAreaBase {
-        private readonly GuiBuilder builder;
-
-        public ScrollArea(float height, GuiBuilder builder, Padding padding = default, bool collapsible = false, bool vertical = true, bool horizontal = false) : base(height, padding, collapsible, vertical, horizontal) {
-            this.builder = builder;
-        }
-
+    public class ScrollArea(float height, GuiBuilder builder, Padding padding = default, bool collapsible = false, bool vertical = true, bool horizontal = false) : ScrollAreaBase(height, padding, collapsible, vertical, horizontal) {
         protected override void BuildContents(ImGui gui) {
             builder(gui);
         }

--- a/Yafc.UI/ImGui/ScrollArea.cs
+++ b/Yafc.UI/ImGui/ScrollArea.cs
@@ -233,7 +233,7 @@ namespace Yafc.UI {
         protected readonly int bufferRows;
         protected int firstVisibleBlock;
         protected int elementsPerRow;
-        private IReadOnlyList<TData> _data = Array.Empty<TData>();
+        private IReadOnlyList<TData> _data = [];
         private readonly int maxRowsVisible;
         private readonly Drawer drawer;
         public float _spacing;
@@ -252,7 +252,7 @@ namespace Yafc.UI {
         public IReadOnlyList<TData> data {
             get => _data;
             set {
-                _data = value ?? Array.Empty<TData>();
+                _data = value ?? [];
                 RebuildContents();
             }
         }

--- a/Yafc.UI/ImGui/ScrollArea.cs
+++ b/Yafc.UI/ImGui/ScrollArea.cs
@@ -164,13 +164,9 @@ namespace Yafc.UI {
             }
         }
 
-        public bool TextInput(string input) {
-            return false;
-        }
+        public bool TextInput(string input) => false;
 
-        public bool KeyUp(SDL.SDL_Keysym key) {
-            return false;
-        }
+        public bool KeyUp(SDL.SDL_Keysym key) => false;
 
         public void FocusChanged(bool focused) { }
     }
@@ -189,29 +185,19 @@ namespace Yafc.UI {
             contents.offset = -scroll2d;
         }
 
-        public void Build(ImGui gui) {
-            Build(gui, height);
-        }
+        public void Build(ImGui gui) => Build(gui, height);
 
         protected abstract void BuildContents(ImGui gui);
 
-        public void RebuildContents() {
-            contents.Rebuild();
-        }
+        public void RebuildContents() => contents.Rebuild();
 
-        protected override Vector2 MeasureContent(Rect rect, ImGui gui) {
-            return contents.CalculateState(rect.Width, gui.pixelsPerUnit);
-        }
+        protected override Vector2 MeasureContent(Rect rect, ImGui gui) => contents.CalculateState(rect.Width, gui.pixelsPerUnit);
     }
 
     public class ScrollArea(float height, GuiBuilder builder, Padding padding = default, bool collapsible = false, bool vertical = true, bool horizontal = false) : ScrollAreaBase(height, padding, collapsible, vertical, horizontal) {
-        protected override void BuildContents(ImGui gui) {
-            builder(gui);
-        }
+        protected override void BuildContents(ImGui gui) => builder(gui);
 
-        public void Rebuild() {
-            RebuildContents();
-        }
+        public void Rebuild() => RebuildContents();
     }
 
     public class VirtualScrollList<TData> : ScrollAreaBase {
@@ -251,9 +237,7 @@ namespace Yafc.UI {
             this.reorder = reorder;
         }
 
-        private int CalcFirstBlock() {
-            return Math.Max(0, MathUtils.Floor((scroll - contents.initialPadding.top) / (elementSize.Y * bufferRows)));
-        }
+        private int CalcFirstBlock() => Math.Max(0, MathUtils.Floor((scroll - contents.initialPadding.top) / (elementSize.Y * bufferRows)));
 
         public override Vector2 scroll2d {
             get => base.scroll2d;
@@ -303,8 +287,6 @@ namespace Yafc.UI {
             }
         }
 
-        protected virtual void BuildElement(ImGui gui, TData element, int index) {
-            drawer(gui, element, index);
-        }
+        protected virtual void BuildElement(ImGui gui, TData element, int index) => drawer(gui, element, index);
     }
 }

--- a/Yafc.UI/Rendering/Font.cs
+++ b/Yafc.UI/Rendering/Font.cs
@@ -43,7 +43,7 @@ namespace Yafc.UI {
 
     public class FontFile : IDisposable {
         public readonly string fileName;
-        private readonly Dictionary<int, FontSize> sizes = new Dictionary<int, FontSize>();
+        private readonly Dictionary<int, FontSize> sizes = [];
         public FontFile(string fileName) {
             this.fileName = fileName;
         }

--- a/Yafc.UI/Rendering/Font.cs
+++ b/Yafc.UI/Rendering/Font.cs
@@ -23,22 +23,16 @@ namespace Yafc.UI {
             return lastFontSize;
         }
 
-        public IntPtr GetHandle(float pixelsPreUnit) {
-            return GetFontSize(pixelsPreUnit).handle;
-        }
+        public IntPtr GetHandle(float pixelsPreUnit) => GetFontSize(pixelsPreUnit).handle;
 
-        public float GetLineSize(float pixelsPreUnit) {
-            return GetFontSize(pixelsPreUnit).lineSize / pixelsPreUnit;
-        }
+        public float GetLineSize(float pixelsPreUnit) => GetFontSize(pixelsPreUnit).lineSize / pixelsPreUnit;
 
         public Font(FontFile file, float size) {
             this.size = size;
             fontFile = file;
         }
 
-        public void Dispose() {
-            fontFile.Dispose();
-        }
+        public void Dispose() => fontFile.Dispose();
     }
 
     public class FontFile : IDisposable {
@@ -58,9 +52,7 @@ namespace Yafc.UI {
             }
 
             public IntPtr handle => _handle;
-            protected override void ReleaseUnmanagedResources() {
-                SDL_ttf.TTF_CloseFont(_handle);
-            }
+            protected override void ReleaseUnmanagedResources() => SDL_ttf.TTF_CloseFont(_handle);
         }
 
         public FontSize GetFontForSize(int size) {

--- a/Yafc.UI/Rendering/Font.cs
+++ b/Yafc.UI/Rendering/Font.cs
@@ -38,9 +38,7 @@ namespace Yafc.UI {
     public class FontFile : IDisposable {
         public readonly string fileName;
         private readonly Dictionary<int, FontSize> sizes = [];
-        public FontFile(string fileName) {
-            this.fileName = fileName;
-        }
+        public FontFile(string fileName) => this.fileName = fileName;
 
         public class FontSize : UnmanagedResource {
             public readonly int size;

--- a/Yafc.UI/Rendering/RenderingUtils.cs
+++ b/Yafc.UI/Rendering/RenderingUtils.cs
@@ -10,18 +10,14 @@ namespace Yafc.UI {
         public static readonly IntPtr cursorHorizontalResize = SDL.SDL_CreateSystemCursor(SDL.SDL_SystemCursor.SDL_SYSTEM_CURSOR_SIZEWE);
         public const byte SEMITRANSPARENT = 100;
 
-        private static SDL.SDL_Color ColorFromHex(int hex) {
-            return new SDL.SDL_Color { r = (byte)(hex >> 16), g = (byte)(hex >> 8), b = (byte)hex, a = 255 };
-        }
+        private static SDL.SDL_Color ColorFromHex(int hex) => new SDL.SDL_Color { r = (byte)(hex >> 16), g = (byte)(hex >> 8), b = (byte)hex, a = 255 };
 
         public static readonly SDL.SDL_Color Black = new SDL.SDL_Color { a = 255 };
         public static readonly SDL.SDL_Color White = new SDL.SDL_Color { r = 255, g = 255, b = 255, a = 255 };
         public static readonly SDL.SDL_Color BlackTransparent = new SDL.SDL_Color { a = SEMITRANSPARENT };
         public static readonly SDL.SDL_Color WhiteTransparent = new SDL.SDL_Color { r = 255, g = 255, b = 255, a = SEMITRANSPARENT };
 
-        public static SchemeColor GetTextColorFromBackgroundColor(SchemeColor color) {
-            return (SchemeColor)((int)color & ~3) + 2;
-        }
+        public static SchemeColor GetTextColorFromBackgroundColor(SchemeColor color) => (SchemeColor)((int)color & ~3) + 2;
 
         private static readonly SDL.SDL_Color[] LightModeScheme = {
             default, new SDL.SDL_Color {b = 255, g = 128, a = 60}, ColorFromHex(0x0645AD), ColorFromHex(0x1b5e20), // Special group
@@ -70,13 +66,9 @@ namespace Yafc.UI {
             _ = SDL.SDL_SetSurfaceColorMod(CircleSurface, col, col, col);
         }
 
-        public static SDL.SDL_Color ToSdlColor(this SchemeColor color) {
-            return SchemeColors[(int)color];
-        }
+        public static SDL.SDL_Color ToSdlColor(this SchemeColor color) => SchemeColors[(int)color];
 
-        public static unsafe ref SDL.SDL_Surface AsSdlSurface(IntPtr ptr) {
-            return ref Unsafe.AsRef<SDL.SDL_Surface>((void*)ptr);
-        }
+        public static unsafe ref SDL.SDL_Surface AsSdlSurface(IntPtr ptr) => ref Unsafe.AsRef<SDL.SDL_Surface>((void*)ptr);
 
         public static readonly IntPtr CircleSurface;
         private static readonly SDL.SDL_Rect CircleTopLeft, CircleTopRight, CircleBottomLeft, CircleBottomRight, CircleTop, CircleBottom, CircleLeft, CircleRight;

--- a/Yafc/Utils/CommandLineParser.cs
+++ b/Yafc/Utils/CommandLineParser.cs
@@ -120,7 +120,7 @@ Examples:
         }
 
         private static bool IsKnownParameter(string arg) {
-            return arg == "--mods-path" || arg == "--project-file" || arg == "--expensive" || arg == "--help";
+            return arg is "--mods-path" or "--project-file" or "--expensive" or "--help";
         }
     }
 }

--- a/Yafc/Utils/CommandLineParser.cs
+++ b/Yafc/Utils/CommandLineParser.cs
@@ -72,8 +72,7 @@ namespace Yafc {
             return options;
         }
 
-        public static void PrintHelp() {
-            Console.WriteLine(@"Usage:
+        public static void PrintHelp() => Console.WriteLine(@"Usage:
 Yafc [<data-path> [--mods-path <path>] [--project-file <path>] [--expensive]] [--help]
 
 Description:
@@ -117,10 +116,7 @@ Examples:
        This opens the supplied project and loads the game data and mods from the supplied
        data and mods directories. Fails if any of the directories and/or the project file
        do not exist.");
-        }
 
-        private static bool IsKnownParameter(string arg) {
-            return arg is "--mods-path" or "--project-file" or "--expensive" or "--help";
-        }
+        private static bool IsKnownParameter(string arg) => arg is "--mods-path" or "--project-file" or "--expensive" or "--help";
     }
 }

--- a/Yafc/Utils/Preferences.cs
+++ b/Yafc/Utils/Preferences.cs
@@ -41,7 +41,7 @@ namespace Yafc {
             byte[] data = JsonSerializer.SerializeToUtf8Bytes(this, JsonUtils.DefaultOptions);
             File.WriteAllBytes(fileName, data);
         }
-        public ProjectDefinition[] recentProjects { get; set; } = Array.Empty<ProjectDefinition>();
+        public ProjectDefinition[] recentProjects { get; set; } = [];
         public bool darkMode { get; set; }
         public string language { get; set; } = "en";
         public string overrideFont { get; set; }

--- a/Yafc/Widgets/DataGrid.cs
+++ b/Yafc/Widgets/DataGrid.cs
@@ -4,31 +4,20 @@ using System.Numerics;
 using SDL2;
 
 namespace Yafc.UI {
-    public abstract class DataColumn<TData> {
-        public readonly float minWidth;
-        public readonly float maxWidth;
-        public readonly bool isFixedSize;
-        public float width;
-
-        public DataColumn(float width, float minWidth = 0f, float maxWidth = 0f) {
-            this.width = width;
-            this.minWidth = minWidth == 0f ? width : minWidth;
-            this.maxWidth = maxWidth == 0f ? width : maxWidth;
-            isFixedSize = minWidth == maxWidth;
-        }
+    public abstract class DataColumn<TData>(float width, float minWidth = 0f, float maxWidth = 0f) {
+        public readonly float minWidth = minWidth == 0f ? width : minWidth;
+        public readonly float maxWidth = maxWidth == 0f ? width : maxWidth;
+        public readonly bool isFixedSize = minWidth == maxWidth;
+        public float width = width;
 
         public abstract void BuildHeader(ImGui gui);
         public abstract void BuildElement(ImGui gui, TData data);
     }
 
-    public abstract class TextDataColumn<TData> : DataColumn<TData> {
-        public readonly string header;
-        private readonly bool hasMenu;
+    public abstract class TextDataColumn<TData>(string header, float width, float minWidth = 0, float maxWidth = 0, bool hasMenu = false) : DataColumn<TData>(width, minWidth, maxWidth) {
+        public readonly string header = header;
+        private readonly bool hasMenu = hasMenu;
 
-        protected TextDataColumn(string header, float width, float minWidth = 0, float maxWidth = 0, bool hasMenu = false) : base(width, minWidth, maxWidth) {
-            this.header = header;
-            this.hasMenu = hasMenu;
-        }
         public override void BuildHeader(ImGui gui) {
             gui.BuildText(header);
             if (hasMenu) {

--- a/Yafc/Widgets/ImmediateWidgets.cs
+++ b/Yafc/Widgets/ImmediateWidgets.cs
@@ -205,9 +205,7 @@ namespace Yafc {
         /// <param name="count">Maximum number of elements in the list. If there are more another popup can be opened by the user to show the full list.</param>
         /// <param name="width">Width of the popup. Make sure the header text fits!</param>
         /// <param name="allowNone">Whether to show a "Clear" option which sets the value to <c>null</c>.</param>
-        public static void BuildObjectSelectDropDown<T>(this ImGui gui, ICollection<T> list, IComparer<T> ordering, Action<T> select, string header, float width = 20f, int count = 6, bool multiple = false, Predicate<T> checkMark = null, bool allowNone = false, Func<T, string> extra = null) where T : FactorioObject {
-            gui.ShowDropDown(imGui => imGui.BuildInlineObjectListAndButton(list, ordering, select, header, count, multiple, checkMark, allowNone, extra), width);
-        }
+        public static void BuildObjectSelectDropDown<T>(this ImGui gui, ICollection<T> list, IComparer<T> ordering, Action<T> select, string header, float width = 20f, int count = 6, bool multiple = false, Predicate<T> checkMark = null, bool allowNone = false, Func<T, string> extra = null) where T : FactorioObject => gui.ShowDropDown(imGui => imGui.BuildInlineObjectListAndButton(list, ordering, select, header, count, multiple, checkMark, allowNone, extra), width);
 
         public static GoodsWithAmountEvent BuildFactorioObjectWithEditableAmount(this ImGui gui, FactorioObject obj, float amount, UnitOfMeasure unit, out float newAmount, SchemeColor color = SchemeColor.None) {
             using var group = gui.EnterGroup(default, RectAllocator.Stretch, spacing: 0f);

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -15,7 +15,7 @@ namespace Yafc {
         private void BuildHeader(ImGui gui) {
             using (gui.EnterGroup(new Padding(1f, 0.5f), RectAllocator.LeftAlign, spacing: 0f)) {
                 string name = target.text;
-                if (extendHeader && !(target is Goods)) {
+                if (extendHeader && target is not Goods) {
                     name = name + " (" + target.target.type + ")";
                 }
 
@@ -219,7 +219,7 @@ namespace Yafc {
 
                 BuildSubHeader(gui, energyUsage);
                 using (gui.EnterGroup(contentPadding)) {
-                    if (entity.energy.type == EntityEnergyType.FluidFuel || entity.energy.type == EntityEnergyType.SolidFuel || entity.energy.type == EntityEnergyType.FluidHeat) {
+                    if (entity.energy.type is EntityEnergyType.FluidFuel or EntityEnergyType.SolidFuel or EntityEnergyType.FluidHeat) {
                         BuildIconRow(gui, entity.energy.fuels, 2);
                     }
 

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -501,8 +501,6 @@ namespace Yafc {
             base.SetFocus(gui, rect);
         }
 
-        public bool IsSameObjectHovered(ImGui gui, FactorioObject factorioObject) {
-            return source == gui && factorioObject == target.target && gui.IsMouseOver(sourceRect);
-        }
+        public bool IsSameObjectHovered(ImGui gui, FactorioObject factorioObject) => source == gui && factorioObject == target.target && gui.IsMouseOver(sourceRect);
     }
 }

--- a/Yafc/Widgets/PseudoScreen.cs
+++ b/Yafc/Widgets/PseudoScreen.cs
@@ -68,7 +68,7 @@ namespace Yafc {
             if (key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_ESCAPE) {
                 Close(false);
             }
-            if (key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_RETURN || key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_RETURN2 || key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_KP_ENTER) {
+            if (key.scancode is SDL.SDL_Scancode.SDL_SCANCODE_RETURN or SDL.SDL_Scancode.SDL_SCANCODE_RETURN2 or SDL.SDL_Scancode.SDL_SCANCODE_KP_ENTER) {
                 ReturnPressed();
             }
 

--- a/Yafc/Widgets/PseudoScreen.cs
+++ b/Yafc/Widgets/PseudoScreen.cs
@@ -17,9 +17,7 @@ namespace Yafc {
             };
         }
 
-        public virtual void Open() {
-            opened = true;
-        }
+        public virtual void Open() => opened = true;
         public abstract void Build(ImGui gui);
 
         public void Build(ImGui gui, Vector2 screenSize) {
@@ -60,9 +58,7 @@ namespace Yafc {
 
         protected virtual void Save() { }
 
-        public void Rebuild() {
-            contents.Rebuild();
-        }
+        public void Rebuild() => contents.Rebuild();
 
         public virtual bool KeyDown(SDL.SDL_Keysym key) {
             if (key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_ESCAPE) {
@@ -77,18 +73,12 @@ namespace Yafc {
 
         protected virtual void ReturnPressed() { }
 
-        public virtual bool TextInput(string input) {
-            return true;
-        }
+        public virtual bool TextInput(string input) => true;
 
-        public virtual bool KeyUp(SDL.SDL_Keysym key) {
-            return true;
-        }
+        public virtual bool KeyUp(SDL.SDL_Keysym key) => true;
 
         public virtual void FocusChanged(bool focused) { }
-        public virtual void Activated() {
-            Rebuild();
-        }
+        public virtual void Activated() => Rebuild();
     }
 
     public abstract class PseudoScreen<T> : PseudoScreen {

--- a/Yafc/Widgets/SearchableList.cs
+++ b/Yafc/Widgets/SearchableList.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Numerics;
 using Yafc.UI;
 

--- a/Yafc/Widgets/SearchableList.cs
+++ b/Yafc/Widgets/SearchableList.cs
@@ -15,11 +15,11 @@ namespace Yafc {
         private readonly IComparer<TData> comparer;
         private readonly Filter filterFunc;
 
-        private IEnumerable<TData> _data = Array.Empty<TData>();
+        private IEnumerable<TData> _data = [];
         public new IEnumerable<TData> data {
             get => _data;
             set {
-                _data = value ?? Array.Empty<TData>();
+                _data = value ?? [];
                 RefreshData();
             }
         }

--- a/Yafc/Widgets/SearchableList.cs
+++ b/Yafc/Widgets/SearchableList.cs
@@ -9,7 +9,7 @@ namespace Yafc {
             filterFunc = filter;
             this.comparer = comparer;
         }
-        private readonly List<TData> list = new List<TData>();
+        private readonly List<TData> list = [];
 
         public delegate bool Filter(TData data, SearchQuery searchTokens);
         private readonly IComparer<TData> comparer;

--- a/Yafc/Widgets/SearchableList.cs
+++ b/Yafc/Widgets/SearchableList.cs
@@ -4,16 +4,12 @@ using System.Numerics;
 using Yafc.UI;
 
 namespace Yafc {
-    public class SearchableList<TData> : VirtualScrollList<TData> {
-        public SearchableList(float height, Vector2 elementSize, Drawer drawer, Filter filter, IComparer<TData> comparer = null) : base(height, elementSize, drawer) {
-            filterFunc = filter;
-            this.comparer = comparer;
-        }
+    public class SearchableList<TData>(float height, Vector2 elementSize, VirtualScrollList<TData>.Drawer drawer, SearchableList<TData>.Filter filter, IComparer<TData> comparer = null) : VirtualScrollList<TData>(height, elementSize, drawer) {
         private readonly List<TData> list = [];
 
         public delegate bool Filter(TData data, SearchQuery searchTokens);
-        private readonly IComparer<TData> comparer;
-        private readonly Filter filterFunc;
+
+        private readonly Filter filterFunc = filter;
 
         private IEnumerable<TData> _data = [];
         public new IEnumerable<TData> data {

--- a/Yafc/Windows/AboutScreen.cs
+++ b/Yafc/Windows/AboutScreen.cs
@@ -4,9 +4,7 @@ namespace Yafc {
     public class AboutScreen : WindowUtility {
         public const string Github = "https://github.com/have-fun-was-taken/yafc-ce";
 
-        public AboutScreen(Window parent) : base(ImGuiUtils.DefaultScreenPadding) {
-            Create("About YAFC-CE", 50, parent);
-        }
+        public AboutScreen(Window parent) : base(ImGuiUtils.DefaultScreenPadding) => Create("About YAFC-CE", 50, parent);
 
         protected override void BuildContents(ImGui gui) {
             gui.allocator = RectAllocator.Center;

--- a/Yafc/Windows/DependencyExplorer.cs
+++ b/Yafc/Windows/DependencyExplorer.cs
@@ -12,7 +12,7 @@ namespace Yafc {
         private readonly ScrollArea dependants;
         private static readonly Padding listPad = new Padding(0.5f);
 
-        private readonly List<FactorioObject> history = new List<FactorioObject>();
+        private readonly List<FactorioObject> history = [];
         private FactorioObject current;
 
         private static readonly Dictionary<DependencyList.Flags, (string name, string missingText)> dependencyListTexts = new Dictionary<DependencyList.Flags, (string, string)>()

--- a/Yafc/Windows/ErrorListPanel.cs
+++ b/Yafc/Windows/ErrorListPanel.cs
@@ -8,9 +8,7 @@ namespace Yafc {
         private readonly ScrollArea verticalList;
         private (string error, ErrorSeverity severity)[] errors;
 
-        public ErrorListPanel() : base(60f) {
-            verticalList = new ScrollArea(30f, BuildErrorList, default, true);
-        }
+        public ErrorListPanel() : base(60f) => verticalList = new ScrollArea(30f, BuildErrorList, default, true);
 
         private void BuildErrorList(ImGui gui) {
             foreach (var error in errors) {

--- a/Yafc/Windows/FilesystemScreen.cs
+++ b/Yafc/Windows/FilesystemScreen.cs
@@ -48,7 +48,7 @@ namespace Yafc {
             }
             gui.AllocateSpacing(0.5f);
             entries.Build(gui);
-            if (mode == Mode.SelectFolder || mode == Mode.SelectOrCreateFolder) {
+            if (mode is Mode.SelectFolder or Mode.SelectOrCreateFolder) {
                 BuildSelectButton(gui);
             }
             else {
@@ -77,13 +77,13 @@ namespace Yafc {
                 }
 
                 var data = Directory.EnumerateDirectories(directory).Select(x => (type: EntryType.Directory, path: x));
-                if (mode == Mode.SelectOrCreateFolder || mode == Mode.SelectOrCreateFile) {
+                if (mode is Mode.SelectOrCreateFolder or Mode.SelectOrCreateFile) {
                     data = data.Append((EntryType.CreateDirectory, directory));
                 }
 
                 string parent = Directory.GetParent(directory)?.FullName ?? "";
                 data = data.Prepend((EntryType.ParentDirectory, parent));
-                if (mode == Mode.SelectFile || mode == Mode.SelectOrCreateFile) {
+                if (mode is Mode.SelectFile or Mode.SelectOrCreateFile) {
                     fileName = defaultFileName;
                     IEnumerable<string> files = extension == null ? Directory.GetFiles(directory) : Directory.GetFiles(directory, "*." + extension);
                     if (filter != null) {

--- a/Yafc/Windows/FilesystemScreen.cs
+++ b/Yafc/Windows/FilesystemScreen.cs
@@ -125,19 +125,15 @@ namespace Yafc {
             rootGui.Rebuild();
         }
 
-        private (Icon, string) GetDisplay((EntryType type, string location) data) {
-            return data.type switch {
-                EntryType.Directory => (Icon.Folder, Path.GetFileName(data.location)),
-                EntryType.Drive => (Icon.FolderOpen, data.location),
-                EntryType.ParentDirectory => (Icon.Upload, ".."),
-                EntryType.CreateDirectory => (Icon.NewFolder, "Create directory here"),
-                _ => (Icon.Settings, Path.GetFileName(data.location)),
-            };
-        }
+        private (Icon, string) GetDisplay((EntryType type, string location) data) => data.type switch {
+            EntryType.Directory => (Icon.Folder, Path.GetFileName(data.location)),
+            EntryType.Drive => (Icon.FolderOpen, data.location),
+            EntryType.ParentDirectory => (Icon.Upload, ".."),
+            EntryType.CreateDirectory => (Icon.NewFolder, "Create directory here"),
+            _ => (Icon.Settings, Path.GetFileName(data.location)),
+        };
 
-        public new void Close() {
-            base.Close();
-        }
+        public new void Close() => base.Close();
 
         private void BuildElement(ImGui gui, (EntryType type, string location) element, int index) {
             var (icon, elementText) = GetDisplay(element);

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -17,7 +17,7 @@ namespace Yafc {
         public static readonly Guid SummaryGuid = Guid.Parse("9bdea333-4be2-4be3-b708-b36a64672a40");
         public static MainScreen Instance { get; private set; }
         private readonly ObjectTooltip objectTooltip = new ObjectTooltip();
-        private readonly List<PseudoScreen> pseudoScreens = new List<PseudoScreen>();
+        private readonly List<PseudoScreen> pseudoScreens = [];
         private readonly VirtualScrollList<ProjectPage> allPages;
         private readonly MainScreenTabBar tabBar;
         private readonly FadeDrawer fadeDrawer = new FadeDrawer();
@@ -36,12 +36,12 @@ namespace Yafc {
         private bool analysisUpdatePending;
         private SearchQuery pageSearch;
         private SearchQuery pageListSearch;
-        private readonly List<ProjectPage> sortedAndFilteredPageList = new List<ProjectPage>();
+        private readonly List<ProjectPage> sortedAndFilteredPageList = [];
         private readonly ImGui searchGui;
         private Rect searchBoxRect;
 
-        private readonly Dictionary<Type, ProjectPageView> registeredPageViews = new Dictionary<Type, ProjectPageView>();
-        private readonly Dictionary<Type, ProjectPageView> secondaryPageViews = new Dictionary<Type, ProjectPageView>();
+        private readonly Dictionary<Type, ProjectPageView> registeredPageViews = [];
+        private readonly Dictionary<Type, ProjectPageView> secondaryPageViews = [];
 
         public MainScreen(int display, Project project) : base(default) {
             summaryView = new SummaryView();

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -186,9 +186,7 @@ namespace Yafc {
             }
         }
 
-        public void RegisterPageView<T>(ProjectPageView pageView) where T : ProjectPageContents {
-            registeredPageViews[typeof(T)] = pageView;
-        }
+        public void RegisterPageView<T>(ProjectPageView pageView) where T : ProjectPageContents => registeredPageViews[typeof(T)] = pageView;
 
         public void RebuildProjectView() {
             rootGui.MarkEverythingForRebuild();
@@ -340,9 +338,7 @@ namespace Yafc {
             }
         }
 
-        private void ShowNeie() {
-            SelectSingleObjectPanel.Select(Database.goods.all, "Open NEIE", NeverEnoughItemsPanel.Show);
-        }
+        private void ShowNeie() => SelectSingleObjectPanel.Select(Database.goods.all, "Open NEIE", NeverEnoughItemsPanel.Show);
 
         private void SetSearch(SearchQuery searchQuery) {
             pageSearch = searchQuery;
@@ -537,9 +533,7 @@ namespace Yafc {
             rootGui.Rebuild();
         }
 
-        public void ClosePage(Guid page) {
-            _ = project.RecordUndo(true).displayPages.Remove(page);
-        }
+        public void ClosePage(Guid page) => _ = project.RecordUndo(true).displayPages.Remove(page);
 
         public void ShowSummaryTab() {
 
@@ -654,18 +648,12 @@ namespace Yafc {
             ForceClose();
         }
 
-        public bool TextInput(string input) {
-            return true;
-        }
+        public bool TextInput(string input) => true;
 
-        public bool KeyUp(SDL.SDL_Keysym key) {
-            return true;
-        }
+        public bool KeyUp(SDL.SDL_Keysym key) => true;
 
         public void FocusChanged(bool focused) { }
-        private new void MainRender() {
-            base.MainRender();
-        }
+        private new void MainRender() => base.MainRender();
 
         private class FadeDrawer : IRenderable {
             private SDL.SDL_Rect srcRect;
@@ -703,13 +691,9 @@ namespace Yafc {
             }
         }
 
-        public void Report((string, string) value) {
-            Console.WriteLine(value); // TODO
-        }
+        public void Report((string, string) value) => Console.WriteLine(value); // TODO
 
-        public bool IsSameObjectHovered(ImGui gui, FactorioObject obj) {
-            return objectTooltip.IsSameObjectHovered(gui, obj);
-        }
+        public bool IsSameObjectHovered(ImGui gui, FactorioObject obj) => objectTooltip.IsSameObjectHovered(gui, obj);
 
         public void ShowTooltip(ImGui gui, ProjectPage page, bool isMiddleEdit, Rect rect) {
             if (page == null || !registeredPageViews.TryGetValue(page.content.GetType(), out var pageView)) {

--- a/Yafc/Windows/MessageBox.cs
+++ b/Yafc/Windows/MessageBox.cs
@@ -13,9 +13,7 @@ namespace Yafc {
             _ = MainScreen.Instance.ShowPseudoScreen(instance);
         }
 
-        public static void Show(string title, string message, string yes) {
-            Show(null, title, message, yes, null);
-        }
+        public static void Show(string title, string message, string yes) => Show(null, title, message, yes, null);
 
         public static Task<(bool haveChoice, bool choice)> Show(string title, string message, string yes, string no) {
             TaskCompletionSource<(bool, bool)> tcs = new TaskCompletionSource<(bool, bool)>();

--- a/Yafc/Windows/MilestonesEditor.cs
+++ b/Yafc/Windows/MilestonesEditor.cs
@@ -17,9 +17,7 @@ namespace Yafc {
             milestoneList.data = Project.current.settings.milestones;
         }
 
-        public static void Show() {
-            _ = MainScreen.Instance.ShowPseudoScreen(Instance);
-        }
+        public static void Show() => _ = MainScreen.Instance.ShowPseudoScreen(Instance);
 
         private void MilestoneDrawer(ImGui gui, FactorioObject element, int index) {
             using (gui.EnterRow()) {

--- a/Yafc/Windows/MilestonesEditor.cs
+++ b/Yafc/Windows/MilestonesEditor.cs
@@ -8,9 +8,7 @@ namespace Yafc {
         private static readonly MilestonesEditor Instance = new MilestonesEditor();
         private readonly VirtualScrollList<FactorioObject> milestoneList;
 
-        public MilestonesEditor() {
-            milestoneList = new VirtualScrollList<FactorioObject>(30f, new Vector2(float.PositiveInfinity, 3f), MilestoneDrawer);
-        }
+        public MilestonesEditor() => milestoneList = new VirtualScrollList<FactorioObject>(30f, new Vector2(float.PositiveInfinity, 3f), MilestoneDrawer);
 
         public override void Open() {
             base.Open();

--- a/Yafc/Windows/MilestonesPanel.cs
+++ b/Yafc/Windows/MilestonesPanel.cs
@@ -6,9 +6,7 @@ namespace Yafc {
     public class MilestonesWidget : VirtualScrollList<FactorioObject> {
         public static readonly MilestonesWidget Instance = new MilestonesWidget();
 
-        public MilestonesWidget() : base(30f, new Vector2(3f, 3f), MilestoneDrawer) {
-            data = Project.current.settings.milestones;
-        }
+        public MilestonesWidget() : base(30f, new Vector2(3f, 3f), MilestoneDrawer) => data = Project.current.settings.milestones;
 
         private static void MilestoneDrawer(ImGui gui, FactorioObject element, int index) {
             var settings = Project.current.settings;

--- a/Yafc/Windows/NeverEnoughItemsPanel.cs
+++ b/Yafc/Windows/NeverEnoughItemsPanel.cs
@@ -9,7 +9,7 @@ namespace Yafc {
         private Goods changing;
         private float currentFlow;
         private EntryStatus showRecipesRange = EntryStatus.Normal;
-        private readonly List<Goods> recent = new List<Goods>();
+        private readonly List<Goods> recent = [];
         private bool atCurrentMilestones;
 
         private readonly ScrollArea productionList;
@@ -57,8 +57,8 @@ namespace Yafc {
             }
         }
 
-        private readonly List<RecipeEntry> productions = new List<RecipeEntry>();
-        private readonly List<RecipeEntry> usages = new List<RecipeEntry>();
+        private readonly List<RecipeEntry> productions = [];
+        private readonly List<RecipeEntry> usages = [];
 
         public NeverEnoughItemsPanel() : base(76f) {
             productionList = new ScrollArea(40f, BuildItemProduction, new Padding(0.5f));

--- a/Yafc/Windows/NeverEnoughItemsPanel.cs
+++ b/Yafc/Windows/NeverEnoughItemsPanel.cs
@@ -308,13 +308,9 @@ namespace Yafc {
             CheckChanging();
         }
 
-        private void BuildItemProduction(ImGui gui) {
-            DrawEntryList(gui, productions, true);
-        }
+        private void BuildItemProduction(ImGui gui) => DrawEntryList(gui, productions, true);
 
-        private void BuildItemUsages(ImGui gui) {
-            DrawEntryList(gui, usages, false);
-        }
+        private void BuildItemUsages(ImGui gui) => DrawEntryList(gui, usages, false);
 
         public override void Build(ImGui gui) {
             BuildHeader(gui, "Never Enough Items Explorer");

--- a/Yafc/Windows/NeverEnoughItemsPanel.cs
+++ b/Yafc/Windows/NeverEnoughItemsPanel.cs
@@ -169,7 +169,7 @@ namespace Yafc {
                         gui.BuildIcon(Icon.Time);
                         gui.BuildText(DataUtils.FormatAmount(entry.recipe.time, UnitOfMeasure.Second), align: RectAlignment.Middle);
                     }
-                    float bh = CostAnalysis.Instance.GetBuildingHours(recipe, entry.recipeFlow);
+                    float bh = CostAnalysis.GetBuildingHours(recipe, entry.recipeFlow);
                     if (bh > 20) {
                         gui.BuildText(DataUtils.FormatAmount(bh, UnitOfMeasure.None, suffix: "bh"), align: RectAlignment.Middle);
                         _ = gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.Grey).WithTooltip(gui, "Building-hours.\nAmount of building-hours required for all researches assuming crafting speed of 1");

--- a/Yafc/Windows/PreferencesScreen.cs
+++ b/Yafc/Windows/PreferencesScreen.cs
@@ -148,8 +148,6 @@ namespace Yafc {
             }
         }
 
-        public static void Show() {
-            _ = MainScreen.Instance.ShowPseudoScreen(Instance);
-        }
+        public static void Show() => _ = MainScreen.Instance.ShowPseudoScreen(Instance);
     }
 }

--- a/Yafc/Windows/PreferencesScreen.cs
+++ b/Yafc/Windows/PreferencesScreen.cs
@@ -24,7 +24,7 @@ namespace Yafc {
                     prefs.RecordUndo(true).time = 3600;
                 }
 
-                if (gui.BuildRadioButton("Custom", prefs.time != 1 && prefs.time != 60 && prefs.time != 3600)) {
+                if (gui.BuildRadioButton("Custom", prefs.time is not 1 and not 60 and not 3600)) {
                     prefs.RecordUndo(true).time = 0;
                 }
 

--- a/Yafc/Windows/ProjectPageSettingsPanel.cs
+++ b/Yafc/Windows/ProjectPageSettingsPanel.cs
@@ -138,7 +138,7 @@ namespace Yafc {
 
             public ExportRow(RecipeRow row) {
                 Header = row.recipe is null ? null : new ExportRecipe(row);
-                Children = row.subgroup?.recipes.Select(r => new ExportRow(r)) ?? Array.Empty<ExportRow>();
+                Children = row.subgroup?.recipes.Select(r => new ExportRow(r)) ?? [];
             }
         }
 
@@ -165,7 +165,7 @@ namespace Yafc {
                 BeaconCount = row.parameters.modules.beaconCount;
 
                 if (row.parameters.modules.modules is null) {
-                    Modules = BeaconModules = Array.Empty<string>();
+                    Modules = BeaconModules = [];
                 }
                 else {
                     List<string> modules = new List<string>();

--- a/Yafc/Windows/ProjectPageSettingsPanel.cs
+++ b/Yafc/Windows/ProjectPageSettingsPanel.cs
@@ -132,14 +132,9 @@ namespace Yafc {
             }
         }
 
-        private class ExportRow {
-            public ExportRecipe Header { get; }
-            public IEnumerable<ExportRow> Children { get; }
-
-            public ExportRow(RecipeRow row) {
-                Header = row.recipe is null ? null : new ExportRecipe(row);
-                Children = row.subgroup?.recipes.Select(r => new ExportRow(r)) ?? [];
-            }
+        private class ExportRow(RecipeRow row) {
+            public ExportRecipe Header { get; } = row.recipe is null ? null : new ExportRecipe(row);
+            public IEnumerable<ExportRow> Children { get; } = row.subgroup?.recipes.Select(r => new ExportRow(r)) ?? [];
         }
 
         private class ExportRecipe {
@@ -186,14 +181,9 @@ namespace Yafc {
             }
         }
 
-        private class ExportMaterial {
-            public string Name { get; }
-            public double CountPerSecond { get; }
-
-            public ExportMaterial(string name, double countPerSecond) {
-                Name = name;
-                CountPerSecond = countPerSecond;
-            }
+        private class ExportMaterial(string name, double countPerSecond) {
+            public string Name { get; } = name;
+            public double CountPerSecond { get; } = countPerSecond;
         }
 
         private static void ExportPage(ProjectPage page) {

--- a/Yafc/Windows/ProjectPageSettingsPanel.cs
+++ b/Yafc/Windows/ProjectPageSettingsPanel.cs
@@ -168,8 +168,8 @@ namespace Yafc {
                     Modules = BeaconModules = [];
                 }
                 else {
-                    List<string> modules = new List<string>();
-                    List<string> beaconModules = new List<string>();
+                    List<string> modules = [];
+                    List<string> beaconModules = [];
 
                     foreach (var (module, count, isBeacon) in row.parameters.modules.modules) {
                         if (isBeacon) {
@@ -215,7 +215,7 @@ namespace Yafc {
                 deflateStream.CopyTo(ms);
                 byte[] bytes = ms.GetBuffer();
                 int index = 0;
-                if (DataUtils.ReadLine(bytes, ref index) != "YAFC" || DataUtils.ReadLine(bytes, ref index) != "ProjectPage") {
+                if (DataUtils.ReadLine(bytes, ref index) is not "YAFC" or not "ProjectPage") {
                     throw new InvalidDataException();
                 }
 

--- a/Yafc/Windows/SelectMultiObjectPanel.cs
+++ b/Yafc/Windows/SelectMultiObjectPanel.cs
@@ -14,9 +14,7 @@ namespace Yafc {
 
         public SelectMultiObjectPanel() : base() { }
 
-        public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, bool allowNone = false, Predicate<T> checkMark = null) where T : FactorioObject {
-            Select(list, header, select, DataUtils.DefaultOrdering, allowNone, checkMark);
-        }
+        public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, bool allowNone = false, Predicate<T> checkMark = null) where T : FactorioObject => Select(list, header, select, DataUtils.DefaultOrdering, allowNone, checkMark);
 
         public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, IComparer<T> ordering, bool allowNone = false, Predicate<T> checkMark = null) where T : FactorioObject {
             Instance.allowAutoClose = true;
@@ -57,8 +55,6 @@ namespace Yafc {
             }
         }
 
-        protected override void ReturnPressed() {
-            CloseWithResult(results);
-        }
+        protected override void ReturnPressed() => CloseWithResult(results);
     }
 }

--- a/Yafc/Windows/SelectMultiObjectPanel.cs
+++ b/Yafc/Windows/SelectMultiObjectPanel.cs
@@ -8,7 +8,7 @@ using Yafc.UI;
 namespace Yafc {
     public class SelectMultiObjectPanel : SelectObjectPanel<IEnumerable<FactorioObject>> {
         private static readonly SelectMultiObjectPanel Instance = new SelectMultiObjectPanel();
-        private readonly HashSet<FactorioObject> results = new HashSet<FactorioObject>();
+        private readonly HashSet<FactorioObject> results = [];
         private bool allowAutoClose;
         private Predicate<FactorioObject> checkMark;
 

--- a/Yafc/Windows/SelectObjectPanel.cs
+++ b/Yafc/Windows/SelectObjectPanel.cs
@@ -12,9 +12,7 @@ namespace Yafc {
         protected Rect searchBox;
         protected bool extendHeader;
 
-        protected SelectObjectPanel() : base(40f) {
-            list = new SearchableList<FactorioObject>(30, new Vector2(2.5f, 2.5f), ElementDrawer, ElementFilter);
-        }
+        protected SelectObjectPanel() : base(40f) => list = new SearchableList<FactorioObject>(30, new Vector2(2.5f, 2.5f), ElementDrawer, ElementFilter);
 
         protected void Select<U>(IEnumerable<U> list, string header, Action<U> select, IComparer<U> ordering, Action<T, Action<FactorioObject>> process, bool allowNone) where U : FactorioObject {
             _ = MainScreen.Instance.ShowPseudoScreen(this);

--- a/Yafc/Windows/SelectObjectPanel.cs
+++ b/Yafc/Windows/SelectObjectPanel.cs
@@ -43,9 +43,7 @@ namespace Yafc {
             });
         }
 
-        protected void Select<U>(IEnumerable<U> list, string header, Action<U> select, Action<T, Action<FactorioObject>> process, bool allowNone = false) where U : FactorioObject {
-            Select(list, header, select, DataUtils.DefaultOrdering, process, allowNone);
-        }
+        protected void Select<U>(IEnumerable<U> list, string header, Action<U> select, Action<T, Action<FactorioObject>> process, bool allowNone = false) where U : FactorioObject => Select(list, header, select, DataUtils.DefaultOrdering, process, allowNone);
 
         private void ElementDrawer(ImGui gui, FactorioObject element, int index) {
             if (element == null) {
@@ -60,9 +58,7 @@ namespace Yafc {
 
         protected abstract void NonNullElementDrawer(ImGui gui, FactorioObject element, int index);
 
-        private bool ElementFilter(FactorioObject data, SearchQuery query) {
-            return data.Match(query);
-        }
+        private bool ElementFilter(FactorioObject data, SearchQuery query) => data.Match(query);
 
         public override void Build(ImGui gui) {
             BuildHeader(gui, header);

--- a/Yafc/Windows/SelectSingleObjectPanel.cs
+++ b/Yafc/Windows/SelectSingleObjectPanel.cs
@@ -8,13 +8,9 @@ namespace Yafc {
         private static readonly SelectSingleObjectPanel Instance = new SelectSingleObjectPanel();
         public SelectSingleObjectPanel() : base() { }
 
-        public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, bool allowNone = false) where T : FactorioObject {
-            Select(list, header, select, DataUtils.DefaultOrdering, allowNone);
-        }
+        public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, bool allowNone = false) where T : FactorioObject => Select(list, header, select, DataUtils.DefaultOrdering, allowNone);
 
-        public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, IComparer<T> ordering, bool allowNone = false) where T : FactorioObject {
-            Instance.Select(list, header, select, ordering, (x, selectItem) => selectItem(x), allowNone);
-        }
+        public static void Select<T>(IEnumerable<T> list, string header, Action<T> select, IComparer<T> ordering, bool allowNone = false) where T : FactorioObject => Instance.Select(list, header, select, ordering, (x, selectItem) => selectItem(x), allowNone);
 
         protected override void NonNullElementDrawer(ImGui gui, FactorioObject element, int index) {
             if (gui.BuildFactorioObjectButton(element, display: MilestoneDisplay.Contained, extendHeader: extendHeader)) {

--- a/Yafc/Windows/ShoppingListScreen.cs
+++ b/Yafc/Windows/ShoppingListScreen.cs
@@ -68,7 +68,7 @@ namespace Yafc {
         }
 
         private List<(T, int)> ExportGoods<T>() where T : Goods {
-            List<(T, int)> items = new List<(T, int)>();
+            List<(T, int)> items = [];
             foreach (var (element, amount) in list.data) {
                 int rounded = MathUtils.Round(amount);
                 if (rounded == 0) {
@@ -117,7 +117,7 @@ namespace Yafc {
         private void Decompose() {
             decomposed = true;
             Queue<FactorioObject> decompositionQueue = new Queue<FactorioObject>();
-            Dictionary<FactorioObject, float> decomposeResult = new Dictionary<FactorioObject, float>();
+            Dictionary<FactorioObject, float> decomposeResult = [];
 
             void AddDecomposition(FactorioObject obj, float amount) {
                 if (!decomposeResult.TryGetValue(obj, out float prev)) {

--- a/Yafc/Windows/ShoppingListScreen.cs
+++ b/Yafc/Windows/ShoppingListScreen.cs
@@ -13,9 +13,7 @@ namespace Yafc {
         private float shoppingCost, totalBuildings, totalModules;
         private bool decomposed = false;
 
-        private ShoppingListScreen() {
-            list = new VirtualScrollList<(FactorioObject, float)>(30f, new Vector2(float.PositiveInfinity, 2), ElementDrawer);
-        }
+        private ShoppingListScreen() => list = new VirtualScrollList<(FactorioObject, float)>(30f, new Vector2(float.PositiveInfinity, 2), ElementDrawer);
 
         private void ElementDrawer(ImGui gui, (FactorioObject obj, float count) element, int index) {
             using (gui.EnterRow()) {

--- a/Yafc/Windows/WelcomeScreen.cs
+++ b/Yafc/Windows/WelcomeScreen.cs
@@ -228,17 +228,11 @@ namespace Yafc {
             }
         }
 
-        public void Report((string, string) value) {
-            (currentLoad1, currentLoad2) = value;
-        }
+        public void Report((string, string) value) => (currentLoad1, currentLoad2) = value;
 
-        private bool FactorioValid(string factorio) {
-            return !string.IsNullOrEmpty(factorio) && Directory.Exists(Path.Combine(factorio, "core"));
-        }
+        private bool FactorioValid(string factorio) => !string.IsNullOrEmpty(factorio) && Directory.Exists(Path.Combine(factorio, "core"));
 
-        private bool ModsValid(string mods) {
-            return string.IsNullOrEmpty(mods) || File.Exists(Path.Combine(mods, "mod-list.json"));
-        }
+        private bool ModsValid(string mods) => string.IsNullOrEmpty(mods) || File.Exists(Path.Combine(mods, "mod-list.json"));
 
         private void ValidateSelection() {
             bool factorioValid = FactorioValid(dataPath);
@@ -352,13 +346,11 @@ namespace Yafc {
             }
         }
 
-        private Func<string, bool> GetFolderFilter(EditType type) {
-            return type switch {
-                EditType.Mods => ModsValid,
-                EditType.Factorio => FactorioValid,
-                _ => null,
-            };
-        }
+        private Func<string, bool> GetFolderFilter(EditType type) => type switch {
+            EditType.Mods => ModsValid,
+            EditType.Factorio => FactorioValid,
+            _ => null,
+        };
 
         private async void ShowFileSelect(string description, string path, EditType type) {
             string result = await new FilesystemScreen("Select folder", description, type == EditType.Workspace ? "Select" : "Select folder", type == EditType.Workspace ? Path.GetDirectoryName(path) : path,
@@ -380,9 +372,7 @@ namespace Yafc {
             }
         }
 
-        private void BuildRecentProjectsDropdown(ImGui gui) {
-            recentProjectScroll.Build(gui);
-        }
+        private void BuildRecentProjectsDropdown(ImGui gui) => recentProjectScroll.Build(gui);
 
         private void BuildRecentProjectList(ImGui gui) {
             gui.spacing = 0f;

--- a/Yafc/Windows/WizardPanel.cs
+++ b/Yafc/Windows/WizardPanel.cs
@@ -6,7 +6,7 @@ namespace Yafc {
     public class WizardPanel : PseudoScreen {
         public static readonly WizardPanel Instance = new WizardPanel();
 
-        private readonly List<PageBuilder> pages = new List<PageBuilder>();
+        private readonly List<PageBuilder> pages = [];
         private string header;
         private Action finish;
         private int page;

--- a/Yafc/Workspace/AutoPlannerView.cs
+++ b/Yafc/Workspace/AutoPlannerView.cs
@@ -21,7 +21,7 @@ namespace Yafc {
         }
 
         private Action CreateAutoPlannerWizard(List<WizardPanel.PageBuilder> pages) {
-            List<AutoPlannerGoal> goal = new List<AutoPlannerGoal>();
+            List<AutoPlannerGoal> goal = [];
             string pageName = "Auto planner";
 
             void Page1(ImGui gui, ref bool valid) {

--- a/Yafc/Workspace/ProductionSummary/ProductionSummaryView.cs
+++ b/Yafc/Workspace/ProductionSummary/ProductionSummaryView.cs
@@ -11,7 +11,7 @@ namespace Yafc {
         private readonly DataGrid<ProductionSummaryEntry> grid;
         private readonly FlatHierarchy<ProductionSummaryEntry, ProductionSummaryGroup> flatHierarchy;
         private Goods filteredGoods;
-        private readonly Dictionary<ProductionSummaryColumn, GoodsColumn> goodsToColumn = new Dictionary<ProductionSummaryColumn, GoodsColumn>();
+        private readonly Dictionary<ProductionSummaryColumn, GoodsColumn> goodsToColumn = [];
         private readonly PaddingColumn padding;
         private readonly SummaryColumn firstColumn;
         private readonly RestGoodsColumn lastColumn;
@@ -233,7 +233,7 @@ namespace Yafc {
 
             int index = 2;
             foreach (var column in model.columns) {
-                if (!(grid.columns[index++] is GoodsColumn goodsColumn) || goodsColumn.goods != column.goods) {
+                if (grid.columns[index++] is not GoodsColumn goodsColumn || goodsColumn.goods != column.goods) {
                     return false;
                 }
             }

--- a/Yafc/Workspace/ProductionSummary/ProductionSummaryView.cs
+++ b/Yafc/Workspace/ProductionSummary/ProductionSummaryView.cs
@@ -55,9 +55,7 @@ namespace Yafc {
                 pagesDropdown = new SearchableList<ProjectPage>(30f, new Vector2(20f, 2f), PagesDropdownDrawer, PagesDropdownFilter);
             }
 
-            public override void BuildHeader(ImGui gui) {
-                BuildButtons(gui, 2f, view.model.group);
-            }
+            public override void BuildHeader(ImGui gui) => BuildButtons(gui, 2f, view.model.group);
 
             private void BuildButtons(ImGui gui, float size, ProductionSummaryGroup group) {
                 using (gui.EnterRow()) {
@@ -134,9 +132,7 @@ namespace Yafc {
                 }
             }
 
-            private bool PagesDropdownFilter(ProjectPage data, SearchQuery searchTokens) {
-                return searchTokens.Match(data.name);
-            }
+            private bool PagesDropdownFilter(ProjectPage data, SearchQuery searchTokens) => searchTokens.Match(data.name);
 
             private void PagesDropdownDrawer(ImGui gui, ProjectPage element, int index) {
                 using (gui.EnterGroup(new Padding(1f, 0.25f), RectAllocator.LeftRow)) {

--- a/Yafc/Workspace/ProductionSummary/ProductionSummaryView.cs
+++ b/Yafc/Workspace/ProductionSummary/ProductionSummaryView.cs
@@ -27,9 +27,7 @@ namespace Yafc {
         private class PaddingColumn : DataColumn<ProductionSummaryEntry> {
             private readonly ProductionSummaryView view;
 
-            public PaddingColumn(ProductionSummaryView view) : base(3f) {
-                this.view = view;
-            }
+            public PaddingColumn(ProductionSummaryView view) : base(3f) => this.view = view;
 
             public override void BuildHeader(ImGui gui) { }
 
@@ -190,9 +188,7 @@ namespace Yafc {
 
         private class RestGoodsColumn : TextDataColumn<ProductionSummaryEntry> {
             private readonly ProductionSummaryView view;
-            public RestGoodsColumn(ProductionSummaryView view) : base("Other", 30f, 5f, 40f) {
-                this.view = view;
-            }
+            public RestGoodsColumn(ProductionSummaryView view) : base("Other", 30f, 5f, 40f) => this.view = view;
 
             public override void BuildElement(ImGui gui, ProductionSummaryEntry data) {
                 using var grid = gui.EnterInlineGrid(2.1f);

--- a/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -134,15 +134,13 @@ namespace Yafc {
             }
         }
 
-        private void SelectBeacon(ImGui gui) {
-            gui.BuildObjectSelectDropDown<EntityBeacon>(Database.allBeacons, DataUtils.DefaultOrdering, sel => {
-                if (modules != null) {
-                    modules.RecordUndo().beacon = sel;
-                }
+        private void SelectBeacon(ImGui gui) => gui.BuildObjectSelectDropDown<EntityBeacon>(Database.allBeacons, DataUtils.DefaultOrdering, sel => {
+            if (modules != null) {
+                modules.RecordUndo().beacon = sel;
+            }
 
-                contents.Rebuild();
-            }, "Select beacon", allowNone: modules.beacon != null);
-        }
+            contents.Rebuild();
+        }, "Select beacon", allowNone: modules.beacon != null);
 
         private ICollection<Item> GetModules(EntityBeacon beacon) {
             var modules = (beacon == null && recipe != null) ? recipe.recipe.modules : Database.allModules;

--- a/Yafc/Workspace/ProductionTable/ModuleTemplateConfiguration.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleTemplateConfiguration.cs
@@ -9,10 +9,8 @@ namespace Yafc {
         private ProjectModuleTemplate pageToDelete;
         private string newPageName = "";
 
-        public ModuleTemplateConfiguration() {
-            templateList = new VirtualScrollList<ProjectModuleTemplate>(30, new Vector2(20, 2.5f), Drawer,
+        public ModuleTemplateConfiguration() => templateList = new VirtualScrollList<ProjectModuleTemplate>(30, new Vector2(20, 2.5f), Drawer,
                 reorder: (from, to) => Project.current.RecordUndo().sharedModuleTemplates.MoveListElementIndex(from, to));
-        }
 
         public static void Show() {
             Instance.RefreshList();

--- a/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
@@ -12,9 +12,7 @@ namespace Yafc {
         private float totalInput, totalOutput;
         private readonly ScrollArea scrollArea;
 
-        private ProductionLinkSummaryScreen() {
-            scrollArea = new ScrollArea(30, BuildScrollArea);
-        }
+        private ProductionLinkSummaryScreen() => scrollArea = new ScrollArea(30, BuildScrollArea);
 
         private void BuildScrollArea(ImGui gui) {
             gui.BuildText("Production: " + DataUtils.FormatAmount(totalInput, link.goods.flowUnitOfMeasure), Font.subheader);

--- a/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
@@ -79,8 +79,6 @@ namespace Yafc {
             _ = MainScreen.Instance.ShowPseudoScreen(Instance);
         }
 
-        public int Compare((RecipeRow row, float flow) x, (RecipeRow row, float flow) y) {
-            return y.flow.CompareTo(x.flow);
-        }
+        public int Compare((RecipeRow row, float flow) x, (RecipeRow row, float flow) y) => y.flow.CompareTo(x.flow);
     }
 }

--- a/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
@@ -7,8 +7,8 @@ namespace Yafc {
     public class ProductionLinkSummaryScreen : PseudoScreen, IComparer<(RecipeRow row, float flow)> {
         private static readonly ProductionLinkSummaryScreen Instance = new ProductionLinkSummaryScreen();
         private ProductionLink link;
-        private readonly List<(RecipeRow row, float flow)> input = new List<(RecipeRow, float)>();
-        private readonly List<(RecipeRow row, float flow)> output = new List<(RecipeRow, float)>();
+        private readonly List<(RecipeRow row, float flow)> input = [];
+        private readonly List<(RecipeRow row, float flow)> output = [];
         private float totalInput, totalOutput;
         private readonly ScrollArea scrollArea;
 

--- a/Yafc/Workspace/ProductionTable/ProductionTableFlatHierarchy.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableFlatHierarchy.cs
@@ -18,9 +18,9 @@ namespace Yafc {
     /// </summary>
     public class FlatHierarchy<TRow, TGroup> where TRow : ModelObject<TGroup>, IGroupedElement<TGroup> where TGroup : ModelObject<ModelObject>, IElementGroup<TRow> {
         private readonly DataGrid<TRow> grid;
-        private readonly List<TRow> flatRecipes = new List<TRow>();
-        private readonly List<TGroup> flatGroups = new List<TGroup>();
-        private readonly List<RowHighlighting> rowHighlighting = new List<RowHighlighting>();
+        private readonly List<TRow> flatRecipes = [];
+        private readonly List<TGroup> flatGroups = [];
+        private readonly List<RowHighlighting> rowHighlighting = [];
         private TRow draggingRecipe;
         private TGroup root;
         private bool rebuildRequired;

--- a/Yafc/Workspace/ProductionTable/ProductionTableFlatHierarchy.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableFlatHierarchy.cs
@@ -262,9 +262,7 @@ namespace Yafc {
             }
         }
 
-        public void BuildHeader(ImGui gui) {
-            grid.BuildHeader(gui);
-        }
+        public void BuildHeader(ImGui gui) => grid.BuildHeader(gui);
 
         /// <summary>
         /// This method is used to determine the background color for a highlighted row. To avoid
@@ -277,15 +275,13 @@ namespace Yafc {
         /// If the row is not enabled, a fainter color is used.
         /// </param>
         /// <returns></returns>
-        private static SchemeColor GetHighlightingBackgroundColor(RowHighlighting highlighting, bool isEnabled) {
-            return highlighting switch {
-                RowHighlighting.Green => isEnabled ? SchemeColor.TagColorGreen : SchemeColor.TagColorGreenAlt,
-                RowHighlighting.Yellow => isEnabled ? SchemeColor.TagColorYellow : SchemeColor.TagColorYellowAlt,
-                RowHighlighting.Red => isEnabled ? SchemeColor.TagColorRed : SchemeColor.TagColorRedAlt,
-                RowHighlighting.Blue => isEnabled ? SchemeColor.TagColorBlue : SchemeColor.TagColorBlueAlt,
-                _ => SchemeColor.None
-            };
-        }
+        private static SchemeColor GetHighlightingBackgroundColor(RowHighlighting highlighting, bool isEnabled) => highlighting switch {
+            RowHighlighting.Green => isEnabled ? SchemeColor.TagColorGreen : SchemeColor.TagColorGreenAlt,
+            RowHighlighting.Yellow => isEnabled ? SchemeColor.TagColorYellow : SchemeColor.TagColorYellowAlt,
+            RowHighlighting.Red => isEnabled ? SchemeColor.TagColorRed : SchemeColor.TagColorRedAlt,
+            RowHighlighting.Blue => isEnabled ? SchemeColor.TagColorBlue : SchemeColor.TagColorBlueAlt,
+            _ => SchemeColor.None
+        };
 
         /// <summary>
         /// This method is used to determine the text color for a highlighted row. To avoid
@@ -295,14 +291,12 @@ namespace Yafc {
         /// Represents the highlighting state for which the corresponding color needs to be determined.
         /// </param>
         /// <returns></returns>
-        private static SchemeColor GetHighlightingTextColor(RowHighlighting highlighting) {
-            return highlighting switch {
-                RowHighlighting.Green => SchemeColor.TagColorGreenText,
-                RowHighlighting.Yellow => SchemeColor.TagColorYellowText,
-                RowHighlighting.Red => SchemeColor.TagColorRedText,
-                RowHighlighting.Blue => SchemeColor.TagColorBlueText,
-                _ => SchemeColor.None
-            };
-        }
+        private static SchemeColor GetHighlightingTextColor(RowHighlighting highlighting) => highlighting switch {
+            RowHighlighting.Green => SchemeColor.TagColorGreenText,
+            RowHighlighting.Yellow => SchemeColor.TagColorYellowText,
+            RowHighlighting.Red => SchemeColor.TagColorRedText,
+            RowHighlighting.Blue => SchemeColor.TagColorBlueText,
+            _ => SchemeColor.None
+        };
     }
 }

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -227,7 +227,7 @@ goodsHaveNoProduction:;
             }
 
             private void ExportIo(float multiplier) {
-                List<(Goods, int)> goods = new List<(Goods, int)>();
+                List<(Goods, int)> goods = [];
                 foreach (var link in view.model.links) {
                     int rounded = MathUtils.Round(link.amount * multiplier);
                     if (rounded == 0) {
@@ -351,13 +351,13 @@ goodsHaveNoProduction:;
 
                     if (recipe.entity != null && gui.BuildButton("Create single building blueprint") && gui.CloseDropdown()) {
                         BlueprintEntity entity = new BlueprintEntity { index = 1, name = recipe.entity.name };
-                        if (!(recipe.recipe is Mechanics)) {
+                        if (recipe.recipe is not Mechanics) {
                             entity.recipe = recipe.recipe.name;
                         }
 
                         var modules = recipe.parameters.modules.modules;
                         if (modules != null) {
-                            entity.items = new Dictionary<string, int>();
+                            entity.items = [];
                             foreach (var (module, count, beacon) in recipe.parameters.modules.modules) {
                                 if (!beacon) {
                                     entity.items[module.name] = count;
@@ -961,13 +961,13 @@ goodsHaveNoProduction:;
         }
 
         private List<RecipeRow> GetRecipesRecursive() {
-            List<RecipeRow> list = new List<RecipeRow>();
+            List<RecipeRow> list = [];
             FillRecipeList(model, list);
             return list;
         }
 
         private List<RecipeRow> GetRecipesRecursive(RecipeRow recipeRoot) {
-            List<RecipeRow> list = new List<RecipeRow> { recipeRoot };
+            List<RecipeRow> list = [recipeRoot];
             if (recipeRoot.subgroup != null) {
                 FillRecipeList(recipeRoot.subgroup, list);
             }
@@ -976,13 +976,13 @@ goodsHaveNoProduction:;
         }
 
         private List<ProductionLink> GetLinksRecursive() {
-            List<ProductionLink> list = new List<ProductionLink>();
+            List<ProductionLink> list = [];
             FillLinkList(model, list);
             return list;
         }
 
         private void BuildShoppingList(RecipeRow recipeRoot) {
-            Dictionary<FactorioObject, int> shopList = new Dictionary<FactorioObject, int>();
+            Dictionary<FactorioObject, int> shopList = [];
             var recipes = recipeRoot == null ? GetRecipesRecursive() : GetRecipesRecursive(recipeRoot);
             foreach (var recipe in recipes) {
                 if (recipe.entity != null) {

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -960,12 +960,6 @@ goodsHaveNoProduction:;
             return list;
         }
 
-        private List<ProductionLink> GetLinksRecursive() {
-            List<ProductionLink> list = [];
-            FillLinkList(model, list);
-            return list;
-        }
-
         private void BuildShoppingList(RecipeRow recipeRoot) {
             Dictionary<FactorioObject, int> shopList = [];
             var recipes = recipeRoot == null ? GetRecipesRecursive() : GetRecipesRecursive(recipeRoot);
@@ -1118,10 +1112,6 @@ goodsHaveNoProduction:;
             {WarningFlags.RecipeTickLimit, "Production is limited to 60 recipes per second (1/tick). This interacts weirdly with productivity bonus - actual productivity may be imprecise and may depend on your setup - test your setup before committing to it."},
             {WarningFlags.ExceedsBuiltCount, "This recipe requires more buildings than are currently built."}
         };
-
-        private void BuildRecipePad(ImGui gui, RecipeRow row) {
-
-        }
 
         private static readonly (Icon icon, SchemeColor color)[] tagIcons = [
             (Icon.Empty, SchemeColor.BackgroundTextFaint),

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -433,9 +433,7 @@ goodsHaveNoProduction:;
             private readonly VirtualScrollList<ProjectModuleTemplate> moduleTemplateList;
             private RecipeRow editingRecipeModules;
 
-            public ModulesColumn(ProductionTableView view) : base(view, "Modules", 10f, 7f, 16f) {
-                moduleTemplateList = new VirtualScrollList<ProjectModuleTemplate>(15f, new Vector2(20f, 2.5f), ModuleTemplateDrawer, collapsible: true);
-            }
+            public ModulesColumn(ProductionTableView view) : base(view, "Modules", 10f, 7f, 16f) => moduleTemplateList = new VirtualScrollList<ProjectModuleTemplate>(15f, new Vector2(20f, 2.5f), ModuleTemplateDrawer, collapsible: true);
 
             private void ModuleTemplateDrawer(ImGui gui, ProjectModuleTemplate element, int index) {
                 var evt = gui.BuildContextMenuButton(element.name, icon: element.icon?.icon ?? default, disabled: !element.template.IsCompatibleWith(editingRecipeModules));

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -306,10 +306,10 @@ goodsHaveNoProduction:;
                 }
             }
 
-            private void ShowAccumulatorDropdown(ImGui gui, RecipeRow recipe, Entity accumulator) {
+            private void ShowAccumulatorDropdown(ImGui gui, RecipeRow recipe, Entity oldAccumulator) {
                 gui.ShowDropDown(imGui => {
                     imGui.BuildInlineObjectListAndButton<EntityAccumulator>(Database.allAccumulators, DataUtils.DefaultOrdering,
-                        accumulator => recipe.RecordUndo().ChangeVariant(accumulator, accumulator), "Select accumulator",
+                        newAccumulator => recipe.RecordUndo().ChangeVariant(oldAccumulator, newAccumulator), "Select accumulator",
                         extra: x => DataUtils.FormatAmount(x.accumulatorCapacity, UnitOfMeasure.Megajoule));
                 });
             }

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -296,9 +296,9 @@ goodsHaveNoProduction:;
                 }
             }
 
-            private void ShowAccumulatorDropdown(ImGui gui, RecipeRow recipe, Entity oldAccumulator) => gui.ShowDropDown(imGui => {
+            private void ShowAccumulatorDropdown(ImGui gui, RecipeRow recipe, Entity currentAccumulator) => gui.ShowDropDown(imGui => {
                 imGui.BuildInlineObjectListAndButton<EntityAccumulator>(Database.allAccumulators, DataUtils.DefaultOrdering,
-                    newAccumulator => recipe.RecordUndo().ChangeVariant(oldAccumulator, newAccumulator), "Select accumulator",
+                    newAccumulator => recipe.RecordUndo().ChangeVariant(currentAccumulator, newAccumulator), "Select accumulator",
                     extra: x => DataUtils.FormatAmount(x.accumulatorCapacity, UnitOfMeasure.Megajoule));
             });
 

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -17,17 +17,11 @@ namespace Yafc {
             flatHierarchyBuilder = new FlatHierarchy<RecipeRow, ProductionTable>(grid, BuildSummary, "This is a nested group. You can drag&drop recipes here. Nested groups can have their own linked materials.");
         }
 
-        private abstract class ProductionTableDataColumn : TextDataColumn<RecipeRow> {
-            protected readonly ProductionTableView view;
-
-            protected ProductionTableDataColumn(ProductionTableView view, string header, float width, float minWidth = 0, float maxWidth = 0, bool hasMenu = true) : base(header, width, minWidth, maxWidth, hasMenu) {
-                this.view = view;
-            }
+        private abstract class ProductionTableDataColumn(ProductionTableView view, string header, float width, float minWidth = 0, float maxWidth = 0, bool hasMenu = true) : TextDataColumn<RecipeRow>(header, width, minWidth, maxWidth, hasMenu) {
+            protected readonly ProductionTableView view = view;
         }
 
-        private class RecipePadColumn : ProductionTableDataColumn {
-            public RecipePadColumn(ProductionTableView view) : base(view, "", 3f, hasMenu: false) { }
-
+        private class RecipePadColumn(ProductionTableView view) : ProductionTableDataColumn(view, "", 3f, hasMenu: false) {
             public override void BuildElement(ImGui gui, RecipeRow row) {
                 gui.allocator = RectAllocator.Center;
                 gui.spacing = 0f;
@@ -100,9 +94,7 @@ namespace Yafc {
             }
         }
 
-        private class RecipeColumn : ProductionTableDataColumn {
-            public RecipeColumn(ProductionTableView view) : base(view, "Recipe", 13f, 13f, 30f) { }
-
+        private class RecipeColumn(ProductionTableView view) : ProductionTableDataColumn(view, "Recipe", 13f, 13f, 30f) {
             public override void BuildElement(ImGui gui, RecipeRow recipe) {
                 gui.spacing = 0.5f;
                 if (gui.BuildFactorioObjectButton(recipe.recipe, 3f)) {
@@ -250,9 +242,7 @@ goodsHaveNoProduction:;
             }
         }
 
-        private class EntityColumn : ProductionTableDataColumn {
-            public EntityColumn(ProductionTableView view) : base(view, "Entity", 8f) { }
-
+        private class EntityColumn(ProductionTableView view) : ProductionTableDataColumn(view, "Entity", 8f) {
             public override void BuildElement(ImGui gui, RecipeRow recipe) {
                 if (recipe.isOverviewMode) {
                     return;
@@ -406,9 +396,7 @@ goodsHaveNoProduction:;
             }
         }
 
-        private class IngredientsColumn : ProductionTableDataColumn {
-            public IngredientsColumn(ProductionTableView view) : base(view, "Ingredients", 32f, 16f, 100f, hasMenu: false) { }
-
+        private class IngredientsColumn(ProductionTableView view) : ProductionTableDataColumn(view, "Ingredients", 32f, 16f, 100f, hasMenu: false) {
             public override void BuildElement(ImGui gui, RecipeRow recipe) {
                 var grid = gui.EnterInlineGrid(3f, 1f);
                 if (recipe.isOverviewMode) {
@@ -427,9 +415,7 @@ goodsHaveNoProduction:;
             }
         }
 
-        private class ProductsColumn : ProductionTableDataColumn {
-            public ProductsColumn(ProductionTableView view) : base(view, "Products", 12f, 10f, 70f, hasMenu: false) { }
-
+        private class ProductsColumn(ProductionTableView view) : ProductionTableDataColumn(view, "Products", 12f, 10f, 70f, hasMenu: false) {
             public override void BuildElement(ImGui gui, RecipeRow recipe) {
                 var grid = gui.EnterInlineGrid(3f, 1f);
                 if (recipe.isOverviewMode) {

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -515,8 +515,7 @@ goodsHaveNoProduction:;
             private void ShowModuleDropDown(ImGui gui, RecipeRow recipe) {
                 var modules = recipe.recipe.modules.Where(x => recipe.entity?.CanAcceptModule(x.module) ?? false).ToArray();
                 editingRecipeModules = recipe;
-                moduleTemplateList.data = Project.current.sharedModuleTemplates.Where(x => x.filterEntities.Count == 0 || x.filterEntities.Contains(recipe.entity))
-                    .OrderByDescending(x => x.template.IsCompatibleWith(recipe)).ToArray();
+                moduleTemplateList.data = [.. Project.current.sharedModuleTemplates.Where(x => x.filterEntities.Count == 0 || x.filterEntities.Contains(recipe.entity)).OrderByDescending(x => x.template.IsCompatibleWith(recipe))];
 
                 gui.ShowDropDown(dropGui => {
                     if (dropGui.BuildButton("Use default modules") && dropGui.CloseDropdown()) {
@@ -1124,7 +1123,7 @@ goodsHaveNoProduction:;
 
         }
 
-        private static readonly (Icon icon, SchemeColor color)[] tagIcons = {
+        private static readonly (Icon icon, SchemeColor color)[] tagIcons = [
             (Icon.Empty, SchemeColor.BackgroundTextFaint),
             (Icon.Check, SchemeColor.Green),
             (Icon.Warning, SchemeColor.Secondary),
@@ -1134,7 +1133,7 @@ goodsHaveNoProduction:;
             (Icon.Time, SchemeColor.BackgroundText),
             (Icon.DarkMode, SchemeColor.BackgroundText),
             (Icon.Settings, SchemeColor.BackgroundText),
-        };
+        ];
 
 
 

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -693,7 +693,7 @@ goodsHaveNoProduction:;
             var selectFuel = type != ProductDropdownType.Fuel ? null : (Action<Goods>)(fuel => {
                 recipe.RecordUndo().fuel = fuel;
             });
-            var allProduction = goods == null ? Array.Empty<Recipe>() : variants == null ? goods.production : variants.SelectMany(x => x.production).Distinct().ToArray();
+            var allProduction = goods == null ? [] : variants == null ? goods.production : variants.SelectMany(x => x.production).Distinct().ToArray();
             Recipe[] fuelUseList = goods?.fuelFor.AsEnumerable().OfType<EntityCrafter>().SelectMany(e => e.recipes).OfType<Recipe>().Distinct().OrderBy(e => e, DataUtils.DefaultRecipeOrdering).ToArray() ?? [];
             var fuelDisplayFunc = recipe?.entity?.energy.type == EntityEnergyType.FluidHeat
                 ? (Func<Goods, string>)(g => DataUtils.FormatAmount(g.fluid?.heatValue ?? 0, UnitOfMeasure.Megajoule))

--- a/Yafc/Workspace/ProjectPageView.cs
+++ b/Yafc/Workspace/ProjectPageView.cs
@@ -23,26 +23,20 @@ namespace Yafc {
             bodyContent.Rebuild();
         }
 
-        protected virtual void ModelContentsChanged(bool visualOnly) {
-            Rebuild(visualOnly);
-        }
+        protected virtual void ModelContentsChanged(bool visualOnly) => Rebuild(visualOnly);
 
         public abstract void BuildPageTooltip(ImGui gui, ProjectPageContents contents);
 
         public abstract void SetModel(ProjectPage page);
 
-        public virtual float CalculateWidth() {
-            return headerContent.width;
-        }
+        public virtual float CalculateWidth() => headerContent.width;
 
         public virtual void SetSearchQuery(SearchQuery query) {
             searchQuery = query;
             Rebuild();
         }
 
-        public virtual ProjectPageView CreateSecondaryView() {
-            return Activator.CreateInstance(GetType()) as ProjectPageView;
-        }
+        public virtual ProjectPageView CreateSecondaryView() => Activator.CreateInstance(GetType()) as ProjectPageView;
 
         public void Build(ImGui gui, Vector2 visibleSize) {
             if (gui.isBuilding) {
@@ -69,9 +63,7 @@ namespace Yafc {
             base.Build(gui, visibleSize.Y - headerHeight, true);
         }
 
-        protected override Vector2 MeasureContent(Rect rect, ImGui gui) {
-            return new Vector2(contentWidth, contentHeight);
-        }
+        protected override Vector2 MeasureContent(Rect rect, ImGui gui) => new Vector2(contentWidth, contentHeight);
 
         protected override void PositionContent(ImGui gui, Rect viewport) {
             headerContent.offset = new Vector2(-scrollX, 0);
@@ -81,9 +73,7 @@ namespace Yafc {
 
         public abstract void CreateModelDropdown(ImGui gui1, Type type, Project project);
 
-        public virtual bool ControlKey(SDL.SDL_Scancode code) {
-            return false;
-        }
+        public virtual bool ControlKey(SDL.SDL_Scancode code) => false;
 
         public MemoryDrawingSurface GenerateFullPageScreenshot() {
             var headerSize = headerContent.contentSize;
@@ -125,9 +115,7 @@ namespace Yafc {
             }
         }
 
-        public override void BuildPageTooltip(ImGui gui, ProjectPageContents contents) {
-            BuildPageTooltip(gui, contents as T);
-        }
+        public override void BuildPageTooltip(ImGui gui, ProjectPageContents contents) => BuildPageTooltip(gui, contents as T);
 
         protected abstract void BuildPageTooltip(ImGui gui, T contents);
     }

--- a/Yafc/Workspace/SummaryView.cs
+++ b/Yafc/Workspace/SummaryView.cs
@@ -12,10 +12,9 @@ namespace Yafc {
             public SummaryScrollArea(GuiBuilder builder) : base(DefaultHeight, builder, default, false, true, true) {
             }
 
-            public new void Build(ImGui gui) {
+            public new void Build(ImGui gui) =>
                 // Maximize scroll area to fit parent area (minus header and 'show issues' heights, and some (2) padding probably)
                 Build(gui, gui.valid ? gui.parent.contentSize.Y - HeaderFont.size - Font.text.size - ScrollbarSize - 2 : DefaultHeight);
-            }
         }
 
         private class SummaryTabColumn : TextDataColumn<ProjectPage> {
@@ -225,9 +224,7 @@ namespace Yafc {
             }
         }
 
-        private void Recalculate() {
-            Recalculate(false);
-        }
+        private void Recalculate() => Recalculate(false);
 
         private void Recalculate(bool visualOnly) {
             allGoods.Clear();

--- a/Yafc/Workspace/SummaryView.cs
+++ b/Yafc/Workspace/SummaryView.cs
@@ -164,7 +164,7 @@ namespace Yafc {
         private readonly SummaryDataColumn goodsColumn;
         private readonly DataGrid<ProjectPage> mainGrid;
 
-        private readonly Dictionary<string, GoodDetails> allGoods = new Dictionary<string, GoodDetails>();
+        private readonly Dictionary<string, GoodDetails> allGoods = [];
 
 
         public SummaryView() {

--- a/Yafc/Workspace/SummaryView.cs
+++ b/Yafc/Workspace/SummaryView.cs
@@ -45,9 +45,7 @@ namespace Yafc {
         private class SummaryDataColumn : TextDataColumn<ProjectPage> {
             protected readonly SummaryView view;
 
-            public SummaryDataColumn(SummaryView view) : base("Linked", float.MaxValue) {
-                this.view = view;
-            }
+            public SummaryDataColumn(SummaryView view) : base("Linked", float.MaxValue) => this.view = view;
 
             public override void BuildElement(ImGui gui, ProjectPage page) {
                 if (page?.contentType != typeof(ProductionTable)) {

--- a/Yafc/YafcLib.cs
+++ b/Yafc/YafcLib.cs
@@ -28,25 +28,21 @@ namespace Yafc {
             }
         }
 
-        private static string GetLinuxMappedLibraryName(string libraryname) {
-            return libraryname switch {
-                "lua52" => "liblua52.so",
-                "SDL2.dll" => "SDL2-2.0.so.0",
-                "SDL2_ttf.dll" => "SDL2_ttf-2.0.so.0",
-                "SDL2_image.dll" => "SDL2_image-2.0.so.0",
-                _ => libraryname,
-            };
-        }
+        private static string GetLinuxMappedLibraryName(string libraryname) => libraryname switch {
+            "lua52" => "liblua52.so",
+            "SDL2.dll" => "SDL2-2.0.so.0",
+            "SDL2_ttf.dll" => "SDL2_ttf-2.0.so.0",
+            "SDL2_image.dll" => "SDL2_image-2.0.so.0",
+            _ => libraryname,
+        };
 
-        private static string GetOsxMappedLibraryName(string libraryname) {
-            return libraryname switch {
-                "lua52" => "liblua52.dylib",
-                "SDL2.dll" => "libSDL2.dylib",
-                "SDL2_ttf.dll" => "libSDL2_ttf.dylib",
-                "SDL2_image.dll" => "libSDL2_image.dylib",
-                _ => libraryname,
-            };
-        }
+        private static string GetOsxMappedLibraryName(string libraryname) => libraryname switch {
+            "lua52" => "liblua52.dylib",
+            "SDL2.dll" => "libSDL2.dylib",
+            "SDL2_ttf.dll" => "libSDL2_ttf.dylib",
+            "SDL2_image.dll" => "libSDL2_image.dylib",
+            _ => libraryname,
+        };
 
         private static IntPtr DllResolver(string libraryname, Assembly assembly, DllImportSearchPath? searchpath) {
             if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux)) {


### PR DESCRIPTION
It turned out all those inspections that were re-enabled and didn't fix anything were just dormant for some reason. Perhaps I should've restarted Visual Studio for them to work.

This PR includes three parts:
* The changes mentioned https://github.com/have-fun-was-taken/yafc-ce/issues/88. Essentially, now everything is lambdas. 
```
csharp_style_expression_bodied_methods = true:suggestion
csharp_style_expression_bodied_constructors = true:suggestion
csharp_style_expression_bodied_operators = true:suggestion
```
The main reason for these changes is that we already enabled arrow notation for the properties, and the other parts of the code stop looking weird with arrows if you read them for a bit.
* The improvements from unmuted suggestions.
* A [bugfix](https://github.com/have-fun-was-taken/yafc-ce/commit/72de773472bcdfbb83e5c135cb1a77aeb7ca16dc) that I found when applying suggestions.

I put the potentially controversial changes at the end, so we can drop them easier if necessary. 

QA: checked the basic functionality on an existing Pyanodons project file.