### PR TITLE
Remove canDelete property so that non-summary pages can always be deleted.

### DIFF
--- a/Yafc.Model/Model/ProjectPage.cs
+++ b/Yafc.Model/Model/ProjectPage.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Yafc.UI;
+using YAFC.Model;
 
 namespace Yafc.Model {
     public class ProjectPage : ModelObject<Project> {
@@ -13,18 +14,18 @@ namespace Yafc.Model {
         public bool visible { get; internal set; }
         [SkipSerialization] public string? modelError { get; set; }
         public bool deleted { get; private set; }
-        public bool canDelete { get; }
+        [SkipSerialization]
+        public bool canDelete => contentType != typeof(Summary);
 
         private uint lastSolvedVersion;
         private uint currentSolvingVersion;
         private uint actualVersion;
         public event Action<bool>? contentChanged;
 
-        public ProjectPage(Project project, Type contentType, bool canDelete = true, Guid guid = default) : base(project) {
+        public ProjectPage(Project project, Type contentType, Guid guid = default) : base(project) {
             this.guid = guid == default ? Guid.NewGuid() : guid;
             actualVersion = project.projectVersion;
             this.contentType = contentType;
-            this.canDelete = canDelete;
             content = Activator.CreateInstance(contentType, this) as ProjectPageContents ?? throw new ArgumentException($"{nameof(contentType)} must derive from {nameof(ProjectPageContents)}", nameof(contentType));
         }
 

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -534,7 +534,7 @@ namespace Yafc {
             ProjectPage? summaryPage = project.FindPage(SummaryGuid);
             if (summaryPage == null) {
 
-                summaryPage = new ProjectPage(project, typeof(Summary), false, SummaryGuid) {
+                summaryPage = new ProjectPage(project, typeof(Summary), SummaryGuid) {
                     name = "Summary",
                 };
                 project.pages.Add(summaryPage);

--- a/changelog.txt
+++ b/changelog.txt
@@ -15,6 +15,8 @@ Version 0.7.2
 Date: soon
     Features:
         - Add several right-click and keyboard shortcuts, notably Enter/Return to close most dialogs.
+    Bugfixes:
+        - Fix that some pages couldn't be deleted.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 0.7.1
 Date: June 12th 2024


### PR DESCRIPTION
Fix #147