### PR TITLE
Fix 5676ce7a, where returning to the Welcome screen and opening a project again could break panels in the main window.

### DIFF
--- a/Yafc/Windows/MilestonesEditor.cs
+++ b/Yafc/Windows/MilestonesEditor.cs
@@ -5,7 +5,6 @@ using Yafc.UI;
 
 namespace Yafc {
     public class MilestonesEditor : PseudoScreen {
-        private static readonly MilestonesEditor Instance = new MilestonesEditor();
         private readonly VirtualScrollList<FactorioObject> milestoneList;
 
         public MilestonesEditor() : base(50) => milestoneList = new VirtualScrollList<FactorioObject>(30f, new Vector2(float.PositiveInfinity, 3f), MilestoneDrawer, MainScreen.Instance.InputSystem);
@@ -15,7 +14,7 @@ namespace Yafc {
             milestoneList.data = Project.current.settings.milestones;
         }
 
-        public static void Show() => _ = MainScreen.Instance.ShowPseudoScreen(Instance);
+        public static void Show() => _ = MainScreen.Instance.ShowPseudoScreen(new MilestonesEditor());
 
         private void MilestoneDrawer(ImGui gui, FactorioObject element, int index) {
             using (gui.EnterRow()) {

--- a/Yafc/Windows/PreferencesScreen.cs
+++ b/Yafc/Windows/PreferencesScreen.cs
@@ -4,8 +4,6 @@ using Yafc.UI;
 
 namespace Yafc {
     public class PreferencesScreen : PseudoScreen {
-        private static readonly PreferencesScreen Instance = new PreferencesScreen();
-
         public override void Build(ImGui gui) {
             BuildHeader(gui, "Preferences");
             gui.BuildText("Unit of time:", Font.subheader);
@@ -183,6 +181,6 @@ namespace Yafc {
             }
         }
 
-        public static void Show() => _ = MainScreen.Instance.ShowPseudoScreen(Instance);
+        public static void Show() => _ = MainScreen.Instance.ShowPseudoScreen(new PreferencesScreen());
     }
 }

--- a/Yafc/Windows/SelectSingleObjectPanel.cs
+++ b/Yafc/Windows/SelectSingleObjectPanel.cs
@@ -8,7 +8,6 @@ namespace Yafc {
     /// Represents a panel that can generate a result by selecting zero or one <see cref="FactorioObject"/>s. (But doesn't have to, if the user selects a close or cancel button.)
     /// </summary>
     public class SelectSingleObjectPanel : SelectObjectPanel<FactorioObject> {
-        private static readonly SelectSingleObjectPanel Instance = new SelectSingleObjectPanel();
         public SelectSingleObjectPanel() : base() { }
 
         /// <summary>
@@ -19,7 +18,7 @@ namespace Yafc {
         /// <param name="selectItem">An action to be called for the selected item when the panel is closed.</param>
         /// <param name="ordering">An optional ordering specifying how to sort the displayed items. If <see langword="null"/>, defaults to <see cref="DataUtils.DefaultOrdering"/>.</param>
         public static void Select<T>(IEnumerable<T> list, string header, Action<T> selectItem, IComparer<T>? ordering = null) where T : FactorioObject
-            => Instance.Select(list, header, selectItem!, ordering, (obj, mappedAction) => mappedAction(obj), false); // null-forgiving: selectItem will not be called with null, because allowNone is false.
+            => new SelectSingleObjectPanel().Select(list, header, selectItem!, ordering, (obj, mappedAction) => mappedAction(obj), false); // null-forgiving: selectItem will not be called with null, because allowNone is false.
 
         /// <summary>
         /// Opens a <see cref="SelectSingleObjectPanel"/> to allow the user to select one <see cref="FactorioObject"/>, or to clear the current selection by selecting
@@ -30,7 +29,7 @@ namespace Yafc {
         /// <param name="selectItem">An action to be called for the selected item when the panel is closed. The parameter will be <see langword="null"/> if the "none" or "clear" option is selected.</param>
         /// <param name="ordering">An optional ordering specifying how to sort the displayed items. If <see langword="null"/>, defaults to <see cref="DataUtils.DefaultOrdering"/>.</param>
         public static void SelectWithNone<T>(IEnumerable<T> list, string header, Action<T?> selectItem, IComparer<T>? ordering = null) where T : FactorioObject
-            => Instance.Select(list, header, selectItem, ordering, (obj, mappedAction) => mappedAction(obj), true);
+            => new SelectSingleObjectPanel().Select(list, header, selectItem, ordering, (obj, mappedAction) => mappedAction(obj), true);
 
         protected override void NonNullElementDrawer(ImGui gui, FactorioObject element, int index) {
             if (gui.BuildFactorioObjectButton(element, 2.5f, MilestoneDisplay.Contained, extendHeader: extendHeader, useScale: true) == Click.Left) {

--- a/Yafc/Windows/ShoppingListScreen.cs
+++ b/Yafc/Windows/ShoppingListScreen.cs
@@ -7,8 +7,6 @@ using Yafc.UI;
 
 namespace Yafc {
     public class ShoppingListScreen : PseudoScreen {
-        private static readonly ShoppingListScreen Instance = new ShoppingListScreen();
-
         private readonly VirtualScrollList<(FactorioObject, float)> list;
         private float shoppingCost, totalBuildings, totalModules;
         private bool decomposed = false;
@@ -25,9 +23,8 @@ namespace Yafc {
 
         public static void Show(Dictionary<FactorioObject, int> counts) {
             float cost = 0f, buildings = 0f, modules = 0f;
-            Instance.decomposed = false;
-            Instance.list.data = counts.Select(x => (x.Key, Value: (float)x.Value)).OrderByDescending(x => x.Value).ToArray();
-            foreach (var (obj, count) in Instance.list.data) {
+            var data = counts.Select(x => (x.Key, Value: (float)x.Value)).OrderByDescending(x => x.Value).ToArray();
+            foreach ((FactorioObject obj, float count) in data) {
                 if (obj is Entity) {
                     buildings += count;
                 }
@@ -37,10 +34,14 @@ namespace Yafc {
 
                 cost += obj.Cost() * count;
             }
-            Instance.shoppingCost = cost;
-            Instance.totalBuildings = buildings;
-            Instance.totalModules = modules;
-            _ = MainScreen.Instance.ShowPseudoScreen(Instance);
+
+            ShoppingListScreen screen = new() {
+                shoppingCost = cost,
+                totalBuildings = buildings,
+                totalModules = modules,
+                list = { data = data }
+            };
+            _ = MainScreen.Instance.ShowPseudoScreen(screen);
         }
 
         public override void Build(ImGui gui) {

--- a/Yafc/Windows/WizardPanel.cs
+++ b/Yafc/Windows/WizardPanel.cs
@@ -6,8 +6,6 @@ using Yafc.UI;
 
 namespace Yafc {
     public class WizardPanel : PseudoScreen {
-        public static readonly WizardPanel Instance = new WizardPanel();
-
         private readonly List<PageBuilder> pages = [];
         private string? header;
         private Action? finish;
@@ -17,10 +15,9 @@ namespace Yafc {
         public delegate Action WizardBuilder(List<PageBuilder> pages);
 
         public static void Show(string header, WizardBuilder builder) {
-            Instance.pages.Clear();
-            Instance.finish = builder(Instance.pages);
-            Instance.header = header;
-            _ = MainScreen.Instance.ShowPseudoScreen(Instance);
+            WizardPanel panel = new() { header = header };
+            panel.finish = builder(panel.pages);
+            _ = MainScreen.Instance.ShowPseudoScreen(panel);
         }
 
         public override void Open() {

--- a/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -6,24 +6,24 @@ using Yafc.UI;
 
 namespace Yafc {
     public class ModuleCustomizationScreen : PseudoScreen {
-        private static readonly ModuleCustomizationScreen Instance = new ModuleCustomizationScreen();
-
         private RecipeRow? recipe;
         private ProjectModuleTemplate? template;
         private ModuleTemplate? modules;
 
         public static void Show(RecipeRow recipe) {
-            Instance.template = null;
-            Instance.recipe = recipe;
-            Instance.modules = recipe.modules;
-            _ = MainScreen.Instance.ShowPseudoScreen(Instance);
+            ModuleCustomizationScreen screen = new() {
+                recipe = recipe,
+                modules = recipe.modules
+            };
+            _ = MainScreen.Instance.ShowPseudoScreen(screen);
         }
 
         public static void Show(ProjectModuleTemplate template) {
-            Instance.recipe = null;
-            Instance.template = template;
-            Instance.modules = template.template;
-            _ = MainScreen.Instance.ShowPseudoScreen(Instance);
+            ModuleCustomizationScreen screen = new() {
+                template = template,
+                modules = template.template
+            };
+            _ = MainScreen.Instance.ShowPseudoScreen(screen);
         }
 
         public override void Build(ImGui gui) {

--- a/Yafc/Workspace/ProductionTable/ModuleTemplateConfiguration.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleTemplateConfiguration.cs
@@ -4,7 +4,6 @@ using Yafc.UI;
 
 namespace Yafc {
     public class ModuleTemplateConfiguration : PseudoScreen {
-        private static readonly ModuleTemplateConfiguration Instance = new ModuleTemplateConfiguration();
         private readonly VirtualScrollList<ProjectModuleTemplate> templateList;
         private ProjectModuleTemplate? pageToDelete;
         private string newPageName = "";
@@ -13,8 +12,9 @@ namespace Yafc {
                 reorder: (from, to) => Project.current.RecordUndo().sharedModuleTemplates.MoveListElementIndex(from, to));
 
         public static void Show() {
-            Instance.RefreshList();
-            _ = MainScreen.Instance.ShowPseudoScreen(Instance);
+            ModuleTemplateConfiguration screen = new();
+            screen.RefreshList();
+            _ = MainScreen.Instance.ShowPseudoScreen(screen);
         }
 
         private void RefreshList() {


### PR DESCRIPTION
To reproduce this, open the Milestones Editor, NEI Explorer, Preferences screen, a single-object selection screen (the full list of fuels or modules is most likely), the Shopping list, the module customization screen, or the module templates screen. Then select "Return to starting screen" from the main menu, load or create any project, and try to interact with any screen you previously opened.

&lt;Escape> and maybe &lt;Enter> will work, but mouse interaction will not work.