### PR TITLE
Fix missing window contents on Linux/Xorg

### DIFF
--- a/Yafc.UI/Core/Ui.cs
+++ b/Yafc.UI/Core/Ui.cs
@@ -146,6 +146,7 @@ namespace Yafc.UI {
                                     break;
                                 default:
                                     Console.WriteLine("Window event of type " + evt.window.windowEvent);
+                                    window.Rebuild(); // might be something like "window exposed", better to paint the UI again
                                     break;
                             }
 


### PR DESCRIPTION
This fixes a glitch that the window contents would be missing after minimization or after covering with another window (on Linux/Xorg).

We now repaint a window when we get window events. The events are usually something like RESTORED, EXPOSED, HIDDEN, SHOWN. I don't really understand what the events mean, but the rebuild is reasonably cheap and neither of the events seems to be very common (all are logged).

The main window already rebuilt on every single repaint, see WindowMain.OnRepaint. This change only affects the other windows, like the file selector or the exception message.