### PR TITLE
Remove textplate's in-game-only items that can cause false-positive accessibility warnings.

### DIFF
--- a/YAFC/Data/Mod-fixes/EvenMoreTextPlates.globals.lua
+++ b/YAFC/Data/Mod-fixes/EvenMoreTextPlates.globals.lua
@@ -1,0 +1,7 @@
+local evenmoretextplates = ...;
+
+for _,plate in pairs(evenmoretextplates.new_types) do
+	plate.symbols = {}
+end
+
+return evenmoretextplates;

--- a/YAFC/Data/Mod-fixes/textplates.textplates.lua
+++ b/YAFC/Data/Mod-fixes/textplates.textplates.lua
@@ -1,0 +1,7 @@
+local textplates = ...;
+
+for _,plate in pairs(textplates.types) do
+	plate.symbols = {}
+end
+
+return textplates;


### PR DESCRIPTION
The textplate-*material*-small/large-*symbol* items are useful in-game, but not in YAFC. The textplate-*material*-small and textplate-*material*-large items still exist, so plate crafting can be planned.

(This is copied from ShadowTheAge/yafc#192)