### PR TITLE
Fix 35806d61, which broke the selection of fluid ingredient variants.

### DIFF
--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -402,7 +402,7 @@ goodsHaveNoProduction:;
                     for (int i = 0; i < recipe.recipe.ingredients.Length; i++) {
                         var ingredient = recipe.recipe.ingredients[i];
                         var link = recipe.hierarchyEnabled ? recipe.links.ingredients[i] : null;
-                        var goods = recipe.hierarchyEnabled ? ingredient.goods : null;
+                        var goods = recipe.hierarchyEnabled ? recipe.links.ingredientGoods[i] : null;
                         grid.Next();
                         view.BuildGoodsIcon(gui, goods, link, (float)(ingredient.amount * recipe.recipesPerSecond), ProductDropdownType.Ingredient, recipe, recipe.linkRoot, ingredient.variants);
                     }


### PR DESCRIPTION
In 35806d61, I changed `recipe.links.ingredientGoods[i]` to `ingredient.goods`, and that broke this dropdown in the ingredients column.
![image](https://github.com/have-fun-was-taken/yafc-ce/assets/21223975/fd44a559-46bc-41a6-bc1f-7ff7fe0aa3a1)

This changes it back and fixes the dropdown.