### PR TITLE
fix: make a test culture-aware

### DIFF
--- a/Yafc.Model.Tests/Data/DataUtils.cs
+++ b/Yafc.Model.Tests/Data/DataUtils.cs
@@ -1,10 +1,15 @@
 ﻿using System;
+using System.Globalization;
+using System.Threading;
 using Xunit;
 
 namespace Yafc.Model.Data.Tests;
 
 public class DataUtilsTests {
-    public DataUtilsTests() => Project.current = new();
+    public DataUtilsTests() {
+        Project.current = new();
+        Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;
+    }
 
     [Fact]
     public void TryParseAmount_IsInverseOfFormatValue() {


### PR DESCRIPTION
Yafc\YafcLib.cs:20 calls `Thread.CurrentThread.CurrentCulture = CultureInfo.InvariantCulture;` but the tests skipped this line, making them all fail on a different decimal seperator (`,` vs `.`) on my local pc. This sets the tests to use InvariantCulture too.