### PR TITLE
Display spent fuel

### DIFF
--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -359,7 +359,7 @@ namespace Yafc.Model {
         /// <summary>
         /// List of recipes belonging to this production link
         /// </summary>
-        [SkipSerialization] public List<RecipeRow> capturedRecipes { get; } = [];
+        [SkipSerialization] public HashSet<RecipeRow> capturedRecipes { get; } = [];
         internal int solverIndex;
         public float dualValue { get; internal set; }
     }

--- a/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
@@ -54,6 +54,9 @@ namespace Yafc {
             totalOutput = 0;
             foreach (var recipe in link.capturedRecipes) {
                 float production = recipe.recipe.GetProduction(link.goods, recipe.parameters.productivity);
+                if (recipe.fuel is not null && recipe.fuel.HasSpentFuel(out Item? spent) && spent == link.goods) {
+                    production += recipe.parameters.fuelUsagePerSecondPerRecipe;
+                }
                 float consumption = recipe.recipe.GetConsumption(link.goods);
                 float fuelUsage = recipe.fuel == link.goods ? recipe.parameters.fuelUsagePerSecondPerRecipe : 0;
                 float localFlow = (float)((production - consumption - fuelUsage) * recipe.recipesPerSecond);

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,11 @@
 ----------------------------------------------------------------------------------------------------------------------
-Version: 0.6.5
+Version: 0.7.1
 Date: soon
+    Fixes:
+        - Display spent fuel items in the production table and link summaries.
+----------------------------------------------------------------------------------------------------------------------
+Version: 0.7.0
+Date: May 25th 2024
     Features:
         - Add the option to specify a number of belts of production, and to specify per-second/minute/hour
           production regardless of the current display setting.


### PR DESCRIPTION
This updates the recipe row and link summary displays to deal with spent fuel, as shown below. The change in ash output for the Void Ash recipe is because ash is both a recipe output and a spent fuel output; the solver already did the right thing.

![Untitled](https://github.com/have-fun-was-taken/yafc-ce/assets/21223975/1afaf043-a934-4ad4-a6f1-2d66b65ea647)
