### PR TITLE
Add a checkbox that uses net production instead of gross production for determining which recipes to display.

### DIFF
--- a/CommandLineToolExample/Program.cs
+++ b/CommandLineToolExample/Program.cs
@@ -22,7 +22,7 @@ namespace CommandLineToolExample {
                 // Empty project path loads default project (with one empty page).
                 // Project is irrelevant if you just need data, but you need it to perform sheet calculations
                 // Set to not render any icons
-                project = FactorioDataSource.Parse(factorioPath, "", "", false, new ConsoleProgressReport(), errorCollector, "en", false);
+                project = FactorioDataSource.Parse(factorioPath, "", "", false, false, new ConsoleProgressReport(), errorCollector, "en", false);
             }
             catch (Exception ex) {
                 // Critical errors that make project un-loadable will be thrown as exceptions

--- a/Yafc.Model/Data/DataUtils.cs
+++ b/Yafc.Model/Data/DataUtils.cs
@@ -79,6 +79,12 @@ namespace Yafc.Model {
         public static string dataPath { get; internal set; }
         public static string modsPath { get; internal set; }
         public static bool expensiveRecipes { get; internal set; }
+        /// <summary>
+        /// If <see langword="true"/>, recipe selection windows will only display recipes that provide net production or consumption of the <see cref="Goods"/> in question.
+        /// If <see langword="false"/>, recipe selection windows will show all recipes that produce or consume any quantity of that <see cref="Goods"/>.<br/>
+        /// For example, Kovarex enrichment will appear for both production and consumption of both U-235 and U-238 when <see langword="false"/>,
+        /// but will appear as only producing U-235 and consuming U-238 when <see langword="true"/>.
+        /// </summary>
         public static bool netProduction { get; internal set; }
         public static string[] allMods { get; internal set; }
         public static Icon NoFuelIcon { get; internal set; }

--- a/Yafc.Model/Data/DataUtils.cs
+++ b/Yafc.Model/Data/DataUtils.cs
@@ -79,6 +79,7 @@ namespace Yafc.Model {
         public static string dataPath { get; internal set; }
         public static string modsPath { get; internal set; }
         public static bool expensiveRecipes { get; internal set; }
+        public static bool netProduction { get; internal set; }
         public static string[] allMods { get; internal set; }
         public static Icon NoFuelIcon { get; internal set; }
         public static Icon WarningIcon { get; internal set; }

--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -83,7 +83,7 @@ namespace Yafc.Parser {
             ];
         }
 
-        public Project LoadData(string projectPath, LuaTable data, LuaTable prototypes, IProgress<(string, string)> progress, ErrorCollector errorCollector, bool renderIcons) {
+        public Project LoadData(string projectPath, LuaTable data, LuaTable prototypes, bool netProduction, IProgress<(string, string)> progress, ErrorCollector errorCollector, bool renderIcons) {
             progress.Report(("Loading", "Loading items"));
             raw = (LuaTable)data["raw"];
             foreach (object prototypeName in ((LuaTable)prototypes["item"]).ObjectElements.Keys) {
@@ -127,7 +127,7 @@ namespace Yafc.Parser {
             var iconRenderTask = renderIcons ? Task.Run(RenderIcons) : Task.CompletedTask;
             UpdateRecipeIngredientFluids();
             UpdateRecipeCatalysts();
-            CalculateMaps();
+            CalculateMaps(netProduction);
             ExportBuiltData();
             progress.Report(("Post-processing", "Calculating dependencies"));
             Dependencies.Calculate();

--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -83,6 +83,20 @@ namespace Yafc.Parser {
             ];
         }
 
+        /// <summary>
+        /// Process the data loaded from Factorio and the mods, and load the project specified by <paramref name="projectPath"/>.
+        /// </summary>
+        /// <param name="projectPath">The path to the project file to create or load. May be <see langword="null"/> or empty.</param>
+        /// <param name="data">The Lua table data (containing data.raw) that was populated by the lua scripts.</param>
+        /// <param name="prototypes">The Lua table defines.prototypes that was populated by the lua scripts.</param>
+        /// <param name="netProduction">If <see langword="true"/>, recipe selection windows will only display recipes that provide net production or consumption of the <see cref="Goods"/> in question.
+        /// If <see langword="false"/>, recipe selection windows will show all recipes that produce or consume any quantity of that <see cref="Goods"/>.<br/>
+        /// For example, Kovarex enrichment will appear for both production and consumption of both U-235 and U-238 when <see langword="false"/>,
+        /// but will appear as only producing U-235 and consuming U-238 when <see langword="true"/>.</param>
+        /// <param name="progress">An <see cref="IProgress{T}"/> that receives two strings describing the current loading state.</param>
+        /// <param name="errorCollector">An <see cref="ErrorCollector"/> that will collect the errors and warnings encountered while loading and processing the file and data.</param>
+        /// <param name="renderIcons">If <see langword="true"/>, Yafc will render the icons necessary for UI display.</param>
+        /// <returns>A <see cref="Project"/> containing the information loaded from <paramref name="projectPath"/>. Also sets the <see langword="static"/> properties in <see cref="Database"/>.</returns>
         public Project LoadData(string projectPath, LuaTable data, LuaTable prototypes, bool netProduction, IProgress<(string, string)> progress, ErrorCollector errorCollector, bool renderIcons) {
             progress.Report(("Loading", "Loading items"));
             raw = (LuaTable)data["raw"];

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
@@ -196,6 +196,13 @@ namespace Yafc.Parser {
             return true;
         }
 
+        /// <summary>
+        /// Locates and stores all the links between different objects, e.g. which crafters can be used by a recipe, which recipes produce a particular product, and so on.
+        /// </summary>
+        /// <param name="netProduction">If <see langword="true"/>, recipe selection windows will only display recipes that provide net production or consumption of the <see cref="Goods"/> in question.
+        /// If <see langword="false"/>, recipe selection windows will show all recipes that produce or consume any quantity of that <see cref="Goods"/>.<br/>
+        /// For example, Kovarex enrichment will appear for both production and consumption of both U-235 and U-238 when <see langword="false"/>,
+        /// but will appear as only producing U-235 and consuming U-238 when <see langword="true"/>.</param>
         private void CalculateMaps(bool netProduction) {
             DataBucket<Goods, Recipe> itemUsages = new DataBucket<Goods, Recipe>();
             DataBucket<Goods, Recipe> itemProduction = new DataBucket<Goods, Recipe>();

--- a/Yafc.Parser/FactorioDataSource.cs
+++ b/Yafc.Parser/FactorioDataSource.cs
@@ -130,7 +130,25 @@ namespace Yafc.Parser {
             }
         }
 
-        public static Project Parse(string factorioPath, string modPath, string projectPath, bool expensive, bool netProduction, IProgress<(string, string)> progress, ErrorCollector errorCollector, string locale, bool renderIcons = true) {
+        /// <summary>
+        /// Create or load the file <paramref name="projectPath"/> (if specified), with the Factorio data at <paramref name="factorioPath"/> and <paramref name="modPath"/>.
+        /// </summary>
+        /// <param name="factorioPath">The path to the data/ folder, containing the base and core folders.</param>
+        /// <param name="modPath">The path to the mods/ folder, containing mod-list.json and the mods. Both zipped and unzipped mods are supported. May be empty (but not <see langword="null"/>)
+        /// to load only vanilla Factorio data.</param>
+        /// <param name="projectPath">The path to the project file to create or load. May be <see langword="null"/> or empty.</param>
+        /// <param name="expensive">Whether to use expensive recipes.</param>
+        /// <param name="netProduction">If <see langword="true"/>, recipe selection windows will only display recipes that provide net production or consumption of the <see cref="Goods"/> in question.
+        /// If <see langword="false"/>, recipe selection windows will show all recipes that produce or consume any quantity of that <see cref="Goods"/>.<br/>
+        /// For example, Kovarex enrichment will appear for both production and consumption of both U-235 and U-238 when <see langword="false"/>,
+        /// but will appear as only producing U-235 and consuming U-238 when <see langword="true"/>.</param>
+        /// <param name="progress">An <see cref="IProgress{T}"/> that receives two strings describing the current loading state.</param>
+        /// <param name="errorCollector">An <see cref="ErrorCollector"/> that will collect the errors and warnings encountered while loading and processing the file and data.</param>
+        /// <param name="locale">One of the languages supported by Factorio. Typically just the two-letter language code, e.g. en, but occasionally also includes the region code, e.g. pt-PT.</param>
+        /// <param name="renderIcons">If <see langword="true"/>, Yafc will render the icons necessary for UI display.</param>
+        /// <returns>A <see cref="Project"/> containing the information loaded from <paramref name="projectPath"/>. Also sets the <see langword="static"/> properties in <see cref="Database"/>.</returns>
+        /// <exception cref="NotSupportedException">Thrown if a mod enabled in mod-list.json could not be found in <paramref name="modPath"/>.</exception>
+        public static Project Parse(string factorioPath, string modPath, string projectPath, bool expensive, bool netProduction, IProgress<(string MajorState, string MinorState)> progress, ErrorCollector errorCollector, string locale, bool renderIcons = true) {
             LuaContext dataContext = null;
             try {
                 currentLoadingMod = null;

--- a/Yafc.Parser/FactorioDataSource.cs
+++ b/Yafc.Parser/FactorioDataSource.cs
@@ -130,7 +130,7 @@ namespace Yafc.Parser {
             }
         }
 
-        public static Project Parse(string factorioPath, string modPath, string projectPath, bool expensive, IProgress<(string, string)> progress, ErrorCollector errorCollector, string locale, bool renderIcons = true) {
+        public static Project Parse(string factorioPath, string modPath, string projectPath, bool expensive, bool netProduction, IProgress<(string, string)> progress, ErrorCollector errorCollector, string locale, bool renderIcons = true) {
             LuaContext dataContext = null;
             try {
                 currentLoadingMod = null;
@@ -257,6 +257,7 @@ namespace Yafc.Parser {
                 DataUtils.dataPath = factorioPath;
                 DataUtils.modsPath = modPath;
                 DataUtils.expensiveRecipes = expensive;
+                DataUtils.netProduction = netProduction;
 
 
                 dataContext = new LuaContext();
@@ -283,7 +284,7 @@ namespace Yafc.Parser {
                 currentLoadingMod = null;
 
                 FactorioDataDeserializer deserializer = new FactorioDataDeserializer(expensive, factorioVersion ?? defaultFactorioVersion);
-                var project = deserializer.LoadData(projectPath, dataContext.data, dataContext.defines["prototypes"] as LuaTable, progress, errorCollector, renderIcons);
+                var project = deserializer.LoadData(projectPath, dataContext.data, dataContext.defines["prototypes"] as LuaTable, netProduction, progress, errorCollector, renderIcons);
                 Console.WriteLine("Completed!");
                 progress.Report(("Completed!", ""));
                 return project;

--- a/Yafc/Utils/Preferences.cs
+++ b/Yafc/Utils/Preferences.cs
@@ -46,9 +46,9 @@ namespace Yafc {
         public string language { get; set; } = "en";
         public string overrideFont { get; set; }
 
-        public void AddProject(string path, string dataPath, string modsPath, bool expensiveRecipes) {
+        public void AddProject(string path, string dataPath, string modsPath, bool expensiveRecipes, bool netProduction) {
             recentProjects = recentProjects.Where(x => string.Compare(path, x.path, StringComparison.InvariantCultureIgnoreCase) != 0)
-                .Prepend(new ProjectDefinition { path = path, modsPath = modsPath, dataPath = dataPath, expensive = expensiveRecipes }).ToArray();
+                .Prepend(new ProjectDefinition { path = path, modsPath = modsPath, dataPath = dataPath, expensive = expensiveRecipes, netProduction = netProduction }).ToArray();
             Save();
         }
     }
@@ -58,5 +58,6 @@ namespace Yafc {
         public string dataPath { get; set; }
         public string modsPath { get; set; }
         public bool expensive { get; set; }
+        public bool netProduction { get; set; }
     }
 }

--- a/Yafc/Utils/Preferences.cs
+++ b/Yafc/Utils/Preferences.cs
@@ -58,6 +58,12 @@ namespace Yafc {
         public string dataPath { get; set; }
         public string modsPath { get; set; }
         public bool expensive { get; set; }
+        /// <summary>
+        /// If <see langword="true"/>, recipe selection windows will only display recipes that provide net production or consumption of the <see cref="Goods"/> in question.
+        /// If <see langword="false"/>, recipe selection windows will show all recipes that produce or consume any quantity of that <see cref="Goods"/>.<br/>
+        /// For example, Kovarex enrichment will appear for both production and consumption of both U-235 and U-238 when <see langword="false"/>,
+        /// but will appear as only producing U-235 and consuming U-238 when <see langword="true"/>.
+        /// </summary>
         public bool netProduction { get; set; }
     }
 }

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -588,7 +588,7 @@ namespace Yafc {
                 FilesystemScreen.Mode.SelectOrCreateFile, "project", this, null, "yafc");
             if (path != null) {
                 project.Save(path);
-                Preferences.Instance.AddProject(path, DataUtils.dataPath, DataUtils.modsPath, DataUtils.expensiveRecipes);
+                Preferences.Instance.AddProject(path, DataUtils.dataPath, DataUtils.modsPath, DataUtils.expensiveRecipes, DataUtils.netProduction);
                 return true;
             }
 

--- a/Yafc/Windows/WelcomeScreen.cs
+++ b/Yafc/Windows/WelcomeScreen.cs
@@ -14,6 +14,7 @@ namespace Yafc {
         private string currentLoad1, currentLoad2;
         private string path = "", dataPath = "", modsPath = "";
         private bool expensive;
+        private bool netProduction;
         private string createText;
         private bool canCreate;
         private readonly ScrollArea errorScroll;
@@ -135,6 +136,10 @@ namespace Yafc {
                     }
 
                     gui.BuildText("In-game objects language:");
+                }
+
+                using (gui.EnterRow()) {
+                    gui.BuildCheckBox("Use net production/consumption when analyzing recipes", netProduction, out netProduction);
                 }
 
                 using (gui.EnterRow()) {
@@ -281,12 +286,14 @@ namespace Yafc {
         private void SetProject(ProjectDefinition project) {
             if (project != null) {
                 expensive = project.expensive;
+                netProduction = project.netProduction;
                 modsPath = project.modsPath ?? "";
                 path = project.path ?? "";
                 dataPath = project.dataPath ?? "";
             }
             else {
                 expensive = false;
+                netProduction = false;
                 modsPath = "";
                 path = "";
                 dataPath = "";
@@ -305,7 +312,7 @@ namespace Yafc {
         private async void LoadProject() {
             try {
                 var (dataPath, modsPath, projectPath, expensiveRecipes) = (this.dataPath, this.modsPath, path, expensive);
-                Preferences.Instance.AddProject(projectPath, dataPath, modsPath, expensiveRecipes);
+                Preferences.Instance.AddProject(projectPath, dataPath, modsPath, expensiveRecipes, netProduction);
                 Preferences.Instance.Save();
                 tip = tips.Length > 0 ? tips[DataUtils.random.Next(tips.Length)] : "";
 
@@ -314,7 +321,7 @@ namespace Yafc {
 
                 await Ui.ExitMainThread();
                 ErrorCollector collector = new ErrorCollector();
-                var project = FactorioDataSource.Parse(dataPath, modsPath, projectPath, expensiveRecipes, this, collector, Preferences.Instance.language);
+                var project = FactorioDataSource.Parse(dataPath, modsPath, projectPath, expensiveRecipes, netProduction, this, collector, Preferences.Instance.language);
                 await Ui.EnterMainThread();
                 Console.WriteLine("Opening main screen");
                 _ = new MainScreen(displayIndex, project);

--- a/changelog.txt
+++ b/changelog.txt
@@ -5,6 +5,8 @@ Date: soon
         - Add the option to specify a number of belts of production, and to specify per-second/minute/hour
           production regardless of the current display setting.
         - When searching in the page list, allow searching in page contents as well as in page names.
+        - Allow the user to select whether catalysts should be considered produced and consumed by the recipes that
+          use them. (e.g. Does coal liquefaction consume heavy oil?)
     Changes:
         - Add a help message and proper handling for command line arguments
         - Removed default pollution cost from calculation. Added a setting to customize pollution cost.


### PR DESCRIPTION
For example, with the box checked, Kovarex enrichment ~~will display as [snip previous confusing text]~~ won't show up as a recipe option when attempting to consume U-235, nor when attempting to produce U-238.

I'm not sure we actually want this to be a checkbox, though. Should I make this always on instead?