### PR TITLE
fix: undo invalid refactoring

### DIFF
--- a/Yafc/Windows/ProjectPageSettingsPanel.cs
+++ b/Yafc/Windows/ProjectPageSettingsPanel.cs
@@ -205,7 +205,7 @@ namespace Yafc {
                 deflateStream.CopyTo(ms);
                 byte[] bytes = ms.GetBuffer();
                 int index = 0;
-                if (DataUtils.ReadLine(bytes, ref index) is not "YAFC" or not "ProjectPage") {
+                if (DataUtils.ReadLine(bytes, ref index) != "YAFC" || DataUtils.ReadLine(bytes, ref index) != "ProjectPage") {
                     throw new InvalidDataException();
                 }
 


### PR DESCRIPTION
See https://github.com/have-fun-was-taken/yafc-ce/pull/116#discussion_r1596979469

> I missed this one, but this is not a valid refactoring.
> 
> ![afbeelding](https://private-user-images.githubusercontent.com/4461459/329656343-f370c6fb-7621-4ad4-a891-a9847effe40d.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTUzNTk5MjksIm5iZiI6MTcxNTM1OTYyOSwicGF0aCI6Ii80NDYxNDU5LzMyOTY1NjM0My1mMzcwYzZmYi03NjIxLTRhZDQtYTg5MS1hOTg0N2VmZmU0MGQucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDUxMCUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDA1MTBUMTY0NzA5WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9MzExODA2YTE2M2UwMWI0Y2FkMjZhNGQ1MWUyYWNhNGYzZTNjYzVmZWQ0NmU5ZjU0ZWJkNDk2NTMzYzNhMTY3OSZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.tFhiJYSgaqV5qbJaBBboBricKoXE_AnYBiXl9UNjOnc)
> 
> This gives a new error in the latest master: ![afbeelding](https://private-user-images.githubusercontent.com/4461459/329656617-13b5107e-3495-4c83-afef-17c88c2599de.png?jwt=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmF3LmdpdGh1YnVzZXJjb250ZW50LmNvbSIsImtleSI6ImtleTUiLCJleHAiOjE3MTUzNTk5MjksIm5iZiI6MTcxNTM1OTYyOSwicGF0aCI6Ii80NDYxNDU5LzMyOTY1NjYxNy0xM2I1MTA3ZS0zNDk1LTRjODMtYWZlZi0xN2M4OGMyNTk5ZGUucG5nP1gtQW16LUFsZ29yaXRobT1BV1M0LUhNQUMtU0hBMjU2JlgtQW16LUNyZWRlbnRpYWw9QUtJQVZDT0RZTFNBNTNQUUs0WkElMkYyMDI0MDUxMCUyRnVzLWVhc3QtMSUyRnMzJTJGYXdzNF9yZXF1ZXN0JlgtQW16LURhdGU9MjAyNDA1MTBUMTY0NzA5WiZYLUFtei1FeHBpcmVzPTMwMCZYLUFtei1TaWduYXR1cmU9N2Y3MGRlOGIxMWI5MWU2NjAxNmIwZjRjNzM5YzYyYWM2ZmJmZTZlMGM3NGYxOGY4NTA5OTliNGZjZmE5NjU1MyZYLUFtei1TaWduZWRIZWFkZXJzPWhvc3QmYWN0b3JfaWQ9MCZrZXlfaWQ9MCZyZXBvX2lkPTAifQ.J1ukOPxV4KPHZDAlm_kQZ9S6v4rRiqcIL4xmS3GfiEM)
> 
> On a separate note: Export project page to cliborad exports json, import project page from clipboard expect base64. So i couldnt test this function, but as you see in the watch screenshot it's not working as intended.

Notice the refactor operator did warn this might not be a correct refactoring:
![afbeelding](https://github.com/have-fun-was-taken/yafc-ce/assets/4461459/5a3702fb-6326-418a-9777-b538867db8de)


