### PR TITLE
Fix handling of disabled recipes

### DIFF
--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -177,7 +177,14 @@ namespace Yafc.Model {
         public RecipeLinks links { get; internal set; }
         public float fixedBuildings { get; set; }
         public int? builtBuildings { get; set; }
+        /// <summary>
+        /// If <see langword="true"/>, the enabled checkbox for this recipe is checked.
+        /// </summary>
         public bool enabled { get; set; } = true;
+        /// <summary>
+        /// If <see langword="true"/>, the enabled checkboxes for this recipe and all its parent recipies are checked.
+        /// If <see langword="false"/>, at least one enabled checkbox for this recipe or its ancestors is unchecked.
+        /// </summary>
         public bool hierarchyEnabled { get; internal set; }
         public int tag { get; set; }
 

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -401,8 +401,8 @@ goodsHaveNoProduction:;
                 else {
                     for (int i = 0; i < recipe.recipe.ingredients.Length; i++) {
                         var ingredient = recipe.recipe.ingredients[i];
-                        var link = recipe.links.ingredients[i];
-                        var goods = recipe.links.ingredientGoods[i];
+                        var link = recipe.hierarchyEnabled ? recipe.links.ingredients[i] : null;
+                        var goods = recipe.hierarchyEnabled ? ingredient.goods : null;
                         grid.Next();
                         view.BuildGoodsIcon(gui, goods, link, (float)(ingredient.amount * recipe.recipesPerSecond), ProductDropdownType.Ingredient, recipe, recipe.linkRoot, ingredient.variants);
                     }
@@ -420,8 +420,10 @@ goodsHaveNoProduction:;
                 else {
                     for (int i = 0; i < recipe.recipe.products.Length; i++) {
                         var product = recipe.recipe.products[i];
+                        var link = recipe.hierarchyEnabled ? recipe.links.products[i] : null;
+                        var goods = recipe.hierarchyEnabled ? product.goods : null;
                         grid.Next();
-                        view.BuildGoodsIcon(gui, product.goods, recipe.links.products[i], (float)(recipe.recipesPerSecond * product.GetAmount(recipe.parameters.productivity)), ProductDropdownType.Product,
+                        view.BuildGoodsIcon(gui, goods, link, (float)(recipe.recipesPerSecond * product.GetAmount(recipe.parameters.productivity)), ProductDropdownType.Product,
                             recipe, recipe.linkRoot);
                     }
                 }

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -461,7 +461,7 @@ goodsHaveNoProduction:;
                 using var grid = gui.EnterInlineGrid(3f);
                 if (recipe.parameters.modules.modules == null || recipe.parameters.modules.modules.Length == 0) {
                     grid.Next();
-                    if (gui.BuildFactorioObjectWithAmount(null, 0, UnitOfMeasure.None)) {
+                    if (gui.BuildFactorioObjectWithAmount(null, 0, UnitOfMeasure.None) && recipe.hierarchyEnabled) {
                         ShowModuleDropDown(gui, recipe);
                     }
                 }
@@ -888,7 +888,7 @@ goodsHaveNoProduction:;
                 textColor = SchemeColor.BackgroundTextFaint;
             }
 
-            if (gui.BuildFactorioObjectWithAmount(goods, amount, goods?.flowUnitOfMeasure ?? UnitOfMeasure.None, iconColor, textColor)) {
+            if (gui.BuildFactorioObjectWithAmount(goods, amount, goods?.flowUnitOfMeasure ?? UnitOfMeasure.None, iconColor, textColor) && goods is not null) {
                 OpenProductDropdown(gui, gui.lastRect, goods, amount, link, dropdownType, recipe, context, variants);
             }
         }


### PR DESCRIPTION
As discussed briefly in #122, always show empty boxes for both the ingredients and products of disabled recipes. That is, they'll always look like this:
![image](https://github.com/have-fun-was-taken/yafc-ce/assets/21223975/d60eeefa-f56d-4d9c-afc7-7dcd8759f784)

I also discovered the code that cleans up old links removes links if the item/fluid does not appear in any _enabled_ recipes. I wanted the links to stay put when disabling and enabling recipes, and I couldn't concentrate on #122 with that behavior, so I changed the code to consider all recipes. If that change (f28d35f) should be discussed more, I can remove it from this PR.