### PR TITLE
Rebuild the full UI when the window is resized.

### DIFF
--- a/Yafc.UI/Core/Window.cs
+++ b/Yafc.UI/Core/Window.cs
@@ -77,7 +77,10 @@ namespace Yafc.UI {
             return desiredUnitsToPixels;
         }
 
-        internal virtual void WindowResize() => rootGui.Rebuild();
+        internal virtual void WindowResize() {
+            rootGui.MarkEverythingForRebuild();
+            rootGui.Rebuild();
+        }
 
         internal void WindowMoved() {
             if (surface is null) { throw new InvalidOperationException($"surface must be set by a derived class before calling {nameof(WindowMoved)}."); }


### PR DESCRIPTION
This is required to fix misplaced elements that are anchored at the right of bottom sides of the window.

I found this while testing the scrollbar #161 that it was not moved down when the window height was resized (dragged).
With this fix the (full) UI is rebuild/recalculated on resize events, causing the scrollable area (of the Summary view for example) to be resized, which in its place causes the scrollbar to be moved with the window bottom as well.

Original behavior:
![original](https://github.com/have-fun-was-taken/yafc-ce/assets/171827/23a77272-7666-47cb-a8a6-096cc3ad3c38)

Fixed behavior:
![fixed](https://github.com/have-fun-was-taken/yafc-ce/assets/171827/5bb3c6a8-1f6d-4111-afb0-f3321f193e6b)


