### PR TITLE
Auto-assign beacons to recipes before modules.

### DIFF
--- a/Yafc.Model/Model/ModuleFillerParameters.cs
+++ b/Yafc.Model/Model/ModuleFillerParameters.cs
@@ -69,8 +69,8 @@ namespace Yafc.Model {
         }
 
         public void GetModulesInfo(RecipeParameters recipeParams, Recipe recipe, EntityCrafter entity, Goods fuel, ref ModuleEffects effects, ref RecipeParameters.UsedModule used) {
-            AutoFillModules(recipeParams, recipe, entity, fuel, ref effects, ref used);
             AutoFillBeacons(recipeParams, recipe, entity, fuel, ref effects, ref used);
+            AutoFillModules(recipeParams, recipe, entity, fuel, ref effects, ref used);
         }
 
         private void AddModuleSimple(Item module, ref ModuleEffects effects, EntityCrafter entity, ref RecipeParameters.UsedModule used) {


### PR DESCRIPTION
This way, effectivity modules will fill to the limit or to the point of counteracting the beacons' effects, rather than stopping at 80% of the 0-beacon consumption.

In the attached IR3 yafc file (save also attached) the original behavior incorrectly auto-assigned two EFF 3 modules to the recipe, when it should have received four. The recipe should get four modules because there are four speed beacons also affecting the building, substantially increasing its consumption. Switching the order to assign beacons first causes the EFF modules to get auto-added correctly.

[IR test.zip](https://github.com/have-fun-was-taken/yafc-ce/files/15268818/IR.test.zip)
[IR3 game.zip](https://github.com/have-fun-was-taken/yafc-ce/files/15268826/IR3.game.zip)

(This is rebased from https://github.com/ShadowTheAge/yafc/pull/201)


It doesn't appear to matter whether this change is based on master or more-code-cleanup, so I based on master, to make it easier to merge it when/wherever. If you'd prefer I rebase it, let me know.