### PR TITLE
Add keyboard and right-click shortcuts 

### DIFF
--- a/Yafc.Model/Blueprints/Blueprint.cs
+++ b/Yafc.Model/Blueprints/Blueprint.cs
@@ -14,7 +14,7 @@ namespace Yafc.Blueprints {
         private static readonly byte[] header = { 0x78, 0xDA };
 
         public string ToBpString() {
-            if (InputSystem.Instance.control) {
+            if (Ui.ActiveInputSystem?.control ?? false) {
                 return ToJson();
             }
 

--- a/Yafc.Model/Serialization/UndoSystem.cs
+++ b/Yafc.Model/Serialization/UndoSystem.cs
@@ -57,8 +57,10 @@ namespace Yafc.Model {
         }
 
         private void Schedule() {
-            InputSystem.Instance.DispatchOnGestureFinish(MakeUndoBatch, this);
-            scheduled = true;
+            if (Ui.ActiveInputSystem != null) {
+                Ui.ActiveInputSystem.DispatchOnGestureFinish(MakeUndoBatch, this);
+                scheduled = true;
+            }
         }
 
         public void Suspend() {

--- a/Yafc.UI/Core/InputSystem.cs
+++ b/Yafc.UI/Core/InputSystem.cs
@@ -17,10 +17,6 @@ namespace Yafc.UI {
     }
 
     public sealed class InputSystem {
-        public static readonly InputSystem Instance = new InputSystem();
-
-        private InputSystem() { }
-
         public Window? mouseOverWindow { get; private set; }
         private IPanel? hoveringPanel;
         private IPanel? mouseDownPanel;

--- a/Yafc.UI/Core/Ui.cs
+++ b/Yafc.UI/Core/Ui.cs
@@ -150,9 +150,6 @@ namespace Yafc.UI {
                                     window.FocusGained();
                                     window.Rebuild();
                                     break;
-                                case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_MINIMIZED:
-                                    window.Minimized();
-                                    break;
                                 case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_MOVED:
                                     window.WindowMoved();
                                     break;

--- a/Yafc.UI/Core/Window.cs
+++ b/Yafc.UI/Core/Window.cs
@@ -164,7 +164,6 @@ namespace Yafc.UI {
 
         public virtual void FocusLost() => active = false;
         public void FocusGained() => active = true;
-        public virtual void Minimized() { }
 
         public void SetNextRepaint(long nextRepaintTime) {
             if (this.nextRepaintTime > nextRepaintTime) {

--- a/Yafc.UI/Core/Window.cs
+++ b/Yafc.UI/Core/Window.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using SDL2;
 
@@ -14,6 +13,7 @@ namespace Yafc.UI {
         internal bool repaintRequired = true;
         internal bool visible;
         internal bool closed;
+        internal bool active;
         internal long nextRepaintTime = long.MaxValue;
         internal float pixelsPerUnit;
         public virtual SchemeColor backgroundColor => SchemeColor.Background;
@@ -28,10 +28,13 @@ namespace Yafc.UI {
         public int displayIndex => SDL.SDL_GetWindowDisplayIndex(window);
         public int repaintCount { get; private set; }
 
+        public InputSystem InputSystem { get; } = new();
+
         public Vector2 size => contentSize;
 
         public virtual bool preventQuit => false;
-        internal Window(Padding padding) => rootGui = new ImGui(Build, padding);
+
+        internal Window(Padding padding) => rootGui = new ImGui(Build, padding, InputSystem);
 
         internal void Create() {
             if (surface is null) { throw new InvalidOperationException($"surface must be set by a derived class before calling {nameof(Create)}."); }
@@ -142,6 +145,7 @@ namespace Yafc.UI {
 
         protected internal virtual void Close() {
             visible = false;
+            active = false;
             closed = true;
             surface?.Dispose();
             SDL.SDL_DestroyWindow(window);
@@ -158,8 +162,8 @@ namespace Yafc.UI {
             }
         }
 
-
-        public virtual void FocusLost() { }
+        public virtual void FocusLost() => active = false;
+        public void FocusGained() => active = true;
         public virtual void Minimized() { }
 
         public void SetNextRepaint(long nextRepaintTime) {
@@ -174,7 +178,7 @@ namespace Yafc.UI {
         }
 
         public void ShowTooltip(ImGui targetGui, Rect target, GuiBuilder builder, float width = 20f) {
-            simpleTooltip ??= new SimpleTooltip();
+            simpleTooltip ??= new SimpleTooltip(InputSystem);
             simpleTooltip.Show(builder, targetGui, target, width);
             ShowTooltip(simpleTooltip);
 
@@ -186,7 +190,7 @@ namespace Yafc.UI {
         }
 
         public void ShowDropDown(ImGui targetGui, Rect target, GuiBuilder builder, Padding padding, float width = 20f) {
-            simpleDropDown ??= new SimpleDropDown();
+            simpleDropDown ??= new SimpleDropDown(InputSystem);
             simpleDropDown.SetPadding(padding);
             simpleDropDown.SetFocus(targetGui, target, builder, width);
             ShowDropDown(simpleDropDown);
@@ -216,6 +220,6 @@ namespace Yafc.UI {
         protected abstract void BuildContents(ImGui gui);
         public virtual void Dispose() => rootGui.Dispose();
 
-        internal ImGui.DragOverlay GetDragOverlay() => draggingOverlay ??= new ImGui.DragOverlay();
+        internal ImGui.DragOverlay GetDragOverlay() => draggingOverlay ??= new ImGui.DragOverlay(InputSystem);
     }
 }

--- a/Yafc.UI/Core/WindowUtility.cs
+++ b/Yafc.UI/Core/WindowUtility.cs
@@ -63,10 +63,11 @@ namespace Yafc.UI {
 
         // TODO this is work-around for inability to create utility or modal window in SDL2
         // Fake utility windows are closed on focus lost
-        public override void Minimized() {
+        public override void FocusLost() {
             if (parent != null) {
                 Close();
             }
+            base.FocusLost();
         }
     }
 

--- a/Yafc.UI/ImGui/DropDownPanel.cs
+++ b/Yafc.UI/ImGui/DropDownPanel.cs
@@ -9,8 +9,8 @@ namespace Yafc.UI {
         protected float width;
         protected virtual SchemeColor background => SchemeColor.PureBackground;
 
-        protected AttachedPanel(Padding padding, float width) {
-            contents = new ImGui(BuildContents, padding) { boxColor = background, boxShadow = RectangleBorder.Thin };
+        protected AttachedPanel(Padding padding, float width, InputSystem inputSystem) {
+            contents = new ImGui(BuildContents, padding, inputSystem) { boxColor = background, boxShadow = RectangleBorder.Thin };
             this.width = width;
         }
 
@@ -49,13 +49,13 @@ namespace Yafc.UI {
         protected abstract void BuildContents(ImGui gui);
     }
 
-    public abstract class DropDownPanel : AttachedPanel, IMouseFocus {
+    public abstract class DropDownPanel(Padding padding, float width, InputSystem inputSystem) : AttachedPanel(padding, width, inputSystem), IMouseFocus {
         private bool focused;
-        protected DropDownPanel(Padding padding, float width) : base(padding, width) { }
+
         protected override bool ShouldBuild(ImGui source, Rect sourceRect, ImGui parent, Rect parentRect) => focused;
 
         public override void SetFocus(ImGui source, Rect rect) {
-            InputSystem.Instance.SetMouseFocus(this);
+            source.inputSystem.SetMouseFocus(this);
             base.SetFocus(source, rect);
         }
 
@@ -80,7 +80,7 @@ namespace Yafc.UI {
     public class SimpleDropDown : DropDownPanel {
         private GuiBuilder? builder;
 
-        public SimpleDropDown() : base(new Padding(1f), 20f) => contents.AddMessageHandler<ImGuiUtils.CloseDropdownEvent>(HandleDropdownClosed);
+        public SimpleDropDown(InputSystem inputSystem) : base(new Padding(1f), 20f, inputSystem) => contents.AddMessageHandler<ImGuiUtils.CloseDropdownEvent>(HandleDropdownClosed);
 
         private bool HandleDropdownClosed(ImGuiUtils.CloseDropdownEvent _) {
             Close();
@@ -118,10 +118,15 @@ namespace Yafc.UI {
     }
 
     public abstract class Tooltip : AttachedPanel {
-        protected Tooltip(Padding padding, float width) : base(padding, width) => contents.mouseCapture = false;
+        private readonly InputSystem inputSystem;
+        protected Tooltip(Padding padding, float width, InputSystem inputSystem) : base(padding, width, inputSystem) {
+            contents.mouseCapture = false;
+            this.inputSystem = inputSystem;
+        }
+
         protected override bool ShouldBuild(ImGui source, Rect sourceRect, ImGui parent, Rect parentRect) {
             var window = source.window;
-            if (InputSystem.Instance.mouseOverWindow != window) {
+            if (inputSystem.mouseOverWindow != window) {
                 return false;
             }
 
@@ -143,15 +148,13 @@ namespace Yafc.UI {
         }
     }
 
-    public class SimpleTooltip : Tooltip {
+    public class SimpleTooltip(InputSystem inputSystem) : Tooltip(new Padding(0.5f), 30f, inputSystem) {
         private GuiBuilder? builder;
         public void Show(GuiBuilder builder, ImGui gui, Rect rect, float width = 30f) {
             this.width = width;
             this.builder = builder;
             base.SetFocus(gui, rect);
         }
-
-        public SimpleTooltip() : base(new Padding(0.5f), 30f) { }
 
         protected override void BuildContents(ImGui gui) {
             gui.boxColor = SchemeColor.PureBackground;

--- a/Yafc.UI/ImGui/ImGui.cs
+++ b/Yafc.UI/ImGui/ImGui.cs
@@ -50,7 +50,7 @@ namespace Yafc.UI {
     public delegate void GuiBuilder(ImGui gui);
 
     public sealed partial class ImGui : IDisposable, IPanel {
-        public ImGui(GuiBuilder? guiBuilder, Padding padding, RectAllocator defaultAllocator = RectAllocator.Stretch, bool clip = false) {
+        public ImGui(GuiBuilder? guiBuilder, Padding padding, InputSystem inputSystem, RectAllocator defaultAllocator = RectAllocator.Stretch, bool clip = false) {
             this.guiBuilder = guiBuilder;
             if (guiBuilder == null) {
                 action = ImGuiAction.Build;
@@ -59,6 +59,7 @@ namespace Yafc.UI {
             this.defaultAllocator = defaultAllocator;
             this.clip = clip;
             initialPadding = padding;
+            this.inputSystem = inputSystem ?? throw new ArgumentNullException(nameof(inputSystem));
         }
 
         public readonly GuiBuilder? guiBuilder;
@@ -94,7 +95,7 @@ namespace Yafc.UI {
                 screenRect -= (_offset - value);
                 _offset = value;
                 if (mousePresent) {
-                    MouseMove(InputSystem.Instance.mouseDownButton);
+                    MouseMove(inputSystem.mouseDownButton);
                 }
                 else {
                     Repaint();

--- a/Yafc.UI/ImGui/ImGuiBuilding.cs
+++ b/Yafc.UI/ImGui/ImGuiBuilding.cs
@@ -30,6 +30,7 @@ namespace Yafc.UI {
         public SchemeColor boxColor { get; set; } = SchemeColor.None;
         public RectangleBorder boxShadow { get; set; } = RectangleBorder.None;
         public Padding initialPadding { get; set; }
+        internal readonly InputSystem inputSystem;
 
         public void DrawRectangle(Rect rect, SchemeColor color, RectangleBorder border = RectangleBorder.None) {
             if (action != ImGuiAction.Build) {
@@ -154,7 +155,7 @@ namespace Yafc.UI {
             }
         }
 
-        public Vector2 mousePosition => InputSystem.Instance.mousePosition - screenRect.Position;
+        public Vector2 mousePosition => inputSystem.mousePosition - screenRect.Position;
         public bool mousePresent { get; private set; }
         public Rect mouseDownRect { get; private set; }
         public Rect mouseOverRect { get; private set; } = Rect.VeryBig;
@@ -348,7 +349,7 @@ namespace Yafc.UI {
         }
 
         public void SetTextInputFocus(Rect rect, string text) {
-            if (textInputHelper != null && InputSystem.Instance.currentKeyboardFocus != textInputHelper) {
+            if (textInputHelper != null && inputSystem.currentKeyboardFocus != textInputHelper) {
                 SetFocus(rect);
                 textInputHelper.SetFocus(rect, text);
             }

--- a/Yafc.UI/ImGui/ImGuiDrag.cs
+++ b/Yafc.UI/ImGui/ImGuiDrag.cs
@@ -65,13 +65,12 @@ namespace Yafc.UI {
         }
 
 
-        internal class DragOverlay {
-            private readonly ImGui contents = new ImGui(null, default) { mouseCapture = false };
+        internal class DragOverlay(InputSystem inputSystem) {
+            private readonly ImGui contents = new ImGui(null, default, inputSystem) { mouseCapture = false };
 
             private ImGui? currentSource;
             private Vector2 mouseOffset;
             private Rect realPosition;
-
 
             public bool ShouldConsumeDrag(ImGui source, Vector2 point) => currentSource == source && realPosition.Contains(source.ToWindowPosition(point));
 
@@ -117,7 +116,7 @@ namespace Yafc.UI {
                     return;
                 }
 
-                if (InputSystem.Instance.mouseDownButton == -1) {
+                if (inputSystem.mouseDownButton == -1) {
                     currentSource = null;
                     realPosition = default;
                     return;
@@ -134,7 +133,7 @@ namespace Yafc.UI {
         }
 
         public bool ShouldEnterDrag(Rect moveHandle) {
-            if (action != ImGuiAction.MouseMove || !IsMouseDown(moveHandle) || isDragging || Vector2.DistanceSquared(InputSystem.Instance.mousePosition, InputSystem.Instance.mouseDownPosition) < 1f) {
+            if (action != ImGuiAction.MouseMove || !IsMouseDown(moveHandle) || isDragging || Vector2.DistanceSquared(inputSystem.mousePosition, inputSystem.mouseDownPosition) < 1f) {
                 return false;
             }
 

--- a/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
+++ b/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
@@ -252,7 +252,7 @@ namespace Yafc.UI {
                 case SDL.SDL_Scancode.SDL_SCANCODE_KP_ENTER:
                 case SDL.SDL_Scancode.SDL_SCANCODE_ESCAPE:
                     gui.inputSystem.SetKeyboardFocus(null);
-                    break;
+                    return false;
                 case SDL.SDL_Scancode.SDL_SCANCODE_LEFT:
                     if (shift) {
                         SetCaret(caret - 1, selectionAnchor);

--- a/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
+++ b/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
@@ -30,7 +30,7 @@ namespace Yafc.UI {
                 editHistory.Clear();
                 text = setText;
             }
-            InputSystem.Instance.SetKeyboardFocus(this);
+            gui.inputSystem.SetKeyboardFocus(this);
             rect = boundingRect;
             caret = selectionAnchor = setText.Length;
         }
@@ -251,7 +251,7 @@ namespace Yafc.UI {
                 case SDL.SDL_Scancode.SDL_SCANCODE_RETURN2:
                 case SDL.SDL_Scancode.SDL_SCANCODE_KP_ENTER:
                 case SDL.SDL_Scancode.SDL_SCANCODE_ESCAPE:
-                    InputSystem.Instance.SetKeyboardFocus(null);
+                    gui.inputSystem.SetKeyboardFocus(null);
                     break;
                 case SDL.SDL_Scancode.SDL_SCANCODE_LEFT:
                     if (shift) {

--- a/Yafc.UI/ImGui/ImGuiUtils.cs
+++ b/Yafc.UI/ImGui/ImGuiUtils.cs
@@ -99,7 +99,7 @@ namespace Yafc.UI {
             return false;
         }
 
-        public static bool BuildButton(this ImGui gui, string text, SchemeColor color = SchemeColor.Primary, Padding? padding = null, bool active = true) {
+        public static ButtonEvent BuildButton(this ImGui gui, string text, SchemeColor color = SchemeColor.Primary, Padding? padding = null, bool active = true) {
             if (!active) {
                 color = SchemeColor.Grey;
             }
@@ -108,7 +108,7 @@ namespace Yafc.UI {
                 gui.BuildText(text, Font.text, align: RectAlignment.Middle);
             }
 
-            return gui.BuildButton(gui.lastRect, color, color + 1) && active;
+            return active ? gui.BuildButton(gui.lastRect, color, color + 1) : ButtonEvent.None;
         }
 
         public static ButtonEvent BuildContextMenuButton(this ImGui gui, string text, string? rightText = null, Icon icon = default, bool disabled = false) {

--- a/Yafc.UI/ImGui/ImGuiUtils.cs
+++ b/Yafc.UI/ImGui/ImGuiUtils.cs
@@ -35,7 +35,7 @@ namespace Yafc.UI {
 
         public static ButtonEvent BuildButton(this ImGui gui, Rect rect, SchemeColor normal, SchemeColor over, SchemeColor down = SchemeColor.None, uint button = SDL.SDL_BUTTON_LEFT) {
             if (button == 0) {
-                button = (uint)InputSystem.Instance.mouseDownButton;
+                button = (uint)gui.inputSystem.mouseDownButton;
             }
 
             switch (gui.action) {

--- a/Yafc.UI/ImGui/ScrollArea.cs
+++ b/Yafc.UI/ImGui/ScrollArea.cs
@@ -59,12 +59,12 @@ namespace Yafc.UI {
             scrollSize = Vector2.Max(scrollSize, Vector2.One);
             var scrollStart = _scroll / maxScroll * (size - scrollSize);
             if ((gui.action == ImGuiAction.MouseDown || gui.action == ImGuiAction.MouseScroll) && rect.Contains(gui.mousePosition)) {
-                InputSystem.Instance.SetKeyboardFocus(this);
+                gui.inputSystem.SetKeyboardFocus(this);
             }
 
             if (gui.action == ImGuiAction.MouseScroll) {
                 if (gui.ConsumeEvent(rect)) {
-                    if (vertical && (!horizontal || !InputSystem.Instance.control)) {
+                    if (vertical && (!horizontal || !gui.inputSystem.control)) {
                         scroll += gui.actionParameter * 3f;
                     }
                     else {
@@ -98,10 +98,10 @@ namespace Yafc.UI {
                 case ImGuiAction.MouseMove:
                     if (gui.IsMouseDown(fullScrollRect, SDL.SDL_BUTTON_LEFT)) {
                         if (axis == 0) {
-                            scrollX += InputSystem.Instance.mouseDelta.X * contentSize.X / fullScrollRect.Width;
+                            scrollX += gui.inputSystem.mouseDelta.X * contentSize.X / fullScrollRect.Width;
                         }
                         else {
-                            scroll += InputSystem.Instance.mouseDelta.Y * contentSize.Y / fullScrollRect.Height;
+                            scroll += gui.inputSystem.mouseDelta.Y * contentSize.Y / fullScrollRect.Height;
                         }
                     }
                     break;
@@ -175,8 +175,8 @@ namespace Yafc.UI {
         protected ImGui contents;
         protected readonly float height;
 
-        public ScrollAreaBase(float height, Padding padding, bool collapsible = false, bool vertical = true, bool horizontal = false) : base(vertical, horizontal, collapsible) {
-            contents = new ImGui(BuildContents, padding, clip: true);
+        public ScrollAreaBase(float height, Padding padding, InputSystem inputSystem, bool collapsible = false, bool vertical = true, bool horizontal = false) : base(vertical, horizontal, collapsible) {
+            contents = new ImGui(BuildContents, padding, inputSystem, clip: true);
             this.height = height;
         }
 
@@ -194,7 +194,7 @@ namespace Yafc.UI {
         protected override Vector2 MeasureContent(Rect rect, ImGui gui) => contents.CalculateState(rect.Width, gui.pixelsPerUnit);
     }
 
-    public class ScrollArea(float height, GuiBuilder builder, Padding padding = default, bool collapsible = false, bool vertical = true, bool horizontal = false) : ScrollAreaBase(height, padding, collapsible, vertical, horizontal) {
+    public class ScrollArea(float height, GuiBuilder builder, InputSystem inputSystem, Padding padding = default, bool collapsible = false, bool vertical = true, bool horizontal = false) : ScrollAreaBase(height, padding, inputSystem, collapsible, vertical, horizontal) {
         protected override void BuildContents(ImGui gui) => builder(gui);
 
         public void Rebuild() => RebuildContents();
@@ -231,7 +231,7 @@ namespace Yafc.UI {
             }
         }
 
-        public VirtualScrollList(float height, Vector2 elementSize, Drawer drawer, Padding padding = default, Action<int, int>? reorder = null, bool collapsible = false) : base(height, padding, collapsible) {
+        public VirtualScrollList(float height, Vector2 elementSize, Drawer drawer, InputSystem inputSystem, Padding padding = default, Action<int, int>? reorder = null, bool collapsible = false) : base(height, padding, inputSystem, collapsible) {
             this.elementSize = elementSize;
             maxRowsVisible = MathUtils.Ceil(height / this.elementSize.Y) + bufferRows + 1;
             this.drawer = drawer;

--- a/Yafc/Widgets/ImmediateWidgets.cs
+++ b/Yafc/Widgets/ImmediateWidgets.cs
@@ -165,7 +165,7 @@ namespace Yafc {
             using (gui.EnterGroup(default, RectAllocator.Stretch)) {
                 if (gui.BuildInlineObjectList(list, ordering, header, out var selected, count, checkMark, extra)) {
                     selectItem(selected);
-                    if (!multiple || !InputSystem.Instance.control) {
+                    if (!multiple || !MainScreen.Instance.InputSystem.control) {
                         _ = gui.CloseDropdown();
                     }
                 }
@@ -210,7 +210,7 @@ namespace Yafc {
                 Click clicked = gui.BuildFactorioObjectButton(goods, 3f, MilestoneDisplay.Contained, bgColor, useScale: useScale);
                 if (goods != null) {
                     gui.BuildText(DataUtils.FormatAmount(amount, unit), Font.text, false, RectAlignment.Middle, textColor);
-                    if (InputSystem.Instance.control && gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.Grey) == ButtonEvent.MouseOver) {
+                    if (MainScreen.Instance.InputSystem.control && gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.Grey) == ButtonEvent.MouseOver) {
                         ShowPrecisionValueTooltip(gui, amount, unit, goods);
                     }
                 }

--- a/Yafc/Widgets/MainScreenTabBar.cs
+++ b/Yafc/Widgets/MainScreenTabBar.cs
@@ -11,7 +11,7 @@ namespace Yafc {
 
         public MainScreenTabBar(MainScreen screen) {
             this.screen = screen;
-            tabs = new ImGui(BuildContents, default, RectAllocator.LeftRow, true);
+            tabs = new ImGui(BuildContents, default, MainScreen.Instance.InputSystem, RectAllocator.LeftRow, true);
         }
 
         private void BuildContents(ImGui gui) {
@@ -67,7 +67,7 @@ namespace Yafc {
 
                 var evt = gui.BuildButton(gui.lastRect, isActive ? SchemeColor.Background : SchemeColor.BackgroundAlt, (isActive || isSecondary) ? SchemeColor.Background : SchemeColor.Grey);
                 if (evt == ButtonEvent.Click) {
-                    changePage = InputSystem.Instance.control ? 2 : 1;
+                    changePage = MainScreen.Instance.InputSystem.control ? 2 : 1;
                     changePageTo = page;
                 }
                 else if (evt == ButtonEvent.MouseOver) {

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -7,7 +7,7 @@ namespace Yafc {
     public class ObjectTooltip : Tooltip {
         public static readonly Padding contentPadding = new Padding(1f, 0.25f);
 
-        public ObjectTooltip() : base(new Padding(0f, 0f, 0f, 0.5f), 25f) { }
+        public ObjectTooltip() : base(new Padding(0f, 0f, 0f, 0.5f), 25f, MainScreen.Instance.InputSystem) { }
 
         private IFactorioObjectWrapper target = null!; // null-forgiving: Set by SetFocus, aka ShowTooltip.
         /// <summary>
@@ -127,7 +127,7 @@ namespace Yafc {
         private void BuildCommon(FactorioObject target, ImGui gui) {
             BuildHeader(gui);
             using (gui.EnterGroup(contentPadding)) {
-                if (InputSystem.Instance.control) {
+                if (MainScreen.Instance.InputSystem.control) {
                     gui.BuildText(target.typeDotName);
                 }
 

--- a/Yafc/Widgets/PseudoScreen.cs
+++ b/Yafc/Widgets/PseudoScreen.cs
@@ -12,7 +12,7 @@ namespace Yafc {
 
         protected PseudoScreen(float width = 40f) {
             this.width = width;
-            contents = new ImGui(Build, ImGuiUtils.DefaultScreenPadding) {
+            contents = new ImGui(Build, ImGuiUtils.DefaultScreenPadding, MainScreen.Instance.InputSystem) {
                 boxColor = SchemeColor.PureBackground
             };
         }
@@ -51,8 +51,8 @@ namespace Yafc {
             }
 
             opened = false;
-            InputSystem.Instance.SetDefaultKeyboardFocus(null);
-            InputSystem.Instance.SetKeyboardFocus(null);
+            MainScreen.Instance.InputSystem.SetDefaultKeyboardFocus(null);
+            MainScreen.Instance.InputSystem.SetKeyboardFocus(null);
             MainScreen.Instance.ClosePseudoScreen(this);
         }
 

--- a/Yafc/Widgets/SearchableList.cs
+++ b/Yafc/Widgets/SearchableList.cs
@@ -3,7 +3,8 @@ using System.Numerics;
 using Yafc.UI;
 
 namespace Yafc {
-    public class SearchableList<TData>(float height, Vector2 elementSize, VirtualScrollList<TData>.Drawer drawer, SearchableList<TData>.Filter filter, IComparer<TData>? comparer = null) : VirtualScrollList<TData>(height, elementSize, drawer) {
+    public class SearchableList<TData>(float height, Vector2 elementSize, VirtualScrollList<TData>.Drawer drawer, SearchableList<TData>.Filter filter, IComparer<TData>? comparer = null)
+        : VirtualScrollList<TData>(height, elementSize, drawer, MainScreen.Instance.InputSystem) {
         private readonly List<TData> list = [];
 
         public delegate bool Filter(TData data, SearchQuery searchTokens);

--- a/Yafc/Windows/DependencyExplorer.cs
+++ b/Yafc/Windows/DependencyExplorer.cs
@@ -29,8 +29,8 @@ namespace Yafc {
 
 
         public DependencyExplorer(FactorioObject current) : base(60f) {
-            dependencies = new ScrollArea(30f, DrawDependencies);
-            dependents = new ScrollArea(30f, DrawDependants);
+            dependencies = new ScrollArea(30f, DrawDependencies, MainScreen.Instance.InputSystem);
+            dependents = new ScrollArea(30f, DrawDependants, MainScreen.Instance.InputSystem);
             this.current = current;
         }
 

--- a/Yafc/Windows/DependencyExplorer.cs
+++ b/Yafc/Windows/DependencyExplorer.cs
@@ -45,7 +45,7 @@ namespace Yafc {
                 string text = fobj.locName + " (" + fobj.type + ")";
                 gui.RemainingRow(0.5f).BuildText(text, null, true, color: fobj.IsAccessible() ? SchemeColor.BackgroundText : SchemeColor.BackgroundTextFaint);
             }
-            if (gui.BuildFactorioObjectButton(gui.lastRect, fobj, extendHeader: true)) {
+            if (gui.BuildFactorioObjectButton(gui.lastRect, fobj, extendHeader: true) == Click.Left) {
                 Change(fobj);
             }
         }
@@ -108,7 +108,7 @@ namespace Yafc {
             BuildHeader(gui, "Dependency explorer");
             using (gui.EnterRow()) {
                 gui.BuildText("Currently inspecting:", Font.subheader);
-                if (gui.BuildFactorioObjectButtonWithText(current)) {
+                if (gui.BuildFactorioObjectButtonWithText(current) == Click.Left) {
                     SelectSingleObjectPanel.Select(Database.objects.all, "Select something", Change);
                 }
 

--- a/Yafc/Windows/ErrorListPanel.cs
+++ b/Yafc/Windows/ErrorListPanel.cs
@@ -8,7 +8,7 @@ namespace Yafc {
         private readonly (string error, ErrorSeverity severity)[] errors;
 
         private ErrorListPanel(ErrorCollector collector) : base(60f) {
-            verticalList = new ScrollArea(30f, BuildErrorList, default, true);
+            verticalList = new ScrollArea(30f, BuildErrorList, MainScreen.Instance.InputSystem, collapsible: true);
             this.collector = collector;
             errors = collector.GetArrErrors();
         }

--- a/Yafc/Windows/ErrorListPanel.cs
+++ b/Yafc/Windows/ErrorListPanel.cs
@@ -36,5 +36,7 @@ namespace Yafc {
             verticalList.Build(gui);
 
         }
+
+        protected override void ReturnPressed() => Close();
     }
 }

--- a/Yafc/Windows/FilesystemScreen.cs
+++ b/Yafc/Windows/FilesystemScreen.cs
@@ -34,7 +34,7 @@ namespace Yafc {
             this.extension = extension;
             this.filter = filter;
             this.button = button;
-            entries = new VirtualScrollList<(EntryType type, string location)>(30f, new Vector2(float.PositiveInfinity, 1.5f), BuildElement);
+            entries = new VirtualScrollList<(EntryType type, string location)>(30f, new Vector2(float.PositiveInfinity, 1.5f), BuildElement, InputSystem);
             SetLocation(Directory.Exists(location) ? location : YafcLib.initialWorkDir);
             Create(header, 30f, parent);
         }

--- a/Yafc/Windows/FilesystemScreen.cs
+++ b/Yafc/Windows/FilesystemScreen.cs
@@ -3,10 +3,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Numerics;
+using SDL2;
 using Yafc.UI;
 
 namespace Yafc {
-    public class FilesystemScreen : TaskWindow<string?> {
+    public class FilesystemScreen : TaskWindow<string?>, IKeyboardFocus {
         private enum EntryType { Drive, ParentDirectory, Directory, CreateDirectory, File }
         public enum Mode {
             SelectFolder,
@@ -37,6 +38,7 @@ namespace Yafc {
             entries = new VirtualScrollList<(EntryType type, string location)>(30f, new Vector2(float.PositiveInfinity, 1.5f), BuildElement, InputSystem);
             SetLocation(Directory.Exists(location) ? location : YafcLib.initialWorkDir);
             Create(header, 30f, parent);
+            InputSystem.SetDefaultKeyboardFocus(this);
         }
 
         protected override void BuildContents(ImGui gui) {
@@ -162,6 +164,25 @@ namespace Yafc {
                 else {
                     SetLocation(element.location);
                 }
+            }
+        }
+
+        public bool KeyDown(SDL.SDL_Keysym key) {
+            if (resultValid && key.scancode is SDL.SDL_Scancode.SDL_SCANCODE_RETURN or SDL.SDL_Scancode.SDL_SCANCODE_RETURN2 or SDL.SDL_Scancode.SDL_SCANCODE_KP_ENTER) {
+                CloseWithResult(selectedResult);
+                return true;
+            }
+            else if (key.scancode is SDL.SDL_Scancode.SDL_SCANCODE_ESCAPE) {
+                Close();
+                return true;
+            }
+            return false;
+        }
+        public bool TextInput(string input) => false;
+        public bool KeyUp(SDL.SDL_Keysym key) => false;
+        public void FocusChanged(bool focused) {
+            if (focused) {
+                InputSystem.SetKeyboardFocus(this);
             }
         }
     }

--- a/Yafc/Windows/ImageSharePanel.cs
+++ b/Yafc/Windows/ImageSharePanel.cs
@@ -9,7 +9,6 @@ namespace Yafc {
         private readonly string header;
         private readonly string name;
         private static readonly string TempImageFile = Path.Combine(Path.GetTempPath(), "yafc_temp.png");
-        private FilesystemScreen? fsScreen;
         private bool copied;
 
         public ImageSharePanel(MemoryDrawingSurface surface, string name) {
@@ -50,8 +49,7 @@ namespace Yafc {
         }
 
         private async void SaveAsPng() {
-            fsScreen ??= new FilesystemScreen(header, "Save as PNG", "Save", null, FilesystemScreen.Mode.SelectOrCreateFile, name + ".png", MainScreen.Instance, null, "png");
-            string? path = await fsScreen;
+            string? path = await new FilesystemScreen(header, "Save as PNG", "Save", null, FilesystemScreen.Mode.SelectOrCreateFile, name + ".png", MainScreen.Instance, null, "png");
             if (path != null) {
                 surface?.SavePng(path);
             }
@@ -60,8 +58,6 @@ namespace Yafc {
         protected override void Close(bool save = true) {
             base.Close(save);
             surface?.Dispose();
-            fsScreen?.Close();
-            fsScreen = null;
         }
     }
 }

--- a/Yafc/Windows/ImageSharePanel.cs
+++ b/Yafc/Windows/ImageSharePanel.cs
@@ -41,12 +41,12 @@ namespace Yafc {
         }
 
         public override bool KeyDown(SDL.SDL_Keysym key) {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_C && InputSystem.Instance.control) {
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_C && MainScreen.Instance.InputSystem.control) {
                 WindowsClipboard.CopySurfaceToClipboard(surface);
                 copied = true;
                 Rebuild();
             }
-            return base.KeyUp(key);
+            return base.KeyDown(key);
         }
 
         private async void SaveAsPng() {

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -546,35 +546,40 @@ namespace Yafc {
         public bool KeyDown(SDL.SDL_Keysym key) {
             bool ctrl = (key.mod & SDL.SDL_Keymod.KMOD_CTRL) != 0;
             if (ctrl) {
-                if (key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_S) {
-                    SaveProject().CaptureException();
-                }
-                else if (key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_Z) {
-                    if ((key.mod & SDL.SDL_Keymod.KMOD_SHIFT) != 0) {
-                        project.undo.PerformRedo();
-                    }
-                    else {
-                        project.undo.PerformUndo();
-                    }
+                switch (key.scancode) {
+                    case SDL.SDL_Scancode.SDL_SCANCODE_S:
+                        SaveProject().CaptureException();
+                        break;
+                    case SDL.SDL_Scancode.SDL_SCANCODE_Z:
+                        if ((key.mod & SDL.SDL_Keymod.KMOD_SHIFT) != 0) {
+                            project.undo.PerformRedo();
+                        }
+                        else {
+                            project.undo.PerformUndo();
+                        }
 
-                    _activePageView?.Rebuild(false);
-                    secondaryPageView?.Rebuild(false);
-                }
-                else if (key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_Y) {
-                    project.undo.PerformRedo();
-                    _activePageView?.Rebuild(false);
-                    secondaryPageView?.Rebuild(false);
-                }
-                else if (key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_N) {
-                    ShowNeie();
-                }
-                else if (key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_F) {
-                    ShowSearch();
-                }
-                else {
-                    if (_activePageView?.ControlKey(key.scancode) != true) {
-                        _ = (secondaryPageView?.ControlKey(key.scancode));
-                    }
+                        _activePageView?.Rebuild(false);
+                        secondaryPageView?.Rebuild(false);
+                        break;
+                    case SDL.SDL_Scancode.SDL_SCANCODE_Y:
+                        project.undo.PerformRedo();
+                        _activePageView?.Rebuild(false);
+                        secondaryPageView?.Rebuild(false);
+                        break;
+                    case SDL.SDL_Scancode.SDL_SCANCODE_N:
+                        ShowNeie();
+                        break;
+                    case SDL.SDL_Scancode.SDL_SCANCODE_F:
+                        ShowSearch();
+                        break;
+                    case SDL.SDL_Scancode.SDL_SCANCODE_T:
+                        ProductionTableView.CreateProductionSheet();
+                        break;
+                    default:
+                        if (_activePageView?.ControlKey(key.scancode) != true) {
+                            _ = (secondaryPageView?.ControlKey(key.scancode));
+                        }
+                        break;
                 }
             }
 

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -18,7 +18,7 @@ namespace Yafc {
         ///<summary>Unique ID for the Summary page</summary>
         public static readonly Guid SummaryGuid = Guid.Parse("9bdea333-4be2-4be3-b708-b36a64672a40");
         public static MainScreen Instance { get; private set; } = null!; // null-forgiving: Set by the instance constructor
-        private readonly ObjectTooltip objectTooltip = new ObjectTooltip();
+        private readonly ObjectTooltip objectTooltip;
         private readonly List<PseudoScreen> pseudoScreens = [];
         private readonly VirtualScrollList<ProjectPage> allPages;
         private readonly MainScreenTabBar tabBar;
@@ -45,15 +45,16 @@ namespace Yafc {
         private readonly Dictionary<Type, ProjectPageView> secondaryPageViews = [];
 
         public MainScreen(int display, Project project) : base(default) {
+            Instance = this;
             summaryView = new SummaryView(project);
             RegisterPageView<ProductionTable>(new ProductionTableView());
             RegisterPageView<AutoPlanner>(new AutoPlannerView());
             RegisterPageView<ProductionSummary>(new ProductionSummaryView());
             RegisterPageView<Summary>(summaryView);
-            searchGui = new ImGui(BuildSearch, new Padding(1f)) { boxShadow = RectangleBorder.Thin, boxColor = SchemeColor.Background };
-            Instance = this;
+            searchGui = new ImGui(BuildSearch, new Padding(1f), InputSystem) { boxShadow = RectangleBorder.Thin, boxColor = SchemeColor.Background };
+            objectTooltip = new ObjectTooltip();
             tabBar = new MainScreenTabBar(this);
-            allPages = new VirtualScrollList<ProjectPage>(30, new Vector2(0f, 2f), BuildPage, collapsible: true);
+            allPages = new VirtualScrollList<ProjectPage>(30, new Vector2(0f, 2f), BuildPage, InputSystem, collapsible: true);
             Create("Yet Another Factorio Calculator CE v" + YafcLib.version, display);
             SetProject(project);
         }
@@ -89,7 +90,7 @@ namespace Yafc {
             SetActivePage(project.FindPage(project.displayPages[0]));
             project.metaInfoChanged += ProjectOnMetaInfoChanged;
             project.settings.changed += ProjectSettingsChanged;
-            InputSystem.Instance.SetDefaultKeyboardFocus(this);
+            InputSystem.SetDefaultKeyboardFocus(this);
         }
 
         private void ProjectSettingsChanged(bool visualOnly) {
@@ -207,14 +208,14 @@ namespace Yafc {
 
                 if (top != topScreen) {
                     topScreen = top;
-                    InputSystem.Instance.SetDefaultKeyboardFocus(top);
+                    InputSystem.SetDefaultKeyboardFocus(top);
                 }
                 top.Build(gui, size);
             }
             else {
                 if (topScreen != null) {
                     project.undo.Resume();
-                    InputSystem.Instance.SetDefaultKeyboardFocus(this);
+                    InputSystem.SetDefaultKeyboardFocus(this);
                     topScreen = null;
                     if (analysisUpdatePending) {
                         ReRunAnalysis();

--- a/Yafc/Windows/MessageBox.cs
+++ b/Yafc/Windows/MessageBox.cs
@@ -46,5 +46,7 @@ namespace Yafc {
                 }
             }
         }
+
+        protected override void ReturnPressed() => CloseWithResult(true);
     }
 }

--- a/Yafc/Windows/MilestonesEditor.cs
+++ b/Yafc/Windows/MilestonesEditor.cs
@@ -8,7 +8,7 @@ namespace Yafc {
         private static readonly MilestonesEditor Instance = new MilestonesEditor();
         private readonly VirtualScrollList<FactorioObject> milestoneList;
 
-        public MilestonesEditor() : base(50) => milestoneList = new VirtualScrollList<FactorioObject>(30f, new Vector2(float.PositiveInfinity, 3f), MilestoneDrawer);
+        public MilestonesEditor() : base(50) => milestoneList = new VirtualScrollList<FactorioObject>(30f, new Vector2(float.PositiveInfinity, 3f), MilestoneDrawer, MainScreen.Instance.InputSystem);
 
         public override void Open() {
             base.Open();

--- a/Yafc/Windows/MilestonesPanel.cs
+++ b/Yafc/Windows/MilestonesPanel.cs
@@ -4,7 +4,7 @@ using Yafc.UI;
 
 namespace Yafc {
     public class MilestonesWidget : VirtualScrollList<FactorioObject> {
-        public MilestonesWidget() : base(30f, new Vector2(3f, 3f), MilestoneDrawer) => data = Project.current.settings.milestones;
+        public MilestonesWidget() : base(30f, new Vector2(3f, 3f), MilestoneDrawer, MainScreen.Instance.InputSystem) => data = Project.current.settings.milestones;
 
         private static void MilestoneDrawer(ImGui gui, FactorioObject element, int index) {
             var settings = Project.current.settings;

--- a/Yafc/Windows/MilestonesPanel.cs
+++ b/Yafc/Windows/MilestonesPanel.cs
@@ -55,5 +55,7 @@ namespace Yafc {
                 }
             }
         }
+
+        protected override void ReturnPressed() => Close();
     }
 }

--- a/Yafc/Windows/MilestonesPanel.cs
+++ b/Yafc/Windows/MilestonesPanel.cs
@@ -9,7 +9,7 @@ namespace Yafc {
         private static void MilestoneDrawer(ImGui gui, FactorioObject element, int index) {
             var settings = Project.current.settings;
             bool unlocked = settings.Flags(element).HasFlags(ProjectPerItemFlags.MilestoneUnlocked);
-            if (gui.BuildFactorioObjectButton(element, 3f, display: MilestoneDisplay.None, bgColor: unlocked ? SchemeColor.Primary : SchemeColor.None)) {
+            if (gui.BuildFactorioObjectButton(element, 3f, display: MilestoneDisplay.None, bgColor: unlocked ? SchemeColor.Primary : SchemeColor.None) == Click.Left) {
                 if (!unlocked) {
                     var massUnlock = Milestones.Instance.GetMilestoneResult(element);
                     int subIndex = 0;

--- a/Yafc/Windows/NeverEnoughItemsPanel.cs
+++ b/Yafc/Windows/NeverEnoughItemsPanel.cs
@@ -62,8 +62,8 @@ namespace Yafc {
         private RecipeEntry[] usages = [];
 
         private NeverEnoughItemsPanel() : base(76f) {
-            productionList = new ScrollArea(40f, BuildItemProduction, new Padding(0.5f));
-            usageList = new ScrollArea(40f, BuildItemUsages, new Padding(0.5f));
+            productionList = new ScrollArea(40f, BuildItemProduction, MainScreen.Instance.InputSystem, new Padding(0.5f));
+            usageList = new ScrollArea(40f, BuildItemUsages, MainScreen.Instance.InputSystem, new Padding(0.5f));
         }
 
         /// <summary>

--- a/Yafc/Windows/NeverEnoughItemsPanel.cs
+++ b/Yafc/Windows/NeverEnoughItemsPanel.cs
@@ -118,7 +118,7 @@ namespace Yafc {
                 return;
             }
             foreach (var ingredient in recipe.ingredients) {
-                if (gui.BuildFactorioObjectWithAmount(ingredient.goods, ingredient.amount, UnitOfMeasure.None)) {
+                if (gui.BuildFactorioObjectWithAmount(ingredient.goods, ingredient.amount, UnitOfMeasure.None) == Click.Left) {
                     if (ingredient.variants != null) {
                         gui.ShowDropDown(imGui => imGui.BuildInlineObjectListAndButton<Goods>(ingredient.variants, DataUtils.DefaultOrdering, SetItem, "Accepted fluid variants"));
                     }
@@ -136,7 +136,7 @@ namespace Yafc {
             }
             for (int i = recipe.products.Length - 1; i >= 0; i--) {
                 var product = recipe.products[i];
-                if (gui.BuildFactorioObjectWithAmount(product.goods, product.amount, UnitOfMeasure.None)) {
+                if (gui.BuildFactorioObjectWithAmount(product.goods, product.amount, UnitOfMeasure.None) == Click.Left) {
                     changing = product.goods;
                 }
             }
@@ -146,7 +146,7 @@ namespace Yafc {
             using var grid = gui.EnterInlineGrid(3f, 0f, maxElemCount);
             foreach (var item in list) {
                 grid.Next();
-                if (gui.BuildFactorioObjectWithAmount(item.target, item.amount, UnitOfMeasure.None)) {
+                if (gui.BuildFactorioObjectWithAmount(item.target, item.amount, UnitOfMeasure.None) == Click.Left) {
                     changing = item.target as Goods;
                 }
             }
@@ -335,7 +335,7 @@ namespace Yafc {
 
                 for (int i = recent.Count - 1; i >= 0; i--) {
                     var elem = recent[i];
-                    if (gui.BuildFactorioObjectButton(elem, 3f)) {
+                    if (gui.BuildFactorioObjectButton(elem, 3f) == Click.Left) {
                         changing = elem;
                     }
                 }
@@ -352,7 +352,7 @@ namespace Yafc {
                 }
             }
 
-            if (gui.BuildFactorioObjectButton(gui.lastRect, current, SchemeColor.Grey)) {
+            if (gui.BuildFactorioObjectButton(gui.lastRect, current, SchemeColor.Grey) == Click.Left) {
                 SelectSingleObjectPanel.Select(Database.goods.all, "Select item", SetItem);
             }
 

--- a/Yafc/Windows/PreferencesScreen.cs
+++ b/Yafc/Windows/PreferencesScreen.cs
@@ -115,6 +115,8 @@ namespace Yafc {
             }
         }
 
+        protected override void ReturnPressed() => Close();
+
         /// <summary>Add a GUI element that opens a popup to allow the user to choose from the <paramref name="list"/>, which triggers <paramref name="selectItem"/>.</summary>
         /// <param name="text">Label to show.</param>
         /// <param name="width">Width of the popup. Make sure it is wide enough to fit text!</param>

--- a/Yafc/Windows/PreferencesScreen.cs
+++ b/Yafc/Windows/PreferencesScreen.cs
@@ -121,7 +121,7 @@ namespace Yafc {
         private static void ChooseObject<T>(ImGui gui, string text, T[] list, T? current, Action<T> selectItem, float width = 20f) where T : FactorioObject {
             using (gui.EnterRow()) {
                 gui.BuildText(text, topOffset: 0.5f);
-                if (gui.BuildFactorioObjectButtonWithText(current)) {
+                if (gui.BuildFactorioObjectButtonWithText(current) == Click.Left) {
                     gui.BuildObjectSelectDropDown(list, DataUtils.DefaultOrdering, selectItem, text, width: width);
                 }
             }
@@ -134,7 +134,7 @@ namespace Yafc {
         private static void ChooseObjectWithNone<T>(ImGui gui, string text, T[] list, T? current, Action<T?> selectItem, float width = 20f) where T : FactorioObject {
             using (gui.EnterRow()) {
                 gui.BuildText(text, topOffset: 0.5f);
-                if (gui.BuildFactorioObjectButtonWithText(current)) {
+                if (gui.BuildFactorioObjectButtonWithText(current) == Click.Left) {
                     gui.BuildObjectSelectDropDownWithNone(list, DataUtils.DefaultOrdering, selectItem, text, width: width);
                 }
             }

--- a/Yafc/Windows/ProjectPageSettingsPanel.cs
+++ b/Yafc/Windows/ProjectPageSettingsPanel.cs
@@ -51,16 +51,11 @@ namespace Yafc {
 
             using (gui.EnterRow(0.5f, RectAllocator.RightRow)) {
                 if (editingPage == null && gui.BuildButton("Create", active: !string.IsNullOrEmpty(name))) {
-                    callback?.Invoke(name, icon);
-                    Close();
+                    ReturnPressed();
                 }
 
                 if (editingPage != null && gui.BuildButton("OK", active: !string.IsNullOrEmpty(name))) {
-                    if (editingPage.name != name || editingPage.icon != icon) {
-                        editingPage.RecordUndo(true).name = name!; // null-forgiving: The button is disabled if name is null or empty.
-                        editingPage.icon = icon;
-                    }
-                    Close();
+                    ReturnPressed();
                 }
 
                 if (gui.BuildButton("Cancel", SchemeColor.Grey)) {
@@ -83,6 +78,17 @@ namespace Yafc {
                     Close();
                 }
             }
+        }
+
+        protected override void ReturnPressed() {
+            if (editingPage is null) {
+                callback?.Invoke(name, icon);
+            }
+            else if (editingPage.name != name || editingPage.icon != icon) {
+                editingPage.RecordUndo(true).name = name!; // null-forgiving: The button is disabled if name is null or empty.
+                editingPage.icon = icon;
+            }
+            Close();
         }
 
         private void OtherToolsDropdown(ImGui gui) {

--- a/Yafc/Windows/ProjectPageSettingsPanel.cs
+++ b/Yafc/Windows/ProjectPageSettingsPanel.cs
@@ -28,7 +28,7 @@ namespace Yafc {
 
         private void Build(ImGui gui, Action<FactorioObject?> setIcon) {
             _ = gui.BuildTextInput(name, out name, "Input name");
-            if (gui.BuildFactorioObjectButton(icon, 4f, MilestoneDisplay.None, SchemeColor.Grey)) {
+            if (gui.BuildFactorioObjectButton(icon, 4f, MilestoneDisplay.None, SchemeColor.Grey) == Click.Left) {
                 SelectSingleObjectPanel.Select(Database.objects.all, "Select icon", setIcon);
             }
 

--- a/Yafc/Windows/SelectMultiObjectPanel.cs
+++ b/Yafc/Windows/SelectMultiObjectPanel.cs
@@ -39,7 +39,7 @@ namespace Yafc {
                 if (!results.Add(element)) {
                     _ = results.Remove(element);
                 }
-                if (!InputSystem.Instance.control && allowAutoClose) {
+                if (!MainScreen.Instance.InputSystem.control && allowAutoClose) {
                     CloseWithResult(results);
                 }
                 allowAutoClose = false;

--- a/Yafc/Windows/SelectMultiObjectPanel.cs
+++ b/Yafc/Windows/SelectMultiObjectPanel.cs
@@ -29,13 +29,13 @@ namespace Yafc {
         }
 
         protected override void NonNullElementDrawer(ImGui gui, FactorioObject element, int index) {
-            bool click = gui.BuildFactorioObjectButton(element, 2.5f, MilestoneDisplay.Contained, results.Contains(element) ? SchemeColor.Primary : SchemeColor.None, extendHeader, true);
+            Click click = gui.BuildFactorioObjectButton(element, 2.5f, MilestoneDisplay.Contained, results.Contains(element) ? SchemeColor.Primary : SchemeColor.None, extendHeader, true);
 
             if (checkMark(element)) {
                 gui.DrawIcon(Rect.SideRect(gui.lastRect.TopLeft + new Vector2(1, 0), gui.lastRect.BottomRight - new Vector2(0, 1)), Icon.Check, SchemeColor.Green);
             }
 
-            if (click) {
+            if (click == Click.Left) {
                 if (!results.Add(element)) {
                     _ = results.Remove(element);
                 }

--- a/Yafc/Windows/SelectSingleObjectPanel.cs
+++ b/Yafc/Windows/SelectSingleObjectPanel.cs
@@ -33,7 +33,7 @@ namespace Yafc {
             => Instance.Select(list, header, selectItem, ordering, (obj, mappedAction) => mappedAction(obj), true);
 
         protected override void NonNullElementDrawer(ImGui gui, FactorioObject element, int index) {
-            if (gui.BuildFactorioObjectButton(element, 2.5f, MilestoneDisplay.Contained, extendHeader: extendHeader, useScale: true)) {
+            if (gui.BuildFactorioObjectButton(element, 2.5f, MilestoneDisplay.Contained, extendHeader: extendHeader, useScale: true) == Click.Left) {
                 CloseWithResult(element);
             }
         }

--- a/Yafc/Windows/ShoppingListScreen.cs
+++ b/Yafc/Windows/ShoppingListScreen.cs
@@ -13,7 +13,7 @@ namespace Yafc {
         private float shoppingCost, totalBuildings, totalModules;
         private bool decomposed = false;
 
-        private ShoppingListScreen() => list = new VirtualScrollList<(FactorioObject, float)>(30f, new Vector2(float.PositiveInfinity, 2), ElementDrawer);
+        private ShoppingListScreen() => list = new VirtualScrollList<(FactorioObject, float)>(30f, new Vector2(float.PositiveInfinity, 2), ElementDrawer, MainScreen.Instance.InputSystem);
 
         private void ElementDrawer(ImGui gui, (FactorioObject obj, float count) element, int index) {
             using (gui.EnterRow()) {

--- a/Yafc/Windows/ShoppingListScreen.cs
+++ b/Yafc/Windows/ShoppingListScreen.cs
@@ -86,12 +86,12 @@ namespace Yafc {
 
         private void ExportBlueprintDropdown(ImGui gui) {
             gui.BuildText("Blueprint string will be copied to clipboard", wrap: true);
-            if (Database.objectsByTypeName.TryGetValue("Entity.constant-combinator", out var combinator) && gui.BuildFactorioObjectButtonWithText(combinator) && gui.CloseDropdown()) {
+            if (Database.objectsByTypeName.TryGetValue("Entity.constant-combinator", out var combinator) && gui.BuildFactorioObjectButtonWithText(combinator) == Click.Left && gui.CloseDropdown()) {
                 _ = BlueprintUtilities.ExportConstantCombinators("Shopping list", ExportGoods<Goods>());
             }
 
             foreach (var container in Database.allContainers) {
-                if (container.logisticMode == "requester" && gui.BuildFactorioObjectButtonWithText(container) && gui.CloseDropdown()) {
+                if (container.logisticMode == "requester" && gui.BuildFactorioObjectButtonWithText(container) == Click.Left && gui.CloseDropdown()) {
                     _ = BlueprintUtilities.ExportRequesterChests("Shopping list", ExportGoods<Item>(), container);
                 }
             }

--- a/Yafc/Windows/WelcomeScreen.cs
+++ b/Yafc/Windows/WelcomeScreen.cs
@@ -10,7 +10,7 @@ using Yafc.Parser;
 using Yafc.UI;
 
 namespace Yafc {
-    public class WelcomeScreen : WindowUtility, IProgress<(string, string)> {
+    public class WelcomeScreen : WindowUtility, IProgress<(string, string)>, IKeyboardFocus {
         private bool loading;
         private string? currentLoad1, currentLoad2;
         private string path = "", dataPath = "", modsPath = "";
@@ -82,6 +82,8 @@ namespace Yafc {
                 ProjectDefinition? lastProject = Preferences.Instance.recentProjects.FirstOrDefault();
                 SetProject(lastProject);
             }
+
+            InputSystem.SetDefaultKeyboardFocus(this);
         }
 
         private void BuildError(ImGui gui) {
@@ -403,5 +405,16 @@ namespace Yafc {
                 }
             }
         }
+
+        public bool KeyDown(SDL.SDL_Keysym key) {
+            if (canCreate && key.scancode is SDL.SDL_Scancode.SDL_SCANCODE_RETURN or SDL.SDL_Scancode.SDL_SCANCODE_RETURN2 or SDL.SDL_Scancode.SDL_SCANCODE_KP_ENTER) {
+                LoadProject();
+            }
+
+            return true;
+        }
+        public bool TextInput(string input) => false;
+        public bool KeyUp(SDL.SDL_Keysym key) => false;
+        public void FocusChanged(bool focused) { }
     }
 }

--- a/Yafc/Windows/WelcomeScreen.cs
+++ b/Yafc/Windows/WelcomeScreen.cs
@@ -69,9 +69,9 @@ namespace Yafc {
             IconCollection.ClearCustomIcons();
             RenderingUtils.SetColorScheme(Preferences.Instance.darkMode);
 
-            recentProjectScroll = new ScrollArea(20f, BuildRecentProjectList, collapsible: true);
-            languageScroll = new ScrollArea(20f, LanguageSelection, collapsible: true);
-            errorScroll = new ScrollArea(20f, BuildError, collapsible: true);
+            recentProjectScroll = new ScrollArea(20f, BuildRecentProjectList, InputSystem, collapsible: true);
+            languageScroll = new ScrollArea(20f, LanguageSelection, InputSystem, collapsible: true);
+            errorScroll = new ScrollArea(20f, BuildError, InputSystem, collapsible: true);
             Create("Welcome to YAFC CE v" + YafcLib.version.ToString(3), 45, null);
 
             if (cliProject != null && !string.IsNullOrEmpty(cliProject.dataPath)) {

--- a/Yafc/Workspace/AutoPlannerView.cs
+++ b/Yafc/Workspace/AutoPlannerView.cs
@@ -91,7 +91,7 @@ namespace Yafc {
                         }
                     }
                     grid.Next();
-                    if (gui.BuildFactorioObjectWithAmount(recipe.recipe, recipe.recipesPerSecond, UnitOfMeasure.PerSecond, color)) {
+                    if (gui.BuildFactorioObjectWithAmount(recipe.recipe, recipe.recipesPerSecond, UnitOfMeasure.PerSecond, color) == Click.Left) {
                         selectedRecipe = recipe;
                     }
                 }

--- a/Yafc/Workspace/ProductionSummary/ProductionSummaryView.cs
+++ b/Yafc/Workspace/ProductionSummary/ProductionSummaryView.cs
@@ -168,7 +168,7 @@ namespace Yafc {
                 var moveHandle = gui.statePosition;
                 moveHandle.Height = 5f;
 
-                if (gui.BuildFactorioObjectWithAmount(goods, view.model.GetTotalFlow(goods), goods.flowUnitOfMeasure, view.filteredGoods == goods ? SchemeColor.Primary : SchemeColor.None)) {
+                if (gui.BuildFactorioObjectWithAmount(goods, view.model.GetTotalFlow(goods), goods.flowUnitOfMeasure, view.filteredGoods == goods ? SchemeColor.Primary : SchemeColor.None) == Click.Left) {
                     view.ApplyFilter(goods);
                 }
 
@@ -181,7 +181,7 @@ namespace Yafc {
             public override void BuildElement(ImGui gui, ProductionSummaryEntry data) {
                 float amount = data.GetAmount(goods);
                 if (amount != 0) {
-                    if (gui.BuildFactorioObjectWithAmount(goods, data.GetAmount(goods), goods.flowUnitOfMeasure)) {
+                    if (gui.BuildFactorioObjectWithAmount(goods, data.GetAmount(goods), goods.flowUnitOfMeasure) == Click.Left) {
                         view.ApplyFilter(goods);
                     }
                 }
@@ -303,7 +303,7 @@ namespace Yafc {
                 using var inlineGrid = gui.EnterInlineGrid(3f, 1f);
                 foreach (var (goods, amount) in model.sortedFlow) {
                     inlineGrid.Next();
-                    if (gui.BuildFactorioObjectWithAmount(goods, amount, goods.flowUnitOfMeasure, model.columnsExist.Contains(goods) ? SchemeColor.Primary : SchemeColor.None)) {
+                    if (gui.BuildFactorioObjectWithAmount(goods, amount, goods.flowUnitOfMeasure, model.columnsExist.Contains(goods) ? SchemeColor.Primary : SchemeColor.None) == Click.Left) {
                         AddOrRemoveColumn(goods);
                     }
                 }

--- a/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -30,7 +30,7 @@ namespace Yafc {
             BuildHeader(gui, "Module customization");
             if (template != null) {
                 using (gui.EnterRow()) {
-                    if (gui.BuildFactorioObjectButton(template.icon)) {
+                    if (gui.BuildFactorioObjectButton(template.icon) == Click.Left) {
                         SelectSingleObjectPanel.SelectWithNone(Database.objects.all, "Select icon", x => {
                             template.RecordUndo().icon = x;
                             Rebuild();
@@ -89,7 +89,7 @@ namespace Yafc {
                     }
                 }
                 else {
-                    if (gui.BuildFactorioObjectButtonWithText(modules.beacon)) {
+                    if (gui.BuildFactorioObjectButtonWithText(modules.beacon) == Click.Left) {
                         SelectBeacon(gui);
                     }
 
@@ -167,7 +167,7 @@ namespace Yafc {
             foreach (RecipeRowCustomModule rowCustomModule in list) {
                 grid.Next();
                 var evt = gui.BuildFactorioObjectWithEditableAmount(rowCustomModule.module, rowCustomModule.fixedCount, UnitOfMeasure.None, out float newAmount);
-                if (evt == GoodsWithAmountEvent.ButtonClick) {
+                if (evt == GoodsWithAmountEvent.LeftButtonClick) {
                     SelectSingleObjectPanel.SelectWithNone(GetModules(beacon), "Select module", sel => {
                         if (sel == null) {
                             _ = modules.RecordUndo().list.Remove(rowCustomModule);

--- a/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -209,5 +209,7 @@ namespace Yafc {
                 }, "Select module");
             }
         }
+
+        protected override void ReturnPressed() => Close();
     }
 }

--- a/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
@@ -91,5 +91,7 @@ namespace Yafc {
                 Project.current.RecalculateDisplayPages();
             }
         }
+
+        protected override void ReturnPressed() => Close();
     }
 }

--- a/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
@@ -44,13 +44,13 @@ namespace Yafc {
             gui.AllocateSpacing();
             gui.BuildText("Filler module:", Font.subheader);
             gui.BuildText("Use this module when aufofill doesn't add anything (for example when productivity modules doesn't fit)", wrap: true);
-            if (gui.BuildFactorioObjectButtonWithText(modules.fillerModule)) {
+            if (gui.BuildFactorioObjectButtonWithText(modules.fillerModule) == Click.Left) {
                 SelectSingleObjectPanel.SelectWithNone(Database.allModules, "Select filler module", select => { modules.RecordUndo().fillerModule = select; });
             }
 
             gui.AllocateSpacing();
             gui.BuildText("Beacons & beacon modules:", Font.subheader);
-            if (gui.BuildFactorioObjectButtonWithText(modules.beacon)) {
+            if (gui.BuildFactorioObjectButtonWithText(modules.beacon) == Click.Left) {
                 SelectSingleObjectPanel.SelectWithNone(Database.allBeacons, "Select beacon", select => {
                     _ = modules.RecordUndo();
                     modules.beacon = select;
@@ -62,7 +62,7 @@ namespace Yafc {
                 });
             }
 
-            if (gui.BuildFactorioObjectButtonWithText(modules.beaconModule)) {
+            if (gui.BuildFactorioObjectButtonWithText(modules.beaconModule) == Click.Left) {
                 SelectSingleObjectPanel.SelectWithNone(Database.allModules.Where(x => modules.beacon?.CanAcceptModule(x.moduleSpecification) ?? false), "Select module for beacon", select => { modules.RecordUndo().beaconModule = select; });
             }
 

--- a/Yafc/Workspace/ProductionTable/ModuleTemplateConfiguration.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleTemplateConfiguration.cs
@@ -9,7 +9,7 @@ namespace Yafc {
         private ProjectModuleTemplate? pageToDelete;
         private string newPageName = "";
 
-        public ModuleTemplateConfiguration() => templateList = new VirtualScrollList<ProjectModuleTemplate>(30, new Vector2(20, 2.5f), Drawer,
+        public ModuleTemplateConfiguration() => templateList = new VirtualScrollList<ProjectModuleTemplate>(30, new Vector2(20, 2.5f), Drawer, MainScreen.Instance.InputSystem,
                 reorder: (from, to) => Project.current.RecordUndo().sharedModuleTemplates.MoveListElementIndex(from, to));
 
         public static void Show() {

--- a/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
@@ -12,7 +12,7 @@ namespace Yafc {
         private readonly ScrollArea scrollArea;
 
         private ProductionLinkSummaryScreen(ProductionLink link) {
-            scrollArea = new ScrollArea(30, BuildScrollArea);
+            scrollArea = new ScrollArea(30, BuildScrollArea, MainScreen.Instance.InputSystem);
             this.link = link;
             CalculateFlow(link);
         }

--- a/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
@@ -36,6 +36,8 @@ namespace Yafc {
             }
         }
 
+        protected override void ReturnPressed() => Close();
+
         private void BuildFlow(ImGui gui, List<(RecipeRow row, float flow)> list, float total) {
             gui.spacing = 0f;
             foreach (var (row, flow) in list) {

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -27,7 +27,7 @@ namespace Yafc {
                 gui.spacing = 0f;
                 if (row.subgroup != null) {
                     if (gui.BuildButton(row.subgroup.expanded ? Icon.ShevronDown : Icon.ShevronRight)) {
-                        if (InputSystem.Instance.control) {
+                        if (MainScreen.Instance.InputSystem.control) {
                             toggleAll(!row.subgroup.expanded, view.model);
                         }
                         else {
@@ -208,7 +208,7 @@ namespace Yafc {
                     view.model.RecordUndo().recipes.Clear();
                 }
 
-                if (InputSystem.Instance.control && gui.BuildButton("Add ALL recipes") && gui.CloseDropdown()) {
+                if (MainScreen.Instance.InputSystem.control && gui.BuildButton("Add ALL recipes") && gui.CloseDropdown()) {
                     foreach (var recipe in Database.recipes.all) {
                         if (!recipe.IsAccessible()) {
                             continue;
@@ -496,7 +496,8 @@ goodsHaveNoProduction:;
             private readonly VirtualScrollList<ProjectModuleTemplate> moduleTemplateList;
             private RecipeRow editingRecipeModules = null!; // null-forgiving: This is set as soon as we open a module dropdown.
 
-            public ModulesColumn(ProductionTableView view) : base(view, "Modules", 10f, 7f, 16f) => moduleTemplateList = new VirtualScrollList<ProjectModuleTemplate>(15f, new Vector2(20f, 2.5f), ModuleTemplateDrawer, collapsible: true);
+            public ModulesColumn(ProductionTableView view) : base(view, "Modules", 10f, 7f, 16f)
+                => moduleTemplateList = new VirtualScrollList<ProjectModuleTemplate>(15f, new Vector2(20f, 2.5f), ModuleTemplateDrawer, MainScreen.Instance.InputSystem, collapsible: true);
 
             private void ModuleTemplateDrawer(ImGui gui, ProjectModuleTemplate element, int index) {
                 var evt = gui.BuildContextMenuButton(element.name, icon: element.icon?.icon ?? default, disabled: !element.template.IsCompatibleWith(editingRecipeModules));
@@ -690,7 +691,7 @@ goodsHaveNoProduction:;
         }
 
         private void OpenProductDropdown(ImGui targetGui, Rect rect, Goods goods, float amount, ProductionLink? link, ProductDropdownType type, RecipeRow? recipe, ProductionTable context, Goods[]? variants = null) {
-            if (InputSystem.Instance.shift) {
+            if (MainScreen.Instance.InputSystem.shift) {
                 Project.current.preferences.SetSourceResource(goods, !goods.IsSourceResource());
                 targetGui.Rebuild();
                 return;
@@ -724,7 +725,7 @@ goodsHaveNoProduction:;
                 }
             }
 
-            if (InputSystem.Instance.control) {
+            if (MainScreen.Instance.InputSystem.control) {
                 bool isInput = type == ProductDropdownType.Fuel || type == ProductDropdownType.Ingredient || (type == ProductDropdownType.DesiredProduct && amount > 0);
                 var recipeList = isInput ? goods.production : goods.usages;
                 if (recipeList.SelectSingle(out var selected)) {

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -634,10 +634,11 @@ goodsHaveNoProduction:;
         public override float CalculateWidth() => flatHierarchyBuilder.width;
 
         public override void CreateModelDropdown(ImGui gui, Type type, Project project) {
-            if (gui.BuildContextMenuButton("Create production sheet") && gui.CloseDropdown()) {
-                ProjectPageSettingsPanel.Show(null, (name, icon) => MainScreen.Instance.AddProjectPage(name, icon, typeof(ProductionTable), true, true));
+            if (gui.BuildContextMenuButton("Create production sheet", "Ctrl+" + ImGuiUtils.ScanToString(SDL.SDL_Scancode.SDL_SCANCODE_T)) && gui.CloseDropdown()) {
+                CreateProductionSheet();
             }
         }
+        public static void CreateProductionSheet() => ProjectPageSettingsPanel.Show(null, (name, icon) => MainScreen.Instance.AddProjectPage(name, icon, typeof(ProductionTable), true, true));
 
         private static readonly IComparer<Goods> DefaultVariantOrdering = new DataUtils.FactorioObjectComparer<Goods>((x, y) => (y.ApproximateFlow() / MathF.Abs(y.Cost())).CompareTo(x.ApproximateFlow() / MathF.Abs(x.Cost())));
         private RecipeRow AddRecipe(ProductionTable table, Recipe recipe, Goods? selectedFuel = null) {

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -97,7 +97,7 @@ namespace Yafc {
         private class RecipeColumn(ProductionTableView view) : ProductionTableDataColumn(view, "Recipe", 13f, 13f, 30f) {
             public override void BuildElement(ImGui gui, RecipeRow recipe) {
                 gui.spacing = 0.5f;
-                if (gui.BuildFactorioObjectButton(recipe.recipe, 3f)) {
+                if (gui.BuildFactorioObjectButton(recipe.recipe, 3f) == Click.Left) {
                     gui.ShowDropDown(delegate (ImGui imgui) {
                         view.DrawRecipeTagSelect(imgui, recipe);
 
@@ -257,10 +257,10 @@ goodsHaveNoProduction:;
                             recipe.RecordUndo().fixedBuildings = newAmount;
                         }
 
-                        clicked = evt == GoodsWithAmountEvent.ButtonClick;
+                        clicked = evt == GoodsWithAmountEvent.LeftButtonClick;
                     }
                     else {
-                        clicked = gui.BuildFactorioObjectWithAmount(recipe.entity, recipe.buildingCount, UnitOfMeasure.None, useScale: false) && recipe.recipe.crafters.Length > 0;
+                        clicked = gui.BuildFactorioObjectWithAmount(recipe.entity, recipe.buildingCount, UnitOfMeasure.None, useScale: false) == Click.Left && recipe.recipe.crafters.Length > 0;
                     }
 
                     if (recipe.builtBuildings != null) {
@@ -287,22 +287,22 @@ goodsHaveNoProduction:;
                 }
             }
 
-            private void BuildSolarPanelAccumulatorView(ImGui gui, RecipeRow recipe) {
+            private static void BuildSolarPanelAccumulatorView(ImGui gui, RecipeRow recipe) {
                 var accumulator = recipe.GetVariant(Database.allAccumulators);
                 float requiredMj = recipe.entity?.craftingSpeed * recipe.buildingCount * (70 / 0.7f) ?? 0; // 70 seconds of charge time to last through the night
                 float requiredAccumulators = requiredMj / accumulator.accumulatorCapacity;
-                if (gui.BuildFactorioObjectWithAmount(accumulator, requiredAccumulators, UnitOfMeasure.None)) {
+                if (gui.BuildFactorioObjectWithAmount(accumulator, requiredAccumulators, UnitOfMeasure.None) == Click.Left) {
                     ShowAccumulatorDropdown(gui, recipe, accumulator);
                 }
             }
 
-            private void ShowAccumulatorDropdown(ImGui gui, RecipeRow recipe, Entity currentAccumulator) => gui.ShowDropDown(imGui => {
+            private static void ShowAccumulatorDropdown(ImGui gui, RecipeRow recipe, Entity currentAccumulator) => gui.ShowDropDown(imGui => {
                 imGui.BuildInlineObjectListAndButton<EntityAccumulator>(Database.allAccumulators, DataUtils.DefaultOrdering,
                     newAccumulator => recipe.RecordUndo().ChangeVariant(currentAccumulator, newAccumulator), "Select accumulator",
                     extra: x => DataUtils.FormatAmount(x.accumulatorCapacity, UnitOfMeasure.Megajoule));
             });
 
-            private void ShowEntityDropdown(ImGui imgui, RecipeRow recipe) => imgui.ShowDropDown(gui => {
+            private static void ShowEntityDropdown(ImGui imgui, RecipeRow recipe) => imgui.ShowDropDown(gui => {
                 gui.BuildInlineObjectListAndButton(recipe.recipe.crafters, DataUtils.FavoriteCrafter, sel => {
                     if (recipe.entity == sel) {
                         return;
@@ -480,7 +480,7 @@ goodsHaveNoProduction:;
                 using var grid = gui.EnterInlineGrid(3f);
                 if (recipe.parameters.modules.modules == null || recipe.parameters.modules.modules.Length == 0) {
                     grid.Next();
-                    if (gui.BuildFactorioObjectWithAmount(null, 0, UnitOfMeasure.None, useScale: false) && recipe.hierarchyEnabled) {
+                    if (gui.BuildFactorioObjectWithAmount(null, 0, UnitOfMeasure.None, useScale: false) == Click.Left && recipe.hierarchyEnabled) {
                         ShowModuleDropDown(gui, recipe);
                     }
                 }
@@ -491,13 +491,13 @@ goodsHaveNoProduction:;
                             wasBeacon = true;
                             if (recipe.parameters.modules.beacon != null) {
                                 grid.Next();
-                                if (gui.BuildFactorioObjectWithAmount(recipe.parameters.modules.beacon, recipe.parameters.modules.beaconCount, UnitOfMeasure.None, useScale: false)) {
+                                if (gui.BuildFactorioObjectWithAmount(recipe.parameters.modules.beacon, recipe.parameters.modules.beaconCount, UnitOfMeasure.None, useScale: false) == Click.Left) {
                                     ShowModuleDropDown(gui, recipe);
                                 }
                             }
                         }
                         grid.Next();
-                        if (gui.BuildFactorioObjectWithAmount(module, count, UnitOfMeasure.None, useScale: false)) {
+                        if (gui.BuildFactorioObjectWithAmount(module, count, UnitOfMeasure.None, useScale: false) == Click.Left) {
                             ShowModuleDropDown(gui, recipe);
                         }
                     }
@@ -714,7 +714,7 @@ goodsHaveNoProduction:;
                     using (var grid = gui.EnterInlineGrid(3f)) {
                         foreach (var variant in variants) {
                             grid.Next();
-                            if (gui.BuildFactorioObjectButton(variant, 3f, MilestoneDisplay.Contained, variant == goods ? SchemeColor.Primary : SchemeColor.None) &&
+                            if (gui.BuildFactorioObjectButton(variant, 3f, MilestoneDisplay.Contained, variant == goods ? SchemeColor.Primary : SchemeColor.None) == Click.Left &&
                                 variant != goods) {
                                 recipe!.RecordUndo().ChangeVariant(goods, variant); // null-forgiving: If variants is not null, neither is recipe: Only the call from BuildGoodsIcon sets variants, and the only call to BuildGoodsIcon that sets variants also sets recipe.
                                 _ = gui.CloseDropdown();
@@ -858,7 +858,7 @@ goodsHaveNoProduction:;
             }
 
             var evt = gui.BuildFactorioObjectWithEditableAmount(element.goods, element.amount, element.goods.flowUnitOfMeasure, out float newAmount, iconColor);
-            if (evt == GoodsWithAmountEvent.ButtonClick) {
+            if (evt == GoodsWithAmountEvent.LeftButtonClick) {
                 OpenProductDropdown(gui, gui.lastRect, element.goods, element.amount, element, ProductDropdownType.DesiredProduct, null, element.owner);
             }
             else if (evt == GoodsWithAmountEvent.TextEditing && newAmount != 0) {
@@ -907,7 +907,7 @@ goodsHaveNoProduction:;
                 textColor = SchemeColor.BackgroundTextFaint;
             }
 
-            if (gui.BuildFactorioObjectWithAmount(goods, amount, goods?.flowUnitOfMeasure ?? UnitOfMeasure.None, iconColor, textColor) && goods is not null) {
+            if (gui.BuildFactorioObjectWithAmount(goods, amount, goods?.flowUnitOfMeasure ?? UnitOfMeasure.None, iconColor, textColor) == Click.Left && goods is not null) {
                 OpenProductDropdown(gui, gui.lastRect, goods, amount, link, dropdownType, recipe, context, variants);
             }
         }
@@ -1003,7 +1003,7 @@ goodsHaveNoProduction:;
             bool click = false;
 
             using (gui.EnterRow()) {
-                click |= gui.BuildFactorioObjectButton(belt);
+                click |= gui.BuildFactorioObjectButton(belt) == Click.Left;
                 gui.BuildText(DataUtils.FormatAmount(beltCount, UnitOfMeasure.None));
                 if (buildingsPerHalfBelt > 0f) {
                     gui.BuildText("(Buildings per half belt: " + DataUtils.FormatAmount(buildingsPerHalfBelt, UnitOfMeasure.None) + ")");
@@ -1013,7 +1013,7 @@ goodsHaveNoProduction:;
             using (gui.EnterRow()) {
                 int capacity = prefs.inserterCapacity;
                 float inserterBase = inserter.inserterSwingTime * amount / capacity;
-                click |= gui.BuildFactorioObjectButton(inserter);
+                click |= gui.BuildFactorioObjectButton(inserter) == Click.Left;
                 string text = DataUtils.FormatAmount(inserterBase, UnitOfMeasure.None);
                 if (buildingCount > 1) {
                     text += " (" + DataUtils.FormatAmount(inserterBase / buildingCount, UnitOfMeasure.None) + "/building)";
@@ -1023,9 +1023,9 @@ goodsHaveNoProduction:;
                 if (capacity > 1) {
                     float withBeltSwingTime = inserter.inserterSwingTime + (2f * (capacity - 1.5f) / belt.beltItemsPerSecond);
                     float inserterToBelt = amount * withBeltSwingTime / capacity;
-                    click |= gui.BuildFactorioObjectButton(belt);
+                    click |= gui.BuildFactorioObjectButton(belt) == Click.Left;
                     gui.AllocateSpacing(-1.5f);
-                    click |= gui.BuildFactorioObjectButton(inserter);
+                    click |= gui.BuildFactorioObjectButton(inserter) == Click.Left;
                     text = DataUtils.FormatAmount(inserterToBelt, UnitOfMeasure.None, "~");
                     if (buildingCount > 1) {
                         text += " (" + DataUtils.FormatAmount(inserterToBelt / buildingCount, UnitOfMeasure.None) + "/b)";

--- a/Yafc/Workspace/ProjectPageView.cs
+++ b/Yafc/Workspace/ProjectPageView.cs
@@ -7,8 +7,8 @@ using Yafc.UI;
 namespace Yafc {
     public abstract class ProjectPageView : Scrollable {
         protected ProjectPageView() : base(true, true, false) {
-            headerContent = new ImGui(BuildHeader, default, RectAllocator.LeftAlign);
-            bodyContent = new ImGui(BuildContent, default, RectAllocator.LeftAlign, true);
+            headerContent = new ImGui(BuildHeader, default, MainScreen.Instance.InputSystem, RectAllocator.LeftAlign);
+            bodyContent = new ImGui(BuildContent, default, MainScreen.Instance.InputSystem, RectAllocator.LeftAlign, true);
         }
 
         public readonly ImGui headerContent;
@@ -106,7 +106,7 @@ namespace Yafc {
                 projectPage.contentChanged -= ModelContentsChanged;
             }
 
-            InputSystem.Instance.SetKeyboardFocus(this);
+            MainScreen.Instance.InputSystem.SetKeyboardFocus(this);
             projectPage = page;
             model = (T)page?.content!; // TODO, null-forgiving: This can clearly be null, but lots of things assume it can't.
             if (model != null && projectPage != null) {

--- a/Yafc/Workspace/SummaryView.cs
+++ b/Yafc/Workspace/SummaryView.cs
@@ -107,7 +107,7 @@ namespace Yafc {
                 if (evt == GoodsWithAmountEvent.TextEditing && newAmount != 0) {
                     SetProviderAmount(element, page, newAmount);
                 }
-                else if (evt == GoodsWithAmountEvent.ButtonClick) {
+                else if (evt == GoodsWithAmountEvent.LeftButtonClick) {
                     SetProviderAmount(element, page, YafcRounding(goodInfo.sum));
                 }
             }

--- a/Yafc/Workspace/SummaryView.cs
+++ b/Yafc/Workspace/SummaryView.cs
@@ -7,11 +7,8 @@ using YAFC.Model;
 
 namespace Yafc {
     public class SummaryView : ProjectPageView<Summary> {
-        private class SummaryScrollArea : ScrollArea {
+        private class SummaryScrollArea(GuiBuilder builder) : ScrollArea(DefaultHeight, builder, MainScreen.Instance.InputSystem, horizontal: true) {
             private static readonly float DefaultHeight = 10;
-
-            public SummaryScrollArea(GuiBuilder builder) : base(DefaultHeight, builder, default, false, true, true) {
-            }
 
             public new void Build(ImGui gui) =>
                 // Maximize scroll area to fit parent area (minus header and 'show issues' heights, and some (2) padding probably)

--- a/changelog.txt
+++ b/changelog.txt
@@ -11,9 +11,13 @@
 //     Internal changes: 
 //         Changes to the code that do not affect the behavior of the program.
 ----------------------------------------------------------------------------------------------------------------------
+Version 0.7.2
+Date: soon
+    Features:
+        - Add several right-click and keyboard shortcuts, notably Enter/Return to close most dialogs.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 0.7.1
-Date: soon
+Date: June 12th 2024
     Features:
         - Allow configuring the size of icons that have backgrounds, since the icon may cover the entire
           background area.


### PR DESCRIPTION
This closes #35 by adding the Enter/Return, right-click, and Ctrl+T behaviors mentioned there. It also adds right-click on products and ingredients to remove or create ordinary links (by asking "What can we clear when right-clicking on an ingredient?"), and right-click on desired products to remove and unlink them.

I'll admit I'm not a fan of 5676ce7a, but I was unable to figure out how to get a single InputSystem to send Enter to the correct window when multiple OS windows were open.