### PR TITLE
Fix #151: Refresh the milestone window after adding or removing milestones.

### DIFF
--- a/Yafc/Windows/MilestonesEditor.cs
+++ b/Yafc/Windows/MilestonesEditor.cs
@@ -14,6 +14,12 @@ namespace Yafc {
             milestoneList.data = Project.current.settings.milestones;
         }
 
+        protected override void Close(bool save = true) {
+            MilestonesPanel.Rebuild();
+            Milestones.Instance.Compute(Project.current, new());
+            base.Close(save);
+        }
+
         public static void Show() => _ = MainScreen.Instance.ShowPseudoScreen(new MilestonesEditor());
 
         private void MilestoneDrawer(ImGui gui, FactorioObject element, int index) {

--- a/Yafc/Windows/MilestonesPanel.cs
+++ b/Yafc/Windows/MilestonesPanel.cs
@@ -32,9 +32,11 @@ namespace Yafc {
     }
 
     public class MilestonesPanel : PseudoScreen {
+        private static MilestonesWidget? instance;
         private readonly MilestonesWidget milestonesWidget = new();
 
         public override void Build(ImGui gui) {
+            instance = milestonesWidget;
             gui.spacing = 1f;
             BuildHeader(gui, "Milestones");
             gui.BuildText("Please select objects that you already have access to:");
@@ -57,5 +59,10 @@ namespace Yafc {
         }
 
         protected override void ReturnPressed() => Close();
+
+        /// <summary>
+        /// Called by <see cref="MilestonesEditor.Close(bool)"/> to force this panel to update its contents and show the possibly-modified milestones.
+        /// </summary>
+        internal static new void Rebuild() => instance?.RebuildContents();
     }
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -18,6 +18,7 @@ Date: soon
           basis, in addition to the global and per-recipe-row settings.
     Bugfixes:
         - Fix PageSearch scrollbar not working.
+        - Refresh the milestones display after adding or removing milestones.
     Internal changes:
         - Finish the namespace rename from YAFC to Yafc.
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Also recalculate the milestones when closing the editor so mass-unlock operations in the milestone window will behave properly.