### PR TITLE
Remove local stacktrace paths

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,0 +1,5 @@
+<Project>
+  <PropertyGroup Label="Normalise stack trace file locations">
+    <PathMap>$([System.IO.Path]::GetFullPath('$(MSBuildThisFileDirectory)'))=.</PathMap>
+  </PropertyGroup>
+</Project>

--- a/Docs/ContributorsGuide.md
+++ b/Docs/ContributorsGuide.md
@@ -3,7 +3,7 @@
 Here are a couple of things to make your experience in the community more enjoyable. 
 
 ## Coding
-* Please use the same code style as the rest of the codebase. Visual Studio should pick up most of it from `.editorconfig`. 
+* Please use the same code style as the rest of the codebase. Visual Studio should pick up most of it from `.editorconfig`. You can autoformat the file with the sequence Ctrl+K, Ctrl+D.
 * Please prioritize maintainability. Aim for understandable code without dirty hacks.
 * Please separate refactoring and the change of behavior into different commits, so it is easier to review the PR.
 * Please document the code. If you also can document the existing code, that would be awesome. More documentation helps others to understand the code faster and make the work on YAFC more enjoyable.

--- a/FactorioCalc.sln
+++ b/FactorioCalc.sln
@@ -1,21 +1,24 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# 
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yafc", "Yafc\Yafc.csproj", "{73EBA162-A3BE-43CC-9B55-CA16332F439D}"
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34728.123
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yafc", "Yafc\Yafc.csproj", "{73EBA162-A3BE-43CC-9B55-CA16332F439D}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yafc.UI", "Yafc.UI\Yafc.UI.csproj", "{70F74D2B-9747-4185-B369-64F77BC8D0D5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yafc.UI", "Yafc.UI\Yafc.UI.csproj", "{70F74D2B-9747-4185-B369-64F77BC8D0D5}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yafc.Model", "Yafc.Model\Yafc.Model.csproj", "{CED05634-9E9E-40EF-9A92-30C8650B14C7}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yafc.Model", "Yafc.Model\Yafc.Model.csproj", "{CED05634-9E9E-40EF-9A92-30C8650B14C7}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yafc.Parser", "Yafc.Parser\Yafc.Parser.csproj", "{4B64D4DD-B6ED-457D-9000-EA0381585959}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yafc.Parser", "Yafc.Parser\Yafc.Parser.csproj", "{4B64D4DD-B6ED-457D-9000-EA0381585959}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "CommandLineToolExample", "CommandLineToolExample\CommandLineToolExample.csproj", "{57E8CAE8-A3F8-4532-B32F-09347852479E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "CommandLineToolExample", "CommandLineToolExample\CommandLineToolExample.csproj", "{57E8CAE8-A3F8-4532-B32F-09347852479E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yafc.Model.Tests", "Yafc.Model.Tests\Yafc.Model.Tests.csproj", "{66B66728-84F0-4242-B49A-B9D746A3CCA5}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Yafc.Model.Tests", "Yafc.Model.Tests\Yafc.Model.Tests.csproj", "{66B66728-84F0-4242-B49A-B9D746A3CCA5}"
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{D6A715CB-5C17-4DD7-9ADA-5D7F44FADFCF}"
 	ProjectSection(SolutionItems) = preProject
 		changelog.txt = changelog.txt
+		Directory.Build.props = Directory.Build.props
 	EndProjectSection
 EndProject
 Global

--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,7 @@ Date: soon
         - Make horizontal scrollbar clickable/draggable.
         - Scroll down/up exactly one page with page down/up keys
         - Fix saving and loading errors with legacy production summaries.
+        - YAFC no longer shows the paths of the releaser in stack traces.
     Internal changes:
         - Initial window size is now separate from the minimal window size.
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Problem: The exception stacktraces contain the paths of the one who built the release.

Solution: use `Directory.Build.props` to sanitize them.

The solution was mentioned by @Dorus in #164:
[The StackExchange question](https://softwareengineering.stackexchange.com/questions/402742/how-can-we-avoid-showing-the-literal-path-in-the-exceptions-stack-trace/421590#421590) 
[The article](https://www.codementor.io/@rowlandbanks/cleaner-stacktraces-13q3hbv2s7)
The theory behind `Directory.Build.props` is described [there](https://learn.microsoft.com/en-us/visualstudio/msbuild/customize-by-directory?view=vs-2022).

The commit contains the following parts:

1. The change itself. It was done by creating `Directory.Build.props` and adding a specific string to it. That triggered the automatic change in `FactorioCalc.sln`.

2. An improvement to the Contributors Guide. It was too small for its own commit.

3. An update to the changelog.

### Quality Assurance 
To check if things work, I've added a line that threw a generic exception when one opened a milestone editor. 
The stack trace was as follows:
```
test of path

   at Yafc.MilestonesEditor.Build(ImGui gui) in X:\Yafc\Windows\MilestonesEditor.cs:line 36
   at Yafc.UI.ImGui.DoGui(ImGuiAction action) in X:\Yafc.UI\ImGui\ImGuiBuilding.cs:line 189
   at Yafc.UI.ImGui.BuildGui(Single width) in X:\Yafc.UI\ImGui\ImGuiBuilding.cs:line 214
   at Yafc.UI.ImGui.CalculateState(Single width, Single pixelsPerUnit) in X:\Yafc.UI\ImGui\ImGui.cs:line 134
   at Yafc.PseudoScreen.Build(ImGui gui, Vector2 screenSize) in X:\Yafc\Widgets\PseudoScreen.cs:line 25
   at Yafc.MainScreen.BuildContent(ImGui gui) in X:\Yafc\Windows\MainScreen.cs:line 213
   at Yafc.UI.WindowMain.BuildContents(ImGui gui) in X:\Yafc.UI\Core\WindowMain.cs:line 38
   at Yafc.UI.Window.Build(ImGui gui) in X:\Yafc.UI\Core\Window.cs:line 206
   at Yafc.UI.ImGui.DoGui(ImGuiAction action) in X:\Yafc.UI\ImGui\ImGuiBuilding.cs:line 189
   at Yafc.UI.ImGui.BuildGui(Single width) in X:\Yafc.UI\ImGui\ImGuiBuilding.cs:line 214
   at Yafc.UI.ImGui.CalculateState(Single width, Single pixelsPerUnit) in X:\Yafc.UI\ImGui\ImGui.cs:line 134
   at Yafc.UI.Window.Render() in X:\Yafc.UI\Core\Window.cs:line 115
   at Yafc.UI.Ui.Render() in X:\Yafc.UI\Core\Ui.cs:line 197
```
The line that threw the exception was deleted before making the PR.
Fixes #164 