### PR TITLE
Fix an exception when recipe-hovering with a pathological configuration.

### DIFF
--- a/Yafc.Model/Analysis/TechnologyScienceAnalysis.cs
+++ b/Yafc.Model/Analysis/TechnologyScienceAnalysis.cs
@@ -7,11 +7,15 @@ namespace Yafc.Model {
         public Mapping<Technology, Ingredient[]> allSciencePacks { get; private set; }
 
         public Ingredient? GetMaxTechnologyIngredient(Technology tech) {
-            var list = allSciencePacks[tech];
+            Ingredient[] list = allSciencePacks[tech];
             Ingredient? ingredient = null;
             Bits order = new Bits();
-            foreach (var entry in list) {
-                var entryOrder = Milestones.Instance.GetMilestoneResult(entry.goods.id) - 1;
+            foreach (Ingredient entry in list) {
+                Bits entryOrder = Milestones.Instance.GetMilestoneResult(entry.goods.id);
+                if (entryOrder != 0) {
+                    entryOrder -= 1;
+                }// else: The science pack is not accessible *and* not a milestone. We may still display it, but any actual milestone will win.
+
                 if (ingredient == null || entryOrder > order) {
                     order = entryOrder;
                     ingredient = entry;

--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,7 @@ Date: soon
     Fixes:
         - Display spent fuel items in the production table and link summaries.
         - Fix error when switching items in NEIE with middle-click
+        - Fix an exception when hovering over recipes in certain pathological cases.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 0.7.0
 Date: May 25th 2024


### PR DESCRIPTION
Specifically, an ArgumentOutOfRangeException happens when hovering over a recipe that is unlocked by a technology that (directly or indirectly) requires a science pack that is both (a) inaccessible and (b) not a milestone.

For an example of this in action, load [this vanilla project](https://github.com/user-attachments/files/15782026/exception.zip) and hover over either of the two personal roboport recipe icons. Both will cause an exception, but the steel recipe icon won't. Open the milestones editor and add Chemical science pack to the milestones. Alternatively, open the Dependency explorer for the Chemical science pack item, and click "Clear mark". In both cases, the exceptions will disappear.