### PR TITLE
Better barrelling and stacking detection

### DIFF
--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -147,7 +147,13 @@ namespace Yafc.Model {
         FilledBarrel,
         Barreling,
         Voiding,
-        Unbarreling
+        Unbarreling,
+        Stacking,
+        StackedItem,
+        Unstacking,
+        Pressurization,
+        PressurizedFluid,
+        Depressurization,
     }
 
     public class Recipe : RecipeOrTechnology {

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -144,16 +144,11 @@ namespace Yafc.Model {
 
     public enum FactorioObjectSpecialType {
         Normal,
-        FilledBarrel,
-        Barreling,
         Voiding,
-        Unbarreling,
+        Barreling,
         Stacking,
-        StackedItem,
-        Unstacking,
         Pressurization,
-        PressurizedFluid,
-        Depressurization,
+        Crating,
     }
 
     public class Recipe : RecipeOrTechnology {

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
@@ -182,13 +182,6 @@ namespace Yafc.Parser {
                 return false;
             }
 
-            // Some mods add productivity permissions to the recipes, but not to the crafters; still allow these to be matched as inverses.
-            // TODO: Consider removing this check entirely?
-            if ((unpacking.crafters.OfType<EntityWithModules>().Any(c => c.moduleSlots > 0 && c.allowedEffects.HasFlag(AllowedEffects.Productivity)) && unpacking.IsProductivityAllowed())
-                || (packing.crafters.OfType<EntityWithModules>().Any(c => c.moduleSlots > 0 && c.allowedEffects.HasFlag(AllowedEffects.Productivity)) && packing.IsProductivityAllowed())) {
-                return false;
-            }
-
             return true;
 
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,12 @@
 ----------------------------------------------------------------------------------------------------------------------
 Version: 0.7.1
 Date: soon
+    Changes:
+        - Update the detection of special recipes and items, to detect stacking from Deadlock's Beltboxes, caging
+          from Pyanodon, and pressurization from Pressurized Fluids.
+          Also detect cases where one direction is required, (e.g. Some Nullius science packs are manufactured in
+          stacks) and do not consider the required recipe special. (The unstacking recipe, in this case)
+          As before, special items/recipes are shown at the end of lists and are not selected when ctrl-clicking.
     Fixes:
         - Display spent fuel items in the production table and link summaries.
         - Fix error when switching items in NEIE with middle-click


### PR DESCRIPTION
### Motivation
I decided I wanted "Iron plate (unstack)" and similar recipes to be treated as special sources of Iron plate, rather than being normal (ctrl+click candidate) sources. I also wanted Nullius's "Iron ore unboxing" and "Physics research boxing" to be flagged as special recipes, without flagging the reverse recipes or the boxed items. (There are recipe chains that use boxed iron ore, but if you're planning to unbox the iron ore, you were probably better off not boxing it in the first place. Conversely, the only source of physics research is unboxing, so you shouldn't ever re-box it.)

### Changes
I basically reimplemented `IsBarrelingRecipe` from first principles to make this all work. As expected, there are changes. Some specific examples from Pyanodon:
* The caged-xeno and boric-acid-barrel items and their corresponding recipes are no longer special, because there are multiple ways to both produce and consume the items. A packing-related item must have exactly one production recipe or exactly one consumption recipe.
* Most of the rest of the caged-_animal_ recipes and items are now normal, since there are good reasons to cage them. The uncaged-_animal_ recipes are still special, since the only source of a caged animal is from the caging recipe. Likewise for all (I expect) the _fuel_-canister items and their recipes; unbarreling is still special, but barreling and the items aren't.
* I yeeted the check for fluid variants. I couldn't figure out why Shadow added them, and removing them means sweet-syrup-barrel and its recipes are now considered special. They were previously excluded because fill-sweet-syrup-barrel accepts both 0° and 10° syrup.
* Packing and unpacking recipes no longer have to match 1:1. A packing recipe that compresses 20 items to 4 can match an unpacking recipe that decompresses 1 item to 5. (Thanks, Nullius. I hate it.)

Here's a diff between the old special objects and the new ones for IR3, Nullius, Pyanodon, and SE. I also tested Angel-Bob-MadClown, but that one changed everything except the Voiding recipes so ... (Update: [DSB](https://mods.factorio.com/mod/deadlock-beltboxes-loaders) confuses the original code pretty badly.)
[changes.patch](https://github.com/have-fun-was-taken/yafc-ce/files/15366906/changes.patch)

### Questions
A few questions before I work too much harder on this:
* Is this a desirable change of definitions? Sometimes X=>Y is a packing recipe, but Y=>X is not unpacking, and vice versa.
* Is the separation of types desirable? I currently distinguish between Barrelling, Stacking, and fluid Pressurization, which means that caged-_animal_ and [Deadlock's crating recipes](https://mods.factorio.com/mod/DeadlockCrating) are described as "Stacking". If desired, I could add a fourth type for those, or I could drop the all the distinctions and stick to the generic "Packing", "Packed", and "Unpacking" I used in the comments.
* What does it get wrong? [Deadlock Stacked Recipes](https://mods.factorio.com/mod/deadlock_stacked_recipes), for example, is a complete disaster.