### PR TITLE
Fix horizontal scrollbar

### DIFF
--- a/Yafc.UI/ImGui/ScrollArea.cs
+++ b/Yafc.UI/ImGui/ScrollArea.cs
@@ -9,6 +9,8 @@ namespace Yafc.UI {
     public abstract class Scrollable(bool vertical, bool horizontal, bool collapsible) : IKeyboardFocus {
         /// <summary>Required size to fit Scrollable (child) contents</summary>
         private Vector2 requiredContentSize;
+        /// <summary>This rectangle contains the available size (and position) of the scrollable content</summary>
+        private Rect contentRect;
         /// <summary>Maximum scroller offset, calculated with the <see cref="requiredContentSize"/> and the available size</summary>
         private Vector2 maxScroll;
         private Vector2 _scroll;
@@ -41,8 +43,7 @@ namespace Yafc.UI {
             float realHeight = collapsible ? MathF.Min(requiredContentSize.Y, availableHeight) : availableHeight;
 
             if (gui.isBuilding) {
-                /// <summary>This rectangle contains the available size (and position) of the scrollable content</summary>
-                var contentRect = rect;
+                contentRect = rect;
                 contentRect.Width = width;
 
                 maxScroll = Vector2.Max(requiredContentSize - new Vector2(contentRect.Width, availableHeight), Vector2.Zero);
@@ -161,10 +162,10 @@ namespace Yafc.UI {
                     scrollX += 3;
                     return true;
                 case SDL.SDL_Scancode.SDL_SCANCODE_PAGEDOWN:
-                    // TODO Calculate page height
+                    scrollY += contentRect.Height;
                     return true;
                 case SDL.SDL_Scancode.SDL_SCANCODE_PAGEUP:
-                    // TODO Calculate page height
+                    scrollY -= contentRect.Height;
                     return true;
                 case SDL.SDL_Scancode.SDL_SCANCODE_HOME:
                     scrollY = 0;

--- a/Yafc.UI/ImGui/ScrollArea.cs
+++ b/Yafc.UI/ImGui/ScrollArea.cs
@@ -55,9 +55,6 @@ namespace Yafc.UI {
             }
             else {
                 float realHeight = collapsible ? MathF.Min(requiredContentSize.Y, availableHeight) : availableHeight;
-                if (horizontal && maxScroll.X > 0) {
-                    realHeight -= ScrollbarSize;
-                }
 
                 rect.Height = realHeight;
                 _ = gui.EncapsulateRect(rect);

--- a/Yafc.UI/ImGui/ScrollArea.cs
+++ b/Yafc.UI/ImGui/ScrollArea.cs
@@ -113,7 +113,7 @@ namespace Yafc.UI {
                     }
                     break;
                 case ImGuiAction.Build:
-                    gui.DrawRectangle(scrollerRect, gui.IsMouseDown(scrollbarRect, SDL.SDL_BUTTON_LEFT) ? SchemeColor.GreyAlt : SchemeColor.Grey);
+                    gui.DrawRectangle(scrollerRect, SchemeColor.Grey);
                     break;
             }
         }

--- a/Yafc.UI/ImGui/ScrollArea.cs
+++ b/Yafc.UI/ImGui/ScrollArea.cs
@@ -31,34 +31,33 @@ namespace Yafc.UI {
             }
 
             if (gui.isBuilding) {
-                /// <summary>This rectangle contains the available size (and position) of the scrollable content</summary>
-                var contentRect = rect;
-                contentRect.Width = width;
-
                 // Calculate required size, including padding if needed
                 requiredContentSize = MeasureContent(width, gui);
                 if (requiredContentSize.Y > availableHeight && useBottomPadding) {
                     requiredContentSize.Y += BottomPaddingInPixels / gui.pixelsPerUnit;
                 }
+            }
+
+            float realHeight = collapsible ? MathF.Min(requiredContentSize.Y, availableHeight) : availableHeight;
+
+            if (gui.isBuilding) {
+                /// <summary>This rectangle contains the available size (and position) of the scrollable content</summary>
+                var contentRect = rect;
+                contentRect.Width = width;
 
                 maxScroll = Vector2.Max(requiredContentSize - new Vector2(contentRect.Width, availableHeight), Vector2.Zero);
                 scroll = Vector2.Clamp(scroll, Vector2.Zero, maxScroll);
 
-                float realHeight = collapsible ? MathF.Min(requiredContentSize.Y, availableHeight) : availableHeight;
-                contentRect.Height = rect.Height = realHeight;
+                contentRect.Height = realHeight;
                 if (horizontal && maxScroll.X > 0) {
                     contentRect.Height -= ScrollbarSize;
                 }
 
-                _ = gui.EncapsulateRect(rect);
                 PositionContent(gui, contentRect);
             }
-            else {
-                float realHeight = collapsible ? MathF.Min(requiredContentSize.Y, availableHeight) : availableHeight;
 
-                rect.Height = realHeight;
-                _ = gui.EncapsulateRect(rect);
-            }
+            rect.Height = realHeight;
+            _ = gui.EncapsulateRect(rect);
 
             // Calculate scroller dimensions.
             Vector2 size = new Vector2(width, availableHeight);

--- a/Yafc.UI/ImGui/ScrollArea.cs
+++ b/Yafc.UI/ImGui/ScrollArea.cs
@@ -4,8 +4,12 @@ using System.Numerics;
 using SDL2;
 
 namespace Yafc.UI {
+    /// <summary> Provide scrolling support for any component.</summary>
+    /// <remarks> The component should use the <see cref="scroll2d"/> property to get the offset of rendering the contents. </remarks>
     public abstract class Scrollable(bool vertical, bool horizontal, bool collapsible) : IKeyboardFocus {
+        /// <summary>Required size to fit Scrollable (child) contents</summary>
         private Vector2 contentSize;
+        /// <summary>Maximum scroller offset, calculated with the <see cref="contentSize"/> and the available size</summary>
         private Vector2 maxScroll;
         private Vector2 _scroll;
         private float height;
@@ -132,7 +136,10 @@ namespace Yafc.UI {
             set => scroll2d = new Vector2(value, _scroll.Y);
         }
 
+        ///<summary>This method is called when the required area of the <see cref="Scrollable"/> is needed.</summary>
+        /// <returns>The required area of the contents of the <see cref="Scrollable"/>.</returns>
         protected abstract Vector2 MeasureContent(Rect rect, ImGui gui);
+
         public bool KeyDown(SDL.SDL_Keysym key) {
             switch (key.scancode) {
                 case SDL.SDL_Scancode.SDL_SCANCODE_UP:
@@ -171,6 +178,7 @@ namespace Yafc.UI {
         public void FocusChanged(bool focused) { }
     }
 
+    /// <summary>Provides a builder to the Scrollable to render the contents.</summary>
     public abstract class ScrollAreaBase : Scrollable {
         protected ImGui contents;
         protected readonly float height;
@@ -194,6 +202,7 @@ namespace Yafc.UI {
         protected override Vector2 MeasureContent(Rect rect, ImGui gui) => contents.CalculateState(rect.Width, gui.pixelsPerUnit);
     }
 
+    ///<summary>Area with scrollbars, which will be visible if it does not fit in the parent area in order to let the user fully view the content of the area.</summary>
     public class ScrollArea(float height, GuiBuilder builder, InputSystem inputSystem, Padding padding = default, bool collapsible = false, bool vertical = true, bool horizontal = false) : ScrollAreaBase(height, padding, inputSystem, collapsible, vertical, horizontal) {
         protected override void BuildContents(ImGui gui) => builder(gui);
 

--- a/Yafc/Windows/FilesystemScreen.cs
+++ b/Yafc/Windows/FilesystemScreen.cs
@@ -99,7 +99,7 @@ namespace Yafc {
             location = directory;
 
             UpdatePossibleResult();
-            entries.scroll = 0;
+            entries.scrollY = 0;
         }
 
         public void UpdatePossibleResult() {

--- a/Yafc/Workspace/ProjectPageView.cs
+++ b/Yafc/Workspace/ProjectPageView.cs
@@ -63,7 +63,7 @@ namespace Yafc {
             base.Build(gui, visibleSize.Y - headerHeight, true);
         }
 
-        protected override Vector2 MeasureContent(Rect rect, ImGui gui) => new Vector2(contentWidth, contentHeight);
+        protected override Vector2 MeasureContent(float _, ImGui gui) => new Vector2(contentWidth, contentHeight);
 
         protected override void PositionContent(ImGui gui, Rect viewport) {
             headerContent.offset = new Vector2(-scrollX, 0);

--- a/Yafc/Workspace/ProjectPageView.cs
+++ b/Yafc/Workspace/ProjectPageView.cs
@@ -67,7 +67,7 @@ namespace Yafc {
 
         protected override void PositionContent(ImGui gui, Rect viewport) {
             headerContent.offset = new Vector2(-scrollX, 0);
-            bodyContent.offset = -scroll2d;
+            bodyContent.offset = -scroll;
             gui.DrawPanel(viewport, bodyContent);
         }
 

--- a/Yafc/Workspace/SummaryView.cs
+++ b/Yafc/Workspace/SummaryView.cs
@@ -11,8 +11,8 @@ namespace Yafc {
             private static readonly float DefaultHeight = 10;
 
             public new void Build(ImGui gui) =>
-                // Maximize scroll area to fit parent area (minus header and 'show issues' heights, and some (2) padding probably)
-                Build(gui, gui.valid && gui.parent is not null ? gui.parent.contentSize.Y - Font.header.size - Font.text.size - ScrollbarSize - 2 : DefaultHeight);
+                // Maximize scroll area to fit parent area (minus header and 'show issues' heights, and some (3) padding probably)
+                Build(gui, gui.valid && gui.parent is not null ? gui.parent.contentSize.Y - Font.header.size - Font.text.size - 3 : DefaultHeight);
         }
 
         private class SummaryTabColumn : TextDataColumn<ProjectPage> {

--- a/changelog.txt
+++ b/changelog.txt
@@ -19,6 +19,7 @@ Date: soon
     Bugfixes:
         - Fix that some pages couldn't be deleted.
         - Fix that returning to the Welcome Screen could break the panels in the main window.
+        - Make horizontal scrollbar clickable/draggable.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 0.7.1
 Date: June 12th 2024

--- a/changelog.txt
+++ b/changelog.txt
@@ -20,6 +20,7 @@ Date: soon
         - Fix that some pages couldn't be deleted.
         - Fix that returning to the Welcome Screen could break the panels in the main window.
         - Make horizontal scrollbar clickable/draggable.
+        - Scroll down/up exactly one page with page down/up keys
 ----------------------------------------------------------------------------------------------------------------------
 Version: 0.7.1
 Date: June 12th 2024


### PR DESCRIPTION
I figured out that clicking the horizontal scrollbar was not possible because the 'click test' area did not match the actual drawn rectangle. This got fixed by d9f815158b71bb8aaab387600220a8281709e821.

In order to figure this out, I did some major documenting/cleanup to get an understanding of what Scrollable class was (intending) to do.

I hope that all new variable/field names make more sense now, if not let me know and we can figure out how to further improve them.

While I was at it I found some other 'oddities' that I fixed/improved:
* cf5518fcfca99d5c306a1c66f65f65f6a180b8e3
* 4a8c135169cbc2f8cce355d81d5c1733afd52764

I assume it would be easiest to review ecah commit separately, as the cleanup shuffled/renames quite come code. Which is much more apparent when reviewing the separate commits.