### PR TITLE
Fix #74, by forcing scroll views to scroll up until items are visible.

### DIFF
--- a/FactorioCalc.sln
+++ b/FactorioCalc.sln
@@ -13,6 +13,11 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommandLineToolExample", "C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yafc.Model.Tests", "Yafc.Model.Tests\Yafc.Model.Tests.csproj", "{66B66728-84F0-4242-B49A-B9D746A3CCA5}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D6A715CB-5C17-4DD7-9ADA-5D7F44FADFCF}"
+	ProjectSection(SolutionItems) = preProject
+		changelog.txt = changelog.txt
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -43,5 +48,8 @@ Global
 		{66B66728-84F0-4242-B49A-B9D746A3CCA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{66B66728-84F0-4242-B49A-B9D746A3CCA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{66B66728-84F0-4242-B49A-B9D746A3CCA5}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
 	EndGlobalSection
 EndGlobal

--- a/Yafc.UI/ImGui/ScrollArea.cs
+++ b/Yafc.UI/ImGui/ScrollArea.cs
@@ -202,14 +202,16 @@ namespace Yafc.UI {
 
     public class VirtualScrollList<TData> : ScrollAreaBase {
         private readonly Vector2 elementSize;
-        protected readonly int bufferRows;
-        protected int firstVisibleBlock;
-        protected int elementsPerRow;
+        // When rendering the scrollable content, render 'blocks' of 4 rows at a time. (As far as I can tell, any positive value works. Shadow picked 4, so I kept that.)
+        private readonly int bufferRows = 4;
+        // The first block of bufferRows that was rendered last time BuildContents was called. If it changes while scrolling, we need to re-render the scrollable content.
+        private int firstVisibleBlock;
+        private int elementsPerRow;
         private IReadOnlyList<TData> _data = [];
         private readonly int maxRowsVisible;
         private readonly Drawer drawer;
-        public float _spacing;
-        protected readonly Action<int, int> reorder;
+        private float _spacing;
+        private readonly Action<int, int> reorder;
 
         public float spacing {
             get => _spacing;
@@ -229,10 +231,9 @@ namespace Yafc.UI {
             }
         }
 
-        public VirtualScrollList(float height, Vector2 elementSize, Drawer drawer, int bufferRows = 4, Padding padding = default, Action<int, int> reorder = null, bool collapsible = false) : base(height, padding, collapsible) {
+        public VirtualScrollList(float height, Vector2 elementSize, Drawer drawer, Padding padding = default, Action<int, int> reorder = null, bool collapsible = false) : base(height, padding, collapsible) {
             this.elementSize = elementSize;
             maxRowsVisible = MathUtils.Ceil(height / this.elementSize.Y) + bufferRows + 1;
-            this.bufferRows = bufferRows;
             this.drawer = drawer;
             this.reorder = reorder;
         }

--- a/Yafc.UI/ImGui/ScrollArea.cs
+++ b/Yafc.UI/ImGui/ScrollArea.cs
@@ -258,9 +258,13 @@ namespace Yafc.UI {
 
             int rowCount = ((_data.Count - 1) / elementsPerRow) + 1;
             firstVisibleBlock = CalcFirstBlock();
-            int firstRow = firstVisibleBlock * bufferRows;
+            // Scroll up until there are maxRowsVisible, or to the top.
+            int firstRow = Math.Max(0, Math.Min(firstVisibleBlock * bufferRows, rowCount - maxRowsVisible));
             int index = firstRow * elementsPerRow;
             if (index >= _data.Count) {
+                // If _data is empty, there's nothing to draw. Make sure MeasureContent reports that, instead of the size of the most recent non-empty content.
+                // This will remove the scroll bar when the search doesn't match anything.
+                gui.lastContentRect = new Rect(gui.lastContentRect.X, gui.lastContentRect.Y, 0, 0);
                 return;
             }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,7 @@ Date: soon
         - Add a help message and proper handling for command line arguments
         - Removed default pollution cost from calculation. Added a setting to customize pollution cost.
         - Add fuel consumption recipe for products
+        - Fix list displays below search boxes. If necessary, they now scroll up until items are visible.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 0.6.4
 Date: April 16th 2024


### PR DESCRIPTION
This fixes at least the object explorer (SelectObjectPanels) and the production sheet list (MainScreen.allPages), and doesn't visibly affect the production tables.