### PR TITLE
Use calculated width for first column of Summary page

### DIFF
--- a/Yafc.UI/ImGui/ImGuiBuilding.cs
+++ b/Yafc.UI/ImGui/ImGuiBuilding.cs
@@ -100,6 +100,19 @@ namespace Yafc.UI {
             }
         }
 
+        public Vector2 GetTextDimensions(out TextCache? cache, string? text, Font? font = null, bool wrap = false, float maxWidth = float.MaxValue) {
+            if (string.IsNullOrEmpty(text)) {
+                cache = null;
+                return Vector2.Zero;
+            }
+
+            var fontSize = GetFontSize(font);
+            cache = textCache.GetCached((fontSize, text, wrap ? (uint)UnitsToPixels(MathF.Max(width, 5f)) : uint.MaxValue));
+            float textWidth = Math.Min(cache.texRect.w / pixelsPerUnit, maxWidth);
+
+            return new Vector2(textWidth, cache.texRect.h / pixelsPerUnit);
+        }
+
         public Rect AllocateTextRect(out TextCache? cache, string? text, Font? font = null, bool wrap = false, RectAlignment align = RectAlignment.MiddleLeft, float topOffset = 0f, float maxWidth = float.MaxValue) {
             var fontSize = GetFontSize(font);
             Rect rect;
@@ -108,9 +121,8 @@ namespace Yafc.UI {
                 rect = AllocateRect(0f, topOffset + (fontSize.lineSize / pixelsPerUnit));
             }
             else {
-                cache = textCache.GetCached((fontSize, text, wrap ? (uint)UnitsToPixels(MathF.Max(width, 5f)) : uint.MaxValue));
-                float textWidth = Math.Min(cache.texRect.w / pixelsPerUnit, maxWidth);
-                rect = AllocateRect(textWidth, topOffset + (cache.texRect.h / pixelsPerUnit), align);
+                Vector2 textSize = GetTextDimensions(out cache, text, font, wrap, maxWidth);
+                rect = AllocateRect(textSize.X, topOffset + (textSize.Y), align);
             }
 
             if (topOffset != 0f) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -17,6 +17,7 @@ Date: soon
         - Add several right-click and keyboard shortcuts, notably Enter/Return to close most dialogs.
         - Add UI rebuilding itself on resize.
         - When opening the main window, use the same size it was when it was last closed.
+        - Use calculated width for first column of Summary page.
     Bugfixes:
         - Fix that some pages couldn't be deleted.
         - Fix that returning to the Welcome Screen could break the panels in the main window.


### PR DESCRIPTION
With this PR the fixed width (introduced by #38) will be no more and the column width is dynamically calculated depending on the names of the production sheets.

---

This change is part of a larger set of changes that I am planning to commit, but those changes need some additional love... (It works, but I broke some things that should not be broken).

This change is ready and works separately and adds value to YAFC already.

I had to apply one small hack to make this a stand-alone PR, which is making `firstColumnWidth` static. In the upcoming PR it will be a regular field of its class.