### PR TITLE
Draw smaller icons over variable backgrounds.

### DIFF
--- a/Yafc.Model/Model/Project.cs
+++ b/Yafc.Model/Model/Project.cs
@@ -191,6 +191,10 @@ namespace Yafc.Model {
         public HashSet<FactorioObject> favorites { get; } = [];
         /// <summary> Target technology for cost analysis - required item counts are estimated for researching this. If null, the is to research all finite technologies. </summary>
         public Technology? targetTechnology { get; set; }
+        /// <summary>
+        /// The scale to use when drawing icons that have information stored in their background color, stored as a ratio from 0 to 1.
+        /// </summary>
+        public float iconScale { get; set; } = .9f;
 
         protected internal override void AfterDeserialize() {
             base.AfterDeserialize();

--- a/Yafc.UI/ImGui/ImGuiUtils.cs
+++ b/Yafc.UI/ImGui/ImGuiUtils.cs
@@ -189,9 +189,9 @@ namespace Yafc.UI {
             return gui.BuildButton(gui.lastRect, normal, over, down);
         }
 
-        public static bool WithTooltip(this ButtonEvent evt, ImGui gui, string tooltip) {
+        public static bool WithTooltip(this ButtonEvent evt, ImGui gui, string tooltip, Rect? rect = null) {
             if (evt == ButtonEvent.MouseOver) {
-                gui.ShowTooltip(gui.lastRect, tooltip);
+                gui.ShowTooltip(rect ?? gui.lastRect, tooltip);
             }
 
             return evt;

--- a/Yafc/Windows/PreferencesScreen.cs
+++ b/Yafc/Windows/PreferencesScreen.cs
@@ -38,13 +38,21 @@ namespace Yafc {
             gui.BuildText("Fluid production/consumption:", Font.subheader);
             BuildUnitPerTime(gui, true, prefs);
 
-            using (gui.EnterRow()) {
-                gui.BuildText("Pollution cost modifier (0 for off, 100% for old default)", Font.text, topOffset: 0.5f); ;
-                if (gui.BuildFloatInput(settings.PollutionCostModifier, out var pollutionCostModifier, UnitOfMeasure.Percent, new Padding(0.5f))) {
-                    settings.RecordUndo().PollutionCostModifier = pollutionCostModifier;
-                    gui.Rebuild();
-                }
-            }
+            drawInputRowWithTooltip(gui, "Pollution cost modifier", "0 for off, 100% for old default",
+                gui => {
+                    if (gui.BuildFloatInput(settings.PollutionCostModifier, out float pollutionCostModifier, UnitOfMeasure.Percent, new Padding(0.5f))) {
+                        settings.RecordUndo().PollutionCostModifier = pollutionCostModifier;
+                        gui.Rebuild();
+                    }
+                });
+
+            drawInputRowWithTooltip(gui, "Display scale for linkable icons", "Some mod icons have little or no transparency, hiding the background color. This setting reduces the size of icons that could hide link information.",
+                gui => {
+                    if (gui.BuildFloatInput(prefs.iconScale, out float iconScale, UnitOfMeasure.Percent, new Padding(0.5f)) && iconScale > 0 && iconScale <= 1) {
+                        prefs.RecordUndo().iconScale = iconScale;
+                        gui.Rebuild();
+                    }
+                });
 
             ChooseObject(gui, "Default belt:", Database.allBelts, prefs.defaultBelt, s => {
                 prefs.RecordUndo().defaultBelt = s;
@@ -91,6 +99,19 @@ namespace Yafc {
 
             if (settings.justChanged) {
                 Project.current.RecalculateDisplayPages();
+            }
+
+            static void drawInputRowWithTooltip(ImGui gui, string text, string tooltip, Action<ImGui> handleInput) {
+                using (gui.EnterRow()) {
+                    gui.BuildText(text, topOffset: 0.5f);
+                    gui.AllocateSpacing();
+                    gui.allocator = RectAllocator.RightRow;
+                    var rect = gui.AllocateRect(1, 1);
+                    handleInput(gui);
+                    rect = new Rect(rect.Center.X, gui.lastRect.Center.Y, 0, 0).Expand(.625f);
+                    gui.DrawIcon(rect, Icon.Help, SchemeColor.BackgroundText);
+                    gui.BuildButton(rect, SchemeColor.None, SchemeColor.Grey).WithTooltip(gui, tooltip, rect);
+                }
             }
         }
 

--- a/Yafc/Windows/SelectMultiObjectPanel.cs
+++ b/Yafc/Windows/SelectMultiObjectPanel.cs
@@ -29,7 +29,7 @@ namespace Yafc {
         }
 
         protected override void NonNullElementDrawer(ImGui gui, FactorioObject element, int index) {
-            bool click = gui.BuildFactorioObjectButton(element, display: MilestoneDisplay.Contained, bgColor: results.Contains(element) ? SchemeColor.Primary : SchemeColor.None, extendHeader: extendHeader);
+            bool click = gui.BuildFactorioObjectButton(element, 2.5f, MilestoneDisplay.Contained, results.Contains(element) ? SchemeColor.Primary : SchemeColor.None, extendHeader, true);
 
             if (checkMark(element)) {
                 gui.DrawIcon(Rect.SideRect(gui.lastRect.TopLeft + new Vector2(1, 0), gui.lastRect.BottomRight - new Vector2(0, 1)), Icon.Check, SchemeColor.Green);

--- a/Yafc/Windows/SelectSingleObjectPanel.cs
+++ b/Yafc/Windows/SelectSingleObjectPanel.cs
@@ -33,7 +33,7 @@ namespace Yafc {
             => Instance.Select(list, header, selectItem, ordering, (obj, mappedAction) => mappedAction(obj), true);
 
         protected override void NonNullElementDrawer(ImGui gui, FactorioObject element, int index) {
-            if (gui.BuildFactorioObjectButton(element, display: MilestoneDisplay.Contained, extendHeader: extendHeader)) {
+            if (gui.BuildFactorioObjectButton(element, 2.5f, MilestoneDisplay.Contained, extendHeader: extendHeader, useScale: true)) {
                 CloseWithResult(element);
             }
         }

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -252,7 +252,7 @@ goodsHaveNoProduction:;
                 using (var group = gui.EnterGroup(default, RectAllocator.Stretch, spacing: 0f)) {
                     group.SetWidth(3f);
                     if (recipe.fixedBuildings > 0) {
-                        var evt = gui.BuildFactorioObjectWithEditableAmount(recipe.entity, recipe.fixedBuildings, UnitOfMeasure.None, out float newAmount);
+                        var evt = gui.BuildFactorioObjectWithEditableAmount(recipe.entity, recipe.fixedBuildings, UnitOfMeasure.None, out float newAmount, useScale: false);
                         if (evt == GoodsWithAmountEvent.TextEditing) {
                             recipe.RecordUndo().fixedBuildings = newAmount;
                         }
@@ -260,7 +260,7 @@ goodsHaveNoProduction:;
                         clicked = evt == GoodsWithAmountEvent.ButtonClick;
                     }
                     else {
-                        clicked = gui.BuildFactorioObjectWithAmount(recipe.entity, recipe.buildingCount, UnitOfMeasure.None) && recipe.recipe.crafters.Length > 0;
+                        clicked = gui.BuildFactorioObjectWithAmount(recipe.entity, recipe.buildingCount, UnitOfMeasure.None, useScale: false) && recipe.recipe.crafters.Length > 0;
                     }
 
                     if (recipe.builtBuildings != null) {
@@ -480,7 +480,7 @@ goodsHaveNoProduction:;
                 using var grid = gui.EnterInlineGrid(3f);
                 if (recipe.parameters.modules.modules == null || recipe.parameters.modules.modules.Length == 0) {
                     grid.Next();
-                    if (gui.BuildFactorioObjectWithAmount(null, 0, UnitOfMeasure.None) && recipe.hierarchyEnabled) {
+                    if (gui.BuildFactorioObjectWithAmount(null, 0, UnitOfMeasure.None, useScale: false) && recipe.hierarchyEnabled) {
                         ShowModuleDropDown(gui, recipe);
                     }
                 }
@@ -491,13 +491,13 @@ goodsHaveNoProduction:;
                             wasBeacon = true;
                             if (recipe.parameters.modules.beacon != null) {
                                 grid.Next();
-                                if (gui.BuildFactorioObjectWithAmount(recipe.parameters.modules.beacon, recipe.parameters.modules.beaconCount, UnitOfMeasure.None)) {
+                                if (gui.BuildFactorioObjectWithAmount(recipe.parameters.modules.beacon, recipe.parameters.modules.beaconCount, UnitOfMeasure.None, useScale: false)) {
                                     ShowModuleDropDown(gui, recipe);
                                 }
                             }
                         }
                         grid.Next();
-                        if (gui.BuildFactorioObjectWithAmount(module, count, UnitOfMeasure.None)) {
+                        if (gui.BuildFactorioObjectWithAmount(module, count, UnitOfMeasure.None, useScale: false)) {
                             ShowModuleDropDown(gui, recipe);
                         }
                     }

--- a/changelog.txt
+++ b/changelog.txt
@@ -1,6 +1,9 @@
 ----------------------------------------------------------------------------------------------------------------------
 Version: 0.7.1
 Date: soon
+    Features:
+        - Allow configuring the size of icons that have backgrounds, since the icon may cover the entire
+          background area.
     Fixes:
         - Display spent fuel items in the production table and link summaries.
         - Fix error when switching items in NEIE with middle-click


### PR DESCRIPTION
This adds a new preference (and alters the UI for an existing one) to allow you to choose how much to scale down certain icons:
![image](https://github.com/have-fun-was-taken/yafc-ce/assets/21223975/b2335234-4ef0-41c9-ae27-7822cd9113b4)
The default is 90%, which is the middle size in this gif. The other two sizes shown are 80% and 100%; 100% shows the issue where the background color is not visible, hiding the link information.
![Untitled](https://github.com/have-fun-was-taken/yafc-ce/assets/21223975/48b36706-b765-4f38-bb71-6463d02676af)

The Desired products, Summary ingredients, and Extra products icons all scale too.

### Potential additions and/or reversions

The `SelectMultiObjectPanel` icons used to be fixed at 80%, but I chose to make them follow this setting too. The `SelectSingleObjectPanel`, icons were also fixed at 80%, but I just bumped them up to 100%, since they never have an interesting background. I can restore one or both `SelectObjectPanel` behaviors, or make `SelectSingleObjectPanel` follow this setting for consistency.
I can also extend the scaling to the recipe, entity, module, and/or beacon icons. I actually originally had the entity icon scale, but I saw how small the small assembler is (the crafter for Electrical engineering research 2) and decided I didn't want to make it even smaller.