### PR TITLE
Fix ShadowTheAge#224, where long milestone names could hide remove buttons.

### DIFF
--- a/Yafc.UI/ImGui/ImGuiBuilding.cs
+++ b/Yafc.UI/ImGui/ImGuiBuilding.cs
@@ -86,18 +86,18 @@ namespace Yafc.UI {
             set => state.textColor = value;
         }
 
-        public void BuildText(string text, Font font = null, bool wrap = false, RectAlignment align = RectAlignment.MiddleLeft, SchemeColor color = SchemeColor.None, float topOffset = 0f) {
+        public void BuildText(string text, Font font = null, bool wrap = false, RectAlignment align = RectAlignment.MiddleLeft, SchemeColor color = SchemeColor.None, float topOffset = 0f, float maxWidth = float.MaxValue) {
             if (color == SchemeColor.None) {
                 color = state.textColor;
             }
 
-            var rect = AllocateTextRect(out var cache, text, font, wrap, align, topOffset);
+            var rect = AllocateTextRect(out var cache, text, font, wrap, align, topOffset, maxWidth);
             if (action == ImGuiAction.Build && cache != null) {
                 DrawRenderable(rect, cache, color);
             }
         }
 
-        public Rect AllocateTextRect(out TextCache cache, string text, Font font = null, bool wrap = false, RectAlignment align = RectAlignment.MiddleLeft, float topOffset = 0f) {
+        public Rect AllocateTextRect(out TextCache cache, string text, Font font = null, bool wrap = false, RectAlignment align = RectAlignment.MiddleLeft, float topOffset = 0f, float maxWidth = float.MaxValue) {
             var fontSize = GetFontSize(font);
             Rect rect;
             if (string.IsNullOrEmpty(text)) {
@@ -106,7 +106,8 @@ namespace Yafc.UI {
             }
             else {
                 cache = textCache.GetCached((fontSize, text, wrap ? (uint)UnitsToPixels(MathF.Max(width, 5f)) : uint.MaxValue));
-                rect = AllocateRect(cache.texRect.w / pixelsPerUnit, topOffset + (cache.texRect.h / pixelsPerUnit), align);
+                float textWidth = Math.Min(cache.texRect.w / pixelsPerUnit, maxWidth);
+                rect = AllocateRect(textWidth, topOffset + (cache.texRect.h / pixelsPerUnit), align);
             }
 
             if (topOffset != 0f) {

--- a/Yafc/Widgets/PseudoScreen.cs
+++ b/Yafc/Widgets/PseudoScreen.cs
@@ -7,7 +7,7 @@ namespace Yafc {
     // Pseudo screen is not an actual screen, it is a panel shown in the middle of the main screen
     public abstract class PseudoScreen : IKeyboardFocus {
         public readonly ImGui contents;
-        private readonly float width;
+        protected readonly float width;
         protected bool opened;
 
         protected PseudoScreen(float width = 40f) {

--- a/Yafc/Windows/MilestonesEditor.cs
+++ b/Yafc/Windows/MilestonesEditor.cs
@@ -8,7 +8,7 @@ namespace Yafc {
         private static readonly MilestonesEditor Instance = new MilestonesEditor();
         private readonly VirtualScrollList<FactorioObject> milestoneList;
 
-        public MilestonesEditor() => milestoneList = new VirtualScrollList<FactorioObject>(30f, new Vector2(float.PositiveInfinity, 3f), MilestoneDrawer);
+        public MilestonesEditor() : base(50) => milestoneList = new VirtualScrollList<FactorioObject>(30f, new Vector2(float.PositiveInfinity, 3f), MilestoneDrawer);
 
         public override void Open() {
             base.Open();
@@ -21,7 +21,7 @@ namespace Yafc {
             using (gui.EnterRow()) {
                 var settings = Project.current.settings;
                 gui.BuildFactorioObjectIcon(element, MilestoneDisplay.None, 3f);
-                gui.BuildText(element.locName);
+                gui.BuildText(element.locName, maxWidth: width - 16.6f); // Experimentally determined width of the non-text parts of the editor.
                 if (gui.BuildButton(Icon.Close, size: 1f)) {
                     _ = settings.RecordUndo().milestones.Remove(element);
                     Rebuild();


### PR DESCRIPTION
Set a maximum width for names in the milestone editor, and then increase the width of the milestone editor so that limit isn't reached in the example case.

This is the object with the longest Russian name I found in Exotic Industries, so that's what I tested with. The first (and more complicated) fix squishes the text horizontally into the available space, as shown in the second screenshot. The second fix, which is the `base(50)` call, expands the available space (third screenshot) so we hopefully won't often need the first fix.
![image](https://github.com/have-fun-was-taken/yafc-ce/assets/21223975/e791f218-36f4-403f-9858-daeff5906be4)