### PR TITLE
Bot placeable is accessible

### DIFF
--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -305,7 +305,7 @@ namespace Yafc.Parser {
             var item = DeserializeCommon<Item>(table, "item");
 
             if (table.Get("place_result", out string placeResult) && !string.IsNullOrEmpty(placeResult)) {
-                placeResults[item] = placeResult;
+                placeResults[item] = [placeResult];
             }
 
             item.stackSize = table.Get("stack_size", 1);

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
@@ -13,7 +13,7 @@ namespace Yafc.Parser {
         private readonly DataBucket<string, RecipeOrTechnology> recipeCategories = new DataBucket<string, RecipeOrTechnology>();
         private readonly DataBucket<EntityCrafter, string> recipeCrafters = new DataBucket<EntityCrafter, string>();
         private readonly DataBucket<Recipe, Item> recipeModules = new DataBucket<Recipe, Item>();
-        private readonly Dictionary<Item, string> placeResults = [];
+        private readonly Dictionary<Item, List<string>> placeResults = [];
         private readonly List<Item> universalModules = [];
         private Item[] allModules;
         private readonly HashSet<Item> sciencePacks = [];
@@ -243,9 +243,11 @@ namespace Yafc.Parser {
 
                         break;
                     case Item item:
-                        if (placeResults.TryGetValue(item, out string placeResultStr)) {
-                            item.placeResult = GetObject<Entity>(placeResultStr);
-                            entityPlacers.Add(item.placeResult, item);
+                        if (placeResults.TryGetValue(item, out var placeResultNames)) {
+                            item.placeResult = GetObject<Entity>(placeResultNames[0]);
+                            foreach (string name in placeResultNames) {
+                                entityPlacers.Add(GetObject<Entity>(name), item);
+                            }
                         }
                         if (item.fuelResult != null) {
                             miscSources.Add(item.fuelResult, item);

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
@@ -162,6 +162,15 @@ namespace Yafc.Parser {
             string name = table.Get("name", "");
             string usesPower;
             float defaultDrain = 0f;
+
+            if (table.Get("placeable_by", out LuaTable placeableBy) && placeableBy.Get("item", out string itemName)) {
+                var item = GetObject<Item>(itemName);
+                if (!placeResults.TryGetValue(item, out var resultNames)) {
+                    resultNames = placeResults[item] = [];
+                }
+                resultNames.Add(name);
+            }
+
             switch (factorioType) {
                 case "transport-belt":
                     GetObject<Entity, EntityBelt>(name).beltItemsPerSecond = table.Get("speed", 0f) * 480f; ;

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -954,9 +954,10 @@ goodsHaveNoProduction:;
             var recipes = recipeRoot == null ? GetRecipesRecursive() : GetRecipesRecursive(recipeRoot);
             foreach (var recipe in recipes) {
                 if (recipe.entity != null) {
-                    _ = shopList.TryGetValue(recipe.entity, out int prev);
+                    FactorioObject shopItem = recipe.entity.itemsToPlace?.FirstOrDefault() ?? (FactorioObject)recipe.entity;
+                    _ = shopList.TryGetValue(shopItem, out int prev);
                     int count = MathUtils.Ceil(recipe.builtBuildings ?? recipe.buildingCount);
-                    shopList[recipe.entity] = prev + count;
+                    shopList[shopItem] = prev + count;
                     if (recipe.parameters.modules.modules != null) {
                         foreach (var module in recipe.parameters.modules.modules) {
                             if (!module.beacon) {


### PR DESCRIPTION
From ShadowTheAge#191:

> This makes bot-placeable (script-created but blueprintable) entities accessible, such as the rod/plate/gear casters from Industrial Revolution. Making the casters accessible also makes the recipes used by those casters accessible.
>
> For recipe accessibility it's only important for crafters, but it also reduces the chances of false positive warnings related to things like the 1-to-N underground pipes in Advanced Fluid Handling.

This also updates the shopping list to show the Metal cast items instead of listing the Plate cast, Rod cast, Gear cast, and Ingot cast entities separately.