### PR TITLE
Default beacon overrides

### DIFF
--- a/Yafc.Model/Data/Database.cs
+++ b/Yafc.Model/Data/Database.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace Yafc.Model {
     public static class Database {
@@ -32,6 +33,11 @@ namespace Yafc.Model {
         public static FactorioIdRange<Technology> technologies { get; internal set; } = null!;
         public static FactorioIdRange<Entity> entities { get; internal set; } = null!;
         public static int constantCombinatorCapacity { get; internal set; } = 18;
+
+        /// <summary>
+        /// Returns the set of beacons filtered to only those that can accept at least one module.
+        /// </summary>
+        public static IEnumerable<EntityBeacon> usableBeacons => allBeacons.Where(b => allModules.Any(m => b.CanAcceptModule(m.moduleSpecification)));
 
         public static FactorioObject? FindClosestVariant(string id) {
             string baseId;

--- a/Yafc.Model/Data/Database.cs
+++ b/Yafc.Model/Data/Database.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Yafc.Model {
@@ -38,6 +39,17 @@ namespace Yafc.Model {
         /// Returns the set of beacons filtered to only those that can accept at least one module.
         /// </summary>
         public static IEnumerable<EntityBeacon> usableBeacons => allBeacons.Where(b => allModules.Any(m => b.CanAcceptModule(m.moduleSpecification)));
+
+        /// <summary>
+        /// Fetches a module that can be used in this beacon, or <see langword="null"/> if no beacon was specified or no module could be found.
+        /// </summary>
+        /// <param name="beacon">The beacon to receive a module. If <see langword="null"/>, <paramref name="module"/> will be set to null and this method will return <see langword="false"/>.</param>
+        /// <param name="module">A module that can be placed in that beacon, if such a module exists.</param>
+        /// <returns><see langword="true"/> if a module could be found, or <see langword="false"/> if the supplied beacon does not accept any modules or was <see langword="null"/>.</returns>
+        public static bool GetDefaultModuleFor(EntityBeacon? beacon, [NotNullWhen(true)] out Module? module) {
+            module = allModules.FirstOrDefault(m => EntityWithModules.CanAcceptModule(m.moduleSpecification, beacon?.allowedEffects ?? AllowedEffects.None));
+            return module != null;
+        }
 
         public static FactorioObject? FindClosestVariant(string id) {
             string baseId;

--- a/Yafc.Model/Model/ModuleFillerParameters.cs
+++ b/Yafc.Model/Model/ModuleFillerParameters.cs
@@ -6,15 +6,37 @@ namespace Yafc.Model {
         void GetModulesInfo(RecipeParameters recipeParams, Recipe recipe, EntityCrafter entity, Goods? fuel, ref ModuleEffects effects, ref RecipeParameters.UsedModule used);
     }
 
+    /// <summary>
+    /// An entry in the per-crafter beacon override configuration. It must specify both a beacon and a module, but it may specify zero beacons.
+    /// </summary>
+    /// <param name="beacon">The beacon to use for this crafter.</param>
+    /// <param name="beaconCount">The number of beacons to use. The total number of modules in beacons is this value times the number of modules that can be placed in a beacon.</param>
+    /// <param name="beaconModule">The module to place in the beacon.</param>
     [Serializable]
-    public record BeaconOverrideConfiguration(EntityBeacon beacon, int beaconCount) {
+    public record BeaconOverrideConfiguration(EntityBeacon beacon, int beaconCount, Module beaconModule) {
+        /// <summary>
+        /// Gets or sets the beacon to use for this crafter.
+        /// </summary>
         public EntityBeacon beacon { get; set; } = beacon;
+        /// <summary>
+        /// Gets or sets the number of beacons to use. The total number of modules in beacons is this value times the number of modules that can be placed in a beacon.
+        /// </summary>
         public int beaconCount { get; set; } = beaconCount;
+        /// <summary>
+        /// Gets or sets the module to place in the beacon.
+        /// </summary>
+        public Module beaconModule { get; set; } = beaconModule;
     }
 
+    /// <summary>
+    /// The result of applying the various beacon preferences to a crafter; this may result in a desired configuration where the beacon or module is not specified.
+    /// </summary>
+    /// <param name="beacon">The beacon to use for this crafter, or <see langword="null"/> if no beacons or beacon modules should be used.</param>
+    /// <param name="beaconCount">The number of beacons to use. The total number of modules in beacons is this value times the number of modules that can be placed in a beacon.</param>
+    /// <param name="beaconModule">The module to place in the beacon, or <see langword="null"/> if no beacons or beacon modules should be used.</param>
     [Serializable]
-    public record BeaconConfiguration(EntityBeacon? beacon, int beaconCount) {
-        public static implicit operator BeaconConfiguration(BeaconOverrideConfiguration beaconConfiguration) => new(beaconConfiguration.beacon, beaconConfiguration.beaconCount);
+    public record BeaconConfiguration(EntityBeacon? beacon, int beaconCount, Module? beaconModule) {
+        public static implicit operator BeaconConfiguration(BeaconOverrideConfiguration beaconConfiguration) => new(beaconConfiguration.beacon, beaconConfiguration.beaconCount, beaconConfiguration.beaconModule);
     }
 
     [Serializable]
@@ -39,21 +61,21 @@ namespace Yafc.Model {
         }
 
         /// <summary>
-        /// Given a building that accepts beacon effects, return the type and number of beacons that should affect that building.
+        /// Given a building that accepts beacon effects, return the type and number of beacons that should affect that building, along with the module to place in those beacons.
         /// </summary>
         /// <param name="crafter">The building to be affected by beacons.</param>
-        /// <returns>The type and number of beacons to apply to that type of building.</returns>
+        /// <returns>The type and number of beacons to apply to that type of building, along with the module that will be placed in the beacons.</returns>
         public BeaconConfiguration GetBeaconsForCrafter(EntityCrafter? crafter) {
             if (crafter is not null && overrideCrafterBeacons.TryGetValue(crafter, out var result)) {
                 return result;
             }
-            return new(beacon, beaconsPerBuilding);
+            return new(beacon, beaconsPerBuilding, beaconModule);
         }
 
         public void AutoFillBeacons(RecipeParameters recipeParams, Recipe recipe, EntityCrafter entity, Goods? fuel, ref ModuleEffects effects, ref RecipeParameters.UsedModule used) {
             BeaconConfiguration beaconsToUse = GetBeaconsForCrafter(entity);
-            if (!recipe.flags.HasFlags(RecipeFlags.UsesMiningProductivity) && beaconsToUse.beacon is EntityBeacon beacon && beaconModule != null) {
-                effects.AddModules(beaconModule.moduleSpecification, beaconsToUse.beaconCount * beacon.beaconEfficiency * beacon.moduleSlots, entity.allowedEffects);
+            if (!recipe.flags.HasFlags(RecipeFlags.UsesMiningProductivity) && beaconsToUse.beacon is EntityBeacon beacon && beaconsToUse.beaconModule != null) {
+                effects.AddModules(beaconsToUse.beaconModule.moduleSpecification, beaconsToUse.beaconCount * beacon.beaconEfficiency * beacon.moduleSlots, entity.allowedEffects);
                 used.beacon = beacon;
                 used.beaconCount = beaconsToUse.beaconCount;
             }

--- a/Yafc/Widgets/ImmediateWidgets.cs
+++ b/Yafc/Widgets/ImmediateWidgets.cs
@@ -262,7 +262,9 @@ namespace Yafc {
         /// <param name="amount">Display this value, formatted appropriately for <paramref name="unit"/>.</param>
         /// <param name="unit">Use this unit of measure when formatting <paramref name="amount"/> for display.</param>
         /// <param name="newAmount">The new value entered by the user, if this returns <see cref="GoodsWithAmountEvent.TextEditing"/>. Otherwise, the original <paramref name="amount"/>.</param>
-        public static GoodsWithAmountEvent BuildFactorioObjectWithEditableAmount(this ImGui gui, FactorioObject? obj, float amount, UnitOfMeasure unit, out float newAmount, SchemeColor color = SchemeColor.None, bool useScale = true) {
+        /// <param name="allowScroll">If <see langword="true"/>, the default, the user can adjust the value by using the scroll wheel while hovering over the editable text.
+        /// If <see langword="false"/>, the scroll wheel will be ignored when hovering.</param>
+        public static GoodsWithAmountEvent BuildFactorioObjectWithEditableAmount(this ImGui gui, FactorioObject? obj, float amount, UnitOfMeasure unit, out float newAmount, SchemeColor color = SchemeColor.None, bool useScale = true, bool allowScroll = true) {
             using var group = gui.EnterGroup(default, RectAllocator.Stretch, spacing: 0f);
             group.SetWidth(3f);
             newAmount = amount;
@@ -274,7 +276,7 @@ namespace Yafc {
                 }
             }
 
-            if (gui.action == ImGuiAction.MouseScroll && gui.ConsumeEvent(gui.lastRect)) {
+            if (allowScroll && gui.action == ImGuiAction.MouseScroll && gui.ConsumeEvent(gui.lastRect)) {
                 float digit = MathF.Pow(10, MathF.Floor(MathF.Log10(amount) - 2f));
                 newAmount = MathF.Round((amount / digit) + gui.actionParameter) * digit;
                 evt = GoodsWithAmountEvent.TextEditing;

--- a/Yafc/Windows/SelectObjectPanel.cs
+++ b/Yafc/Windows/SelectObjectPanel.cs
@@ -14,6 +14,7 @@ namespace Yafc {
         private readonly SearchableList<FactorioObject?> list;
         private string header = null!; // null-forgiving: set by Select
         private Rect searchBox;
+        private string? noneTooltip;
         /// <summary>
         /// If <see langword="true"/> and the object being hovered is not a <see cref="Goods"/>, the <see cref="ObjectTooltip"/> should specify the type of object.
         /// See also <see cref="ObjectTooltip.extendHeader"/>.
@@ -34,8 +35,10 @@ namespace Yafc {
         /// parameter for each <see cref="FactorioObject"/>. The first parameter may be <see langword="null"/> if <paramref name="allowNone"/> is <see langword="true"/>.</param>
         /// <param name="allowNone">If <see langword="true"/>, a "none" option will be displayed. Selection of this item will be conveyed by calling <paramref name="mapResult"/>
         /// and <paramref name="selectItem"/> with <see langword="default"/> values for <typeparamref name="T"/> and <typeparamref name="U"/>.</param>
-        protected void Select<U>(IEnumerable<U> list, string header, Action<U?> selectItem, IComparer<U>? ordering, Action<T?, Action<FactorioObject?>> mapResult, bool allowNone) where U : FactorioObject {
+        /// <param name="noneTooltip">If not <see langword="null"/>, this tooltip will be displayed when hovering over the "none" item.</param>
+        protected void Select<U>(IEnumerable<U> list, string header, Action<U?> selectItem, IComparer<U>? ordering, Action<T?, Action<FactorioObject?>> mapResult, bool allowNone, string? noneTooltip = null) where U : FactorioObject {
             _ = MainScreen.Instance.ShowPseudoScreen(this);
+            this.noneTooltip = noneTooltip;
             extendHeader = typeof(U) == typeof(FactorioObject);
             List<U?> data = new List<U?>(list);
             ordering ??= DataUtils.DefaultOrdering;
@@ -68,7 +71,11 @@ namespace Yafc {
 
         private void ElementDrawer(ImGui gui, FactorioObject? element, int index) {
             if (element == null) {
-                if (gui.BuildRedButton(Icon.Close)) {
+                ButtonEvent evt = gui.BuildRedButton(Icon.Close);
+                if (noneTooltip != null) {
+                    evt.WithTooltip(gui, noneTooltip);
+                }
+                if (evt) {
                     CloseWithResult(default);
                 }
             }

--- a/Yafc/Windows/SelectSingleObjectPanel.cs
+++ b/Yafc/Windows/SelectSingleObjectPanel.cs
@@ -28,8 +28,9 @@ namespace Yafc {
         /// <param name="header">The string that describes to the user why they're selecting these items.</param>
         /// <param name="selectItem">An action to be called for the selected item when the panel is closed. The parameter will be <see langword="null"/> if the "none" or "clear" option is selected.</param>
         /// <param name="ordering">An optional ordering specifying how to sort the displayed items. If <see langword="null"/>, defaults to <see cref="DataUtils.DefaultOrdering"/>.</param>
-        public static void SelectWithNone<T>(IEnumerable<T> list, string header, Action<T?> selectItem, IComparer<T>? ordering = null) where T : FactorioObject
-            => new SelectSingleObjectPanel().Select(list, header, selectItem, ordering, (obj, mappedAction) => mappedAction(obj), true);
+        /// <param name="noneTooltip">If not <see langword="null"/>, this tooltip will be displayed when hovering over the "none" item.</param>
+        public static void SelectWithNone<T>(IEnumerable<T> list, string header, Action<T?> selectItem, IComparer<T>? ordering = null, string? noneTooltip = null) where T : FactorioObject
+            => new SelectSingleObjectPanel().Select(list, header, selectItem, ordering, (obj, mappedAction) => mappedAction(obj), true, noneTooltip);
 
         protected override void NonNullElementDrawer(ImGui gui, FactorioObject element, int index) {
             if (gui.BuildFactorioObjectButton(element, 2.5f, MilestoneDisplay.Contained, extendHeader: extendHeader, useScale: true) == Click.Left) {

--- a/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -84,8 +84,8 @@ namespace Yafc {
                     }
 
                     var defaultFiller = recipe?.GetModuleFiller();
-                    if (defaultFiller?.GetBeaconsForCrafter(recipe?.entity) is BeaconConfiguration { beacon: not null } beaconsToUse && defaultFiller.beaconModule != null) {
-                        effects.AddModules(defaultFiller.beaconModule.moduleSpecification, beaconsToUse.beacon.beaconEfficiency * beaconsToUse.beacon.moduleSlots * beaconsToUse.beaconCount);
+                    if (defaultFiller?.GetBeaconsForCrafter(recipe?.entity) is BeaconConfiguration { beacon: not null, beaconModule: not null } beaconsToUse) {
+                        effects.AddModules(beaconsToUse.beaconModule.moduleSpecification, beaconsToUse.beacon.beaconEfficiency * beaconsToUse.beacon.moduleSlots * beaconsToUse.beaconCount);
                     }
                 }
                 else {

--- a/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -84,8 +84,8 @@ namespace Yafc {
                     }
 
                     var defaultFiller = recipe?.GetModuleFiller();
-                    if (defaultFiller?.beacon != null && defaultFiller.beaconModule != null) {
-                        effects.AddModules(defaultFiller.beaconModule.moduleSpecification, defaultFiller.beacon.beaconEfficiency * defaultFiller.beacon.moduleSlots * defaultFiller.GetBeaconsForCrafter(recipe?.entity));
+                    if (defaultFiller?.GetBeaconsForCrafter(recipe?.entity) is BeaconConfiguration { beacon: not null } beaconsToUse && defaultFiller.beaconModule != null) {
+                        effects.AddModules(defaultFiller.beaconModule.moduleSpecification, beaconsToUse.beacon.beaconEfficiency * beaconsToUse.beacon.moduleSlots * beaconsToUse.beaconCount);
                     }
                 }
                 else {

--- a/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -85,7 +85,7 @@ namespace Yafc {
 
                     var defaultFiller = recipe?.GetModuleFiller();
                     if (defaultFiller?.beacon != null && defaultFiller.beaconModule != null) {
-                        effects.AddModules(defaultFiller.beaconModule.moduleSpecification, defaultFiller.beacon.beaconEfficiency * defaultFiller.beacon.moduleSlots * defaultFiller.beaconsPerBuilding);
+                        effects.AddModules(defaultFiller.beaconModule.moduleSpecification, defaultFiller.beacon.beaconEfficiency * defaultFiller.beacon.moduleSlots * defaultFiller.GetBeaconsForCrafter(recipe?.entity));
                     }
                 }
                 else {

--- a/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
@@ -75,6 +75,29 @@ namespace Yafc {
             }
             gui.BuildText("Please note that beacons themselves are not part of the calculation", wrap: true);
 
+            gui.AllocateSpacing();
+            gui.BuildText("Override beacon count:", Font.subheader);
+            using (gui.EnterRow()) {
+                foreach (var (crafter, count) in modules.overrideCrafterBeacons) {
+                    switch (gui.BuildFactorioObjectWithEditableAmount(crafter, count, UnitOfMeasure.None, out float newAmount)) {
+                        case GoodsWithAmountEvent.RightButtonClick:
+                            modules.RecordUndo().overrideCrafterBeacons.Remove(crafter);
+                            return;
+                        case GoodsWithAmountEvent.TextEditing:
+                            modules.RecordUndo().overrideCrafterBeacons[crafter] = (int)newAmount;
+                            return;
+                    }
+                }
+            }
+
+            using (gui.EnterRow(allocator: RectAllocator.Center)) {
+                if (gui.BuildButton("Add an override for a building type")) {
+                    SelectMultiObjectPanel.Select(Database.allCrafters.Where(x => x.allowedEffects != AllowedEffects.None && !modules.overrideCrafterBeacons.ContainsKey(x)), "Add exception(s) for:",
+                        crafter => modules.RecordUndo().overrideCrafterBeacons[crafter] = modules.beaconsPerBuilding);
+                }
+            }
+
+            gui.AllocateSpacing();
             using (gui.EnterRow()) {
                 gui.BuildText("Mining productivity bonus (project-wide setting): ");
                 if (gui.BuildTextInput(DataUtils.FormatAmount(Project.current.settings.miningProductivity, UnitOfMeasure.Percent), out string newText, null, Icon.None, true, new Padding(0.5f, 0f)) &&

--- a/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Numerics;
 using Yafc.Model;
 using Yafc.UI;
 
@@ -35,6 +36,8 @@ namespace Yafc {
         }
 
         public override void Build(ImGui gui) {
+            EntityBeacon? defaultBeacon = Database.usableBeacons.FirstOrDefault();
+
             BuildHeader(gui, "Module autofill parameters");
             BuildSimple(gui, modules);
             if (gui.BuildCheckBox("Fill modules in miners", modules.fillMiners, out bool newFill)) {
@@ -50,50 +53,70 @@ namespace Yafc {
 
             gui.AllocateSpacing();
             gui.BuildText("Beacons & beacon modules:", Font.subheader);
-            if (gui.BuildFactorioObjectButtonWithText(modules.beacon) == Click.Left) {
-                SelectSingleObjectPanel.SelectWithNone(Database.allBeacons, "Select beacon", select => {
-                    _ = modules.RecordUndo();
-                    modules.beacon = select;
-                    if (modules.beaconModule != null && (modules.beacon == null || !modules.beacon.CanAcceptModule(modules.beaconModule.moduleSpecification))) {
-                        modules.beaconModule = null;
-                    }
-
-                    gui.Rebuild();
-                });
+            if (defaultBeacon is null) {
+                gui.BuildText("Your mods contain no beacons, or no modules that can be put into beacons.");
             }
+            else {
+                if (gui.BuildFactorioObjectButtonWithText(modules.beacon) == Click.Left) {
+                    SelectSingleObjectPanel.SelectWithNone(Database.allBeacons, "Select beacon", select => {
+                        _ = modules.RecordUndo();
+                        modules.beacon = select;
+                        if (modules.beaconModule != null && (modules.beacon == null || !modules.beacon.CanAcceptModule(modules.beaconModule.moduleSpecification))) {
+                            modules.beaconModule = null;
+                        }
 
-            if (gui.BuildFactorioObjectButtonWithText(modules.beaconModule) == Click.Left) {
-                SelectSingleObjectPanel.SelectWithNone(Database.allModules.Where(x => modules.beacon?.CanAcceptModule(x.moduleSpecification) ?? false), "Select module for beacon", select => { modules.RecordUndo().beaconModule = select; });
-            }
-
-            using (gui.EnterRow()) {
-                gui.BuildText("Beacons per building: ");
-                if (gui.BuildTextInput(modules.beaconsPerBuilding.ToString(), out string newText, null, Icon.None, true, new Padding(0.5f, 0f)) &&
-                    int.TryParse(newText, out int newAmount) && newAmount > 0) {
-                    modules.RecordUndo().beaconsPerBuilding = newAmount;
+                        gui.Rebuild();
+                    });
                 }
-            }
-            gui.BuildText("Please note that beacons themselves are not part of the calculation", wrap: true);
 
-            gui.AllocateSpacing();
-            gui.BuildText("Override beacon count:", Font.subheader);
-            using (gui.EnterRow()) {
-                foreach (var (crafter, count) in modules.overrideCrafterBeacons) {
-                    switch (gui.BuildFactorioObjectWithEditableAmount(crafter, count, UnitOfMeasure.None, out float newAmount)) {
-                        case GoodsWithAmountEvent.RightButtonClick:
-                            modules.RecordUndo().overrideCrafterBeacons.Remove(crafter);
-                            return;
-                        case GoodsWithAmountEvent.TextEditing:
-                            modules.RecordUndo().overrideCrafterBeacons[crafter] = (int)newAmount;
-                            return;
+                if (gui.BuildFactorioObjectButtonWithText(modules.beaconModule) == Click.Left) {
+                    SelectSingleObjectPanel.SelectWithNone(Database.allModules.Where(x => modules.beacon?.CanAcceptModule(x.moduleSpecification) ?? false), "Select module for beacon", select => { modules.RecordUndo().beaconModule = select; });
+                }
+
+                using (gui.EnterRow()) {
+                    gui.BuildText("Beacons per building: ");
+                    if (gui.BuildTextInput(modules.beaconsPerBuilding.ToString(), out string newText, null, Icon.None, true, new Padding(0.5f, 0f)) &&
+                        int.TryParse(newText, out int newAmount) && newAmount > 0) {
+                        modules.RecordUndo().beaconsPerBuilding = newAmount;
                     }
                 }
-            }
+                gui.BuildText("Please note that beacons themselves are not part of the calculation", wrap: true);
 
-            using (gui.EnterRow(allocator: RectAllocator.Center)) {
-                if (gui.BuildButton("Add an override for a building type")) {
-                    SelectMultiObjectPanel.Select(Database.allCrafters.Where(x => x.allowedEffects != AllowedEffects.None && !modules.overrideCrafterBeacons.ContainsKey(x)), "Add exception(s) for:",
-                        crafter => modules.RecordUndo().overrideCrafterBeacons[crafter] = modules.beaconsPerBuilding);
+                gui.AllocateSpacing();
+                gui.BuildText("Override beacons:", Font.subheader);
+                if (modules.overrideCrafterBeacons.Count > 0) {
+                    gui.BuildText("  Click to change beacon", topOffset: -0.5f);
+                }
+                using (gui.EnterRow()) {
+                    foreach ((EntityCrafter crafter, BeaconOverrideConfiguration beaconInfo) in modules.overrideCrafterBeacons) {
+                        GoodsWithAmountEvent click = gui.BuildFactorioObjectWithEditableAmount(crafter, beaconInfo.beaconCount, UnitOfMeasure.None, out float newAmount);
+                        gui.DrawIcon(new Rect(gui.lastRect.TopLeft, new Vector2(1.25f, 1.25f)), beaconInfo.beacon.icon, SchemeColor.Source);
+                        switch (click) {
+                            case GoodsWithAmountEvent.LeftButtonClick:
+                                SelectSingleObjectPanel.SelectWithNone(Database.allBeacons, "Select beacon", selectedBeacon => {
+                                    if (selectedBeacon is null) {
+                                        modules.RecordUndo().overrideCrafterBeacons.Remove(crafter);
+                                    }
+                                    else {
+                                        modules.RecordUndo().overrideCrafterBeacons[crafter].beacon = selectedBeacon;
+                                    }
+                                }, noneTooltip: "Click here to remove the current override.");
+                                return;
+                            case GoodsWithAmountEvent.RightButtonClick:
+                                modules.RecordUndo().overrideCrafterBeacons.Remove(crafter);
+                                return;
+                            case GoodsWithAmountEvent.TextEditing:
+                                modules.RecordUndo().overrideCrafterBeacons[crafter].beaconCount = (int)newAmount;
+                                return;
+                        }
+                    }
+                }
+
+                using (gui.EnterRow(allocator: RectAllocator.Center)) {
+                    if (gui.BuildButton("Add an override for a building type")) {
+                        SelectMultiObjectPanel.Select(Database.allCrafters.Where(x => x.allowedEffects != AllowedEffects.None && !modules.overrideCrafterBeacons.ContainsKey(x)), "Add exception(s) for:",
+                            crafter => modules.RecordUndo().overrideCrafterBeacons[crafter] = new(modules.beacon ?? defaultBeacon, modules.beaconsPerBuilding));
+                    }
                 }
             }
 

--- a/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
@@ -24,7 +24,7 @@ namespace Yafc {
         /// </summary>
         private void ListDrawer(ImGui gui, KeyValuePair<EntityCrafter, BeaconOverrideConfiguration> element, int index) {
             (EntityCrafter crafter, BeaconOverrideConfiguration config) = element;
-            GoodsWithAmountEvent click = gui.BuildFactorioObjectWithEditableAmount(crafter, config.beaconCount, UnitOfMeasure.None, out float newAmount);
+            GoodsWithAmountEvent click = gui.BuildFactorioObjectWithEditableAmount(crafter, config.beaconCount, UnitOfMeasure.None, out float newAmount, allowScroll: false);
             gui.DrawIcon(new(gui.lastRect.X, gui.lastRect.Y, 1.25f, 1.25f), config.beacon.icon, SchemeColor.Source);
             gui.DrawIcon(new(gui.lastRect.TopRight - new Vector2(1.25f, 0), new Vector2(1.25f, 1.25f)), config.beaconModule.icon, SchemeColor.Source);
             switch (click) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -13,6 +13,9 @@
 ----------------------------------------------------------------------------------------------------------------------
 Version 0.7.3
 Date: soon
+    Features:
+        - Add the option to specify how many beacons, with what modules, should be applied on a per-building-type
+          basis, in addition to the global and per-recipe-row settings.
     Bugfixes:
         - Fix PageSearch scrollbar not working.
     Internal changes:


### PR DESCRIPTION
This adds an intermediate level of beacon definitions; more general than the per-recipe-row definitions in the production table, but more specific than the whole-page settings.

It was inspired by my desire to tell YAFC that the rows using IR3's small assemblers (~50 of my recipe rows) would be affected by three beacons, while (most of) the remaining recipe rows would be affected by four.


On the module settings page, it adds this section. This allows you to specify the number of beacons, the beacon, and the beacon module on a per-building basis.

![image](https://user-images.githubusercontent.com/21223975/214727217-4dec35e3-ff3e-4581-9e59-71c8af0a2be9.png)

"Add building override" lets you select any previously unselected crafter that accepts beacon effects. Left and right clicking open the same dialogs as clicking on the beacon and module settings above.

This is a rebase and minor update (changes to the hint texts) of ShadowTheAge#200. I haven't used it recently (I primarily use it for megabasing), but I'm hoping it will be helpful for TURD beacons and similar. I'm hoping it will also satisfy requests like [this one](https://discord.com/channels/560199483065892894/1210135763422027837/1253101648872472649).