### PR TITLE
Add recipes for research consumption

### DIFF
--- a/Yafc.Model/Analysis/AutomationAnalysis.cs
+++ b/Yafc.Model/Analysis/AutomationAnalysis.cs
@@ -20,7 +20,7 @@ namespace Yafc.Model {
             state[Database.voidEnergy] = AutomationStatus.AutomatableNow;
             Queue<FactorioId> processingQueue = new Queue<FactorioId>(Database.objects.count);
             int unknowns = 0;
-            foreach (var recipe in Database.recipes.all) {
+            foreach (Recipe recipe in Database.recipes.all.ExceptExcluded(this)) {
                 bool hasAutomatableCrafter = false;
                 foreach (var crafter in recipe.crafters) {
                     if (crafter != Database.character && crafter.IsAccessible()) {
@@ -32,7 +32,7 @@ namespace Yafc.Model {
                 }
             }
 
-            foreach (var obj in Database.objects.all) {
+            foreach (FactorioObject obj in Database.objects.all.ExceptExcluded(this)) {
                 if (!obj.IsAccessible()) {
                     state[obj] = AutomationStatus.NotAutomatable;
                 }

--- a/Yafc.Model/Analysis/CostAnalysis.cs
+++ b/Yafc.Model/Analysis/CostAnalysis.cs
@@ -57,7 +57,7 @@ namespace Yafc.Model {
             }
             else {
                 itemAmountPrefix = "Estimated amount for all researches: ";
-                foreach (Technology technology in Database.technologies.all) {
+                foreach (Technology technology in Database.technologies.all.ExceptExcluded(this)) {
                     if (technology.IsAccessible() && technology.ingredients is not null) {
                         foreach (var ingredient in technology.ingredients) {
                             if (ingredient.goods.IsAutomatable()) {
@@ -74,7 +74,7 @@ namespace Yafc.Model {
             }
 
 
-            foreach (var goods in Database.goods.all) {
+            foreach (Goods goods in Database.goods.all.ExceptExcluded(this)) {
                 if (!ShouldInclude(goods)) {
                     continue;
                 }
@@ -103,7 +103,7 @@ namespace Yafc.Model {
             recipeCost = Database.recipes.CreateMapping<float>();
             flow = Database.objects.CreateMapping<float>();
             var lastVariable = Database.goods.CreateMapping<Variable>();
-            foreach (var recipe in Database.recipes.all) {
+            foreach (Recipe recipe in Database.recipes.all.ExceptExcluded(this)) {
                 if (!ShouldInclude(recipe)) {
                     continue;
                 }
@@ -229,7 +229,7 @@ namespace Yafc.Model {
             }
 
             // TODO this is temporary fix for strange item sources (make the cost of item not higher than the cost of its source)
-            foreach (var item in Database.items.all) {
+            foreach (Item item in Database.items.all.ExceptExcluded(this)) {
                 if (ShouldInclude(item)) {
                     foreach (var source in item.miscSources) {
                         if (source is Goods g && ShouldInclude(g)) {
@@ -260,7 +260,7 @@ namespace Yafc.Model {
             if (result is Solver.ResultStatus.OPTIMAL or Solver.ResultStatus.FEASIBLE) {
                 float objectiveValue = (float)objective.Value();
                 Console.WriteLine("Estimated modpack cost: " + DataUtils.FormatAmount(objectiveValue * 1000f, UnitOfMeasure.None));
-                foreach (var g in Database.goods.all) {
+                foreach (Goods g in Database.goods.all.ExceptExcluded(this)) {
                     if (variables[g] == null) {
                         continue;
                     }
@@ -269,7 +269,7 @@ namespace Yafc.Model {
                     export[g] = value;
                 }
 
-                foreach (var recipe in Database.recipes.all) {
+                foreach (Recipe recipe in Database.recipes.all.ExceptExcluded(this)) {
                     if (constraints[recipe] == null) {
                         continue;
                     }
@@ -285,7 +285,7 @@ namespace Yafc.Model {
                     }
                 }
             }
-            foreach (var o in Database.objects.all) {
+            foreach (FactorioObject o in Database.objects.all.ExceptExcluded(this)) {
                 if (!ShouldInclude(o)) {
                     export[o] = float.PositiveInfinity;
                     continue;
@@ -335,7 +335,7 @@ namespace Yafc.Model {
                 }
             }
 
-            importantItems = [.. Database.goods.all.Where(x => x.usages.Length > 1).OrderByDescending(x => flow[x] * cost[x] * x.usages.Count(y => ShouldInclude(y) && recipeWastePercentage[y] == 0f))];
+            importantItems = [.. Database.goods.all.ExceptExcluded(this).Where(x => x.usages.Length > 1).OrderByDescending(x => flow[x] * cost[x] * x.usages.Count(y => ShouldInclude(y) && recipeWastePercentage[y] == 0f))];
 
             workspaceSolver.Dispose();
         }

--- a/Yafc.Model/Analysis/TechnologyScienceAnalysis.cs
+++ b/Yafc.Model/Analysis/TechnologyScienceAnalysis.cs
@@ -41,7 +41,7 @@ namespace Yafc.Model {
             var requirementMap = Database.technologies.CreateMapping<Technology, bool>(Database.technologies);
 
             Queue<Technology> queue = new Queue<Technology>();
-            foreach (var tech in Database.technologies.all) {
+            foreach (Technology tech in Database.technologies.all.ExceptExcluded(this)) {
                 if (tech.prerequisites.Length == 0) {
                     processing[tech] = true;
                     queue.Enqueue(tech);

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -140,6 +140,8 @@ namespace Yafc.Model {
             }
             return true;
         }
+
+        public virtual bool CanAcceptModule(Item _) => true;
     }
 
     public enum FactorioObjectSpecialType {
@@ -180,7 +182,7 @@ namespace Yafc.Model {
             return false;
         }
 
-        public bool CanAcceptModule(Item module) {
+        public override bool CanAcceptModule(Item module) {
             return modules.Contains(module);
         }
     }

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -452,7 +452,12 @@ namespace Yafc.Model {
         public int fluidInputs { get; internal set; } // fluid inputs for recipe, not including power
         public Goods[]? inputs { get; internal set; }
         public RecipeOrTechnology[] recipes { get; internal set; } = null!; // null-forgiving: Set in the first step of CalculateMaps
-        public float craftingSpeed { get; internal set; } = 1f;
+        private float _craftingSpeed = 1;
+        public float craftingSpeed {
+            // The speed of a lab is baseSpeed * (1 + researchSpeedBonus) * Math.Min(0.2, 1 + moduleAndBeaconSpeedBonus)
+            get => _craftingSpeed * (1 + (factorioType == "lab" ? Project.current.settings.researchSpeedBonus : 0));
+            internal set => _craftingSpeed = value;
+        }
         public float productivity { get; internal set; }
     }
 

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -67,6 +67,8 @@ namespace Yafc.Model {
         public int CompareTo(FactorioObject? other) {
             return DataUtils.DefaultOrdering.Compare(this, other);
         }
+
+        public virtual bool showInExplorers => true;
     }
 
     public class FactorioIconPart(string path) {

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -366,10 +366,21 @@ namespace Yafc.Model {
     public class Special : Goods {
         internal string? virtualSignal { get; set; }
         internal bool power;
+        internal bool isResearch;
         public override bool isPower => power;
         public override string type => isPower ? "Power" : "Special";
         public override UnitOfMeasure flowUnitOfMeasure => isPower ? UnitOfMeasure.Megawatt : UnitOfMeasure.PerSecond;
         internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.SpecialGoods;
+        public override bool showInExplorers => !isResearch;
+
+        public override void GetDependencies(IDependencyCollector collector, List<FactorioObject> temp) {
+            if (isResearch) {
+                collector.Add(Database.technologies.all.ToArray(), DependencyList.Flags.Source);
+            }
+            else {
+                base.GetDependencies(collector, temp);
+            }
+        }
     }
 
     [Flags]

--- a/Yafc.Model/Data/DataUtils.cs
+++ b/Yafc.Model/Data/DataUtils.cs
@@ -265,7 +265,7 @@ namespace Yafc.Model {
             }
         }
 
-        public static float GetProduction(this Recipe recipe, Goods product) {
+        public static float GetProduction(this RecipeOrTechnology recipe, Goods product) {
             float amount = 0f;
             foreach (var p in recipe.products) {
                 if (p.goods == product) {

--- a/Yafc.Model/Data/DataUtils.cs
+++ b/Yafc.Model/Data/DataUtils.cs
@@ -275,7 +275,7 @@ namespace Yafc.Model {
             return amount;
         }
 
-        public static float GetProduction(this Recipe recipe, Goods product, float productivity) {
+        public static float GetProduction(this RecipeOrTechnology recipe, Goods product, float productivity) {
             float amount = 0f;
             foreach (var p in recipe.products) {
                 if (p.goods == product) {
@@ -285,7 +285,7 @@ namespace Yafc.Model {
             return amount;
         }
 
-        public static float GetConsumption(this Recipe recipe, Goods product) {
+        public static float GetConsumption(this RecipeOrTechnology recipe, Goods product) {
             float amount = 0f;
             foreach (var ingredient in recipe.ingredients) {
                 if (ingredient.ContainsVariant(product)) {

--- a/Yafc.Model/Data/Database.cs
+++ b/Yafc.Model/Data/Database.cs
@@ -92,6 +92,7 @@ namespace Yafc.Model {
         internal readonly int start;
         public int count { get; }
         public T[] all { get; }
+        public IEnumerable<T> explorable => all.Where(o => o.showInExplorers);
 
         public FactorioIdRange(int start, int end, List<FactorioObject> source) {
             this.start = start;

--- a/Yafc.Model/Data/Database.cs
+++ b/Yafc.Model/Data/Database.cs
@@ -12,6 +12,7 @@ namespace Yafc.Model {
         public static Dictionary<string, FactorioObject> objectsByTypeName { get; internal set; } = null!;
         public static Dictionary<string, List<Fluid>> fluidVariants { get; internal set; } = null!;
         public static Goods voidEnergy { get; internal set; } = null!;
+        public static Goods researchUnit { get; internal set; } = null!;
         public static Goods electricity { get; internal set; } = null!;
         public static Recipe electricityGeneration { get; internal set; } = null!;
         public static Goods heat { get; internal set; } = null!;

--- a/Yafc.Model/Model/ModuleFillerParameters.cs
+++ b/Yafc.Model/Model/ModuleFillerParameters.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 
 namespace Yafc.Model {
     public interface IModuleFiller {
-        void GetModulesInfo(RecipeParameters recipeParams, Recipe recipe, EntityCrafter entity, Goods? fuel, ref ModuleEffects effects, ref RecipeParameters.UsedModule used);
+        void GetModulesInfo(RecipeParameters recipeParams, RecipeOrTechnology recipe, EntityCrafter entity, Goods? fuel, ref ModuleEffects effects, ref RecipeParameters.UsedModule used);
     }
 
     /// <summary>
@@ -72,7 +72,7 @@ namespace Yafc.Model {
             return new(beacon, beaconsPerBuilding, beaconModule);
         }
 
-        public void AutoFillBeacons(RecipeParameters recipeParams, Recipe recipe, EntityCrafter entity, Goods? fuel, ref ModuleEffects effects, ref RecipeParameters.UsedModule used) {
+        public void AutoFillBeacons(RecipeParameters recipeParams, RecipeOrTechnology recipe, EntityCrafter entity, Goods? fuel, ref ModuleEffects effects, ref RecipeParameters.UsedModule used) {
             BeaconConfiguration beaconsToUse = GetBeaconsForCrafter(entity);
             if (!recipe.flags.HasFlags(RecipeFlags.UsesMiningProductivity) && beaconsToUse.beacon is EntityBeacon beacon && beaconsToUse.beaconModule != null) {
                 effects.AddModules(beaconsToUse.beaconModule.moduleSpecification, beaconsToUse.beaconCount * beacon.beaconEfficiency * beacon.moduleSlots, entity.allowedEffects);
@@ -81,7 +81,7 @@ namespace Yafc.Model {
             }
         }
 
-        public void AutoFillModules(RecipeParameters recipeParams, Recipe recipe, EntityCrafter entity, Goods? fuel, ref ModuleEffects effects, ref RecipeParameters.UsedModule used) {
+        public void AutoFillModules(RecipeParameters recipeParams, RecipeOrTechnology recipe, EntityCrafter entity, Goods? fuel, ref ModuleEffects effects, ref RecipeParameters.UsedModule used) {
             if (autoFillPayback > 0 && (fillMiners || !recipe.flags.HasFlags(RecipeFlags.UsesMiningProductivity))) {
                 float productivityEconomy = recipe.Cost() / recipeParams.recipeTime;
                 float effectivityEconomy = recipeParams.fuelUsagePerSecondPerBuilding * fuel?.Cost() ?? 0;
@@ -116,7 +116,7 @@ namespace Yafc.Model {
             }
         }
 
-        public void GetModulesInfo(RecipeParameters recipeParams, Recipe recipe, EntityCrafter entity, Goods? fuel, ref ModuleEffects effects, ref RecipeParameters.UsedModule used) {
+        public void GetModulesInfo(RecipeParameters recipeParams, RecipeOrTechnology recipe, EntityCrafter entity, Goods? fuel, ref ModuleEffects effects, ref RecipeParameters.UsedModule used) {
             AutoFillBeacons(recipeParams, recipe, entity, fuel, ref effects, ref used);
             AutoFillModules(recipeParams, recipe, entity, fuel, ref effects, ref used);
         }

--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -132,16 +132,16 @@ match:
         }
 
         /// <summary>
-        /// Add a recipe to this table, and configure the recipe's crafter and fuel to reasonable values.
+        /// Add a recipe or technology to this table, and configure the crafter and fuel to reasonable values.
         /// </summary>
-        /// <param name="recipe">The recipe to add.</param>
+        /// <param name="recipe">The recipe or technology to add.</param>
         /// <param name="ingredientVariantComparer">If not <see langword="null"/>, the comparer to use when deciding which fluid variants to use.</param>
-        /// <param name="selectedFuel">If not <see langword="null"/>, this method will select a crafter that can use this fuel, assuming such an entity exists.
-        /// For example, if the selected fuel is coal, the recipe will be configured with a burner assembler if any are available.</param>
-        public void AddRecipe(Recipe recipe, IComparer<Goods>? ingredientVariantComparer = null, Goods? selectedFuel = null) {
+        /// <param name="selectedFuel">If not <see langword="null"/>, this method will select a crafter or lab that can use this fuel, assuming such an entity exists.
+        /// For example, if the selected fuel is coal, the recipe will be configured with a burner assembler/lab if any are available.</param>
+        public void AddRecipe(RecipeOrTechnology recipe, IComparer<Goods>? ingredientVariantComparer = null, Goods? selectedFuel = null) {
             RecipeRow recipeRow = new RecipeRow(this, recipe);
             this.RecordUndo().recipes.Add(recipeRow);
-            EntityCrafter? selectedFuelCrafter = selectedFuel?.fuelFor.OfType<EntityCrafter>().Where(e => e.recipes.OfType<Recipe>().Contains(recipe)).AutoSelect(DataUtils.FavoriteCrafter);
+            EntityCrafter? selectedFuelCrafter = selectedFuel?.fuelFor.OfType<EntityCrafter>().Where(e => e.recipes.Contains(recipe)).AutoSelect(DataUtils.FavoriteCrafter);
             recipeRow.entity = selectedFuelCrafter ?? recipe.crafters.AutoSelect(DataUtils.FavoriteCrafter);
             if (recipeRow.entity != null) {
                 recipeRow.fuel = recipeRow.entity.energy.fuels.FirstOrDefault(e => e == selectedFuel) ?? recipeRow.entity.energy.fuels.AutoSelect(DataUtils.FavoriteFuel);
@@ -371,7 +371,7 @@ match:
 
             await Ui.ExitMainThread();
             for (int i = 0; i < allRecipes.Count; i++) {
-                objective.SetCoefficient(vars[i], allRecipes[i].recipe.RecipeBaseCost());
+                objective.SetCoefficient(vars[i], (allRecipes[i].recipe as Recipe)?.RecipeBaseCost() ?? 0);
             }
 
             var result = productionTableSolver.Solve();

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -98,7 +98,7 @@ namespace Yafc.Model {
 
 
         private static readonly List<(Module module, int count, bool beacon)> buffer = [];
-        public void GetModulesInfo(RecipeParameters recipeParams, Recipe recipe, EntityCrafter entity, Goods? fuel, ref ModuleEffects effects, ref RecipeParameters.UsedModule used, ModuleFillerParameters? filler) {
+        public void GetModulesInfo(RecipeParameters recipeParams, RecipeOrTechnology recipe, EntityCrafter entity, Goods? fuel, ref ModuleEffects effects, ref RecipeParameters.UsedModule used, ModuleFillerParameters? filler) {
             int beaconedModules = 0;
             Item? nonBeacon = null;
             buffer.Clear();
@@ -173,7 +173,7 @@ namespace Yafc.Model {
     }
 
     public class RecipeRow : ModelObject<ProductionTable>, IModuleFiller, IGroupedElement<ProductionTable> {
-        public Recipe recipe { get; }
+        public RecipeOrTechnology recipe { get; }
         // Variable parameters
         public EntityCrafter? entity { get; set; }
         public Goods? fuel { get; set; }
@@ -243,7 +243,7 @@ namespace Yafc.Model {
         public float buildingCount => (float)recipesPerSecond * parameters.recipeTime;
         public bool visible { get; internal set; } = true;
 
-        public RecipeRow(ProductionTable owner, Recipe recipe) : base(owner) {
+        public RecipeRow(ProductionTable owner, RecipeOrTechnology recipe) : base(owner) {
             this.recipe = recipe ?? throw new ArgumentNullException(nameof(recipe), "Recipe does not exist");
             links = new RecipeLinks {
                 ingredients = new ProductionLink[recipe.ingredients.Length],
@@ -297,7 +297,7 @@ namespace Yafc.Model {
             return null;
         }
 
-        public void GetModulesInfo(RecipeParameters recipeParams, Recipe recipe, EntityCrafter entity, Goods? fuel, ref ModuleEffects effects, ref RecipeParameters.UsedModule used) {
+        public void GetModulesInfo(RecipeParameters recipeParams, RecipeOrTechnology recipe, EntityCrafter entity, Goods? fuel, ref ModuleEffects effects, ref RecipeParameters.UsedModule used) {
             ModuleFillerParameters? filler = null;
             var useModules = modules;
             if (useModules == null || useModules.beacon == null) {

--- a/Yafc.Model/Model/Project.cs
+++ b/Yafc.Model/Model/Project.cs
@@ -155,6 +155,7 @@ namespace Yafc.Model {
         public SortedList<FactorioObject, ProjectPerItemFlags> itemFlags { get; } = new SortedList<FactorioObject, ProjectPerItemFlags>(DataUtils.DeterministicComparer);
         public float miningProductivity { get; set; }
         public float researchSpeedBonus { get; set; }
+        public float researchProductivity { get; set; }
         public int reactorSizeX { get; set; } = 2;
         public int reactorSizeY { get; set; } = 2;
         public float PollutionCostModifier { get; set; } = 0;

--- a/Yafc.Model/Model/Project.cs
+++ b/Yafc.Model/Model/Project.cs
@@ -154,6 +154,7 @@ namespace Yafc.Model {
         public List<FactorioObject> milestones { get; } = [];
         public SortedList<FactorioObject, ProjectPerItemFlags> itemFlags { get; } = new SortedList<FactorioObject, ProjectPerItemFlags>(DataUtils.DeterministicComparer);
         public float miningProductivity { get; set; }
+        public float researchSpeedBonus { get; set; }
         public int reactorSizeX { get; set; } = 2;
         public int reactorSizeY { get; set; } = 2;
         public float PollutionCostModifier { get; set; } = 0;

--- a/Yafc.Model/Model/RecipeParameters.cs
+++ b/Yafc.Model/Model/RecipeParameters.cs
@@ -54,7 +54,7 @@ namespace Yafc.Model {
             modules = default;
         }
 
-        public void CalculateParameters(Recipe recipe, EntityCrafter? entity, Goods? fuel, HashSet<FactorioObject> variants, IModuleFiller moduleFiller) {
+        public void CalculateParameters(RecipeOrTechnology recipe, EntityCrafter? entity, Goods? fuel, HashSet<FactorioObject> variants, IModuleFiller moduleFiller) {
             warningFlags = 0;
             if (entity == null) {
                 warningFlags |= WarningFlags.EntityNotSpecified;

--- a/Yafc.Model/Model/RecipeParameters.cs
+++ b/Yafc.Model/Model/RecipeParameters.cs
@@ -142,6 +142,9 @@ namespace Yafc.Model {
                 if (isMining) {
                     productivity += Project.current.settings.miningProductivity;
                 }
+                else if (recipe is Technology) {
+                    productivity += Project.current.settings.researchProductivity;
+                }
 
                 if (entity is EntityReactor reactor && reactor.reactorNeighborBonus > 0f) {
                     productivity += reactor.reactorNeighborBonus * Project.current.settings.GetReactorBonusMultiplier();

--- a/Yafc.Parser/Data/DataParserUtils.cs
+++ b/Yafc.Parser/Data/DataParserUtils.cs
@@ -119,5 +119,6 @@ namespace Yafc.Parser {
         public const string RocketLaunch = "launch";
         public const string RocketCraft = "rocket.";
         public const string ReactorRecipe = "reactor";
+        public const string ResearchUnit = "research-unit";
     }
 }

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
@@ -29,6 +29,7 @@ namespace Yafc.Parser {
         private readonly Special heat;
         private readonly Special electricity;
         private readonly Special rocketLaunch;
+        private readonly Special researchUnit;
         private readonly EntityEnergy voidEntityEnergy;
         private readonly EntityEnergy laborEntityEnergy;
         private Entity? character;
@@ -67,6 +68,9 @@ namespace Yafc.Parser {
             rootAccessible.Add(voidEnergy);
 
             rocketLaunch = createSpecialObject(false, SpecialNames.RocketLaunch, "Rocket launch slot", "This is a slot in a rocket ready to be launched", "__base__/graphics/entity/rocket-silo/02-rocket.png", "signal-R");
+            researchUnit = createSpecialObject(false, SpecialNames.ResearchUnit, "Research", "This represents one unit of a research task.", "__base__/graphics/icons/compilatron.png", "signal-L");
+            researchUnit.isResearch = true;
+            Analysis.ExcludeFromAnalysis<CostAnalysis>(researchUnit);
 
             generatorProduction = CreateSpecialRecipe(electricity, SpecialNames.GeneratorRecipe, "generating");
             generatorProduction.products = new Product(electricity, 1f).SingleElementArray();
@@ -117,6 +121,7 @@ namespace Yafc.Parser {
 
             Database.allSciencePacks = sciencePacks.ToArray();
             Database.voidEnergy = voidEnergy;
+            Database.researchUnit = researchUnit;
             Database.electricity = electricity;
             Database.electricityGeneration = generatorProduction;
             Database.heat = heat;

--- a/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
@@ -42,6 +42,7 @@ namespace Yafc.Parser {
         private void DeserializeTechnology(LuaTable table, ErrorCollector errorCollector) {
             var technology = DeserializeWithDifficulty<Technology>(table, "technology", LoadTechnologyData, errorCollector);
             recipeCategories.Add(SpecialNames.Labs, technology);
+            technology.modules = [.. allModules];
             technology.products = [];
         }
 

--- a/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
@@ -43,7 +43,7 @@ namespace Yafc.Parser {
             var technology = DeserializeWithDifficulty<Technology>(table, "technology", LoadTechnologyData, errorCollector);
             recipeCategories.Add(SpecialNames.Labs, technology);
             technology.modules = [.. allModules];
-            technology.products = [];
+            technology.products = [new(researchUnit, 1)];
         }
 
         private void UpdateRecipeCatalysts() {

--- a/Yafc/Data/Tips.txt
+++ b/Yafc/Data/Tips.txt
@@ -1,6 +1,7 @@
 Want to see your tips here? Message me on Github!
 Tip: You can see more precision and values per second/minute/hour if you hover over numbers with CTRL
 Tip: You can calculate electricity, just add "Electricity" as a desired product
+Tip: You can calculate research by adding "Research" as a desired product, by ctrl-clicking an "Add raw recipe" button, or by adding consumption for a science pack
 Tip: If YAFC thinks that something is inaccessible while it isn't, you can mark it as accessible in the "Dependency explorer"
 Tip: You can drag-reorder recipes, pages, milestones and some other lists!
 Tip: You can open recipe explorer using Ctrl+N or with middle mouse click on any game object

--- a/Yafc/Widgets/ImmediateWidgets.cs
+++ b/Yafc/Widgets/ImmediateWidgets.cs
@@ -86,11 +86,13 @@ namespace Yafc {
             }
             else if (evt == ButtonEvent.Click) {
                 if (gui.actionParameter == SDL.SDL_BUTTON_MIDDLE && obj != null) {
-                    if (obj is Goods goods && obj.IsAccessible()) {
-                        NeverEnoughItemsPanel.Show(goods);
-                    }
-                    else {
-                        DependencyExplorer.Show(obj);
+                    if (obj.showInExplorers) {
+                        if (obj is Goods goods && obj.IsAccessible()) {
+                            NeverEnoughItemsPanel.Show(goods);
+                        }
+                        else {
+                            DependencyExplorer.Show(obj);
+                        }
                     }
                 }
                 else if (gui.actionParameter == SDL.SDL_BUTTON_LEFT) {

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -273,8 +273,10 @@ namespace Yafc {
 
         private void BuildGoods(Goods goods, ImGui gui) {
             BuildCommon(goods, gui);
-            using (gui.EnterGroup(contentPadding)) {
-                gui.BuildText("Middle mouse button to open Never Enough Items Explorer for this " + goods.type, wrap: true);
+            if (goods.showInExplorers) {
+                using (gui.EnterGroup(contentPadding)) {
+                    gui.BuildText("Middle mouse button to open Never Enough Items Explorer for this " + goods.type, wrap: true);
+                }
             }
 
             if (goods.production.Length > 0) {

--- a/Yafc/Windows/DependencyExplorer.cs
+++ b/Yafc/Windows/DependencyExplorer.cs
@@ -109,7 +109,7 @@ namespace Yafc {
             using (gui.EnterRow()) {
                 gui.BuildText("Currently inspecting:", Font.subheader);
                 if (gui.BuildFactorioObjectButtonWithText(current) == Click.Left) {
-                    SelectSingleObjectPanel.Select(Database.objects.all, "Select something", Change);
+                    SelectSingleObjectPanel.Select(Database.objects.explorable, "Select something", Change);
                 }
 
                 gui.BuildText("(Click to change)", color: SchemeColor.BackgroundTextFaint);

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -328,7 +328,7 @@ namespace Yafc {
             }
         }
 
-        private void ShowNeie() => SelectSingleObjectPanel.Select(Database.goods.all, "Open NEIE", NeverEnoughItemsPanel.Show);
+        private void ShowNeie() => SelectSingleObjectPanel.Select(Database.goods.explorable, "Open NEIE", NeverEnoughItemsPanel.Show);
 
         private void SetSearch(SearchQuery searchQuery) {
             pageSearch = searchQuery;
@@ -407,7 +407,7 @@ namespace Yafc {
             }
 
             if (gui.BuildContextMenuButton("Dependency Explorer") && gui.CloseDropdown()) {
-                SelectSingleObjectPanel.Select(Database.objects.all, "Open Dependency Explorer", DependencyExplorer.Show);
+                SelectSingleObjectPanel.Select(Database.objects.explorable, "Open Dependency Explorer", DependencyExplorer.Show);
             }
 
             BuildSubHeader(gui, "Extra");

--- a/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
@@ -188,8 +188,15 @@ namespace Yafc {
             using (gui.EnterRow()) {
                 gui.BuildText("Mining productivity bonus (project-wide setting): ");
                 if (gui.BuildTextInput(DataUtils.FormatAmount(Project.current.settings.miningProductivity, UnitOfMeasure.Percent), out string newText, null, Icon.None, true, new Padding(0.5f, 0f)) &&
-                    DataUtils.TryParseAmount(newText, out float newAmount, UnitOfMeasure.Percent)) {
+                    DataUtils.TryParseAmount(newText, out float newAmount, UnitOfMeasure.Percent) && newAmount >= 0) {
                     Project.current.settings.RecordUndo().miningProductivity = newAmount;
+                }
+            }
+            using (gui.EnterRow()) {
+                gui.BuildText("Research speed bonus (project-wide setting): ");
+                if (gui.BuildTextInput(DataUtils.FormatAmount(Project.current.settings.researchSpeedBonus, UnitOfMeasure.Percent), out string newText, null, Icon.None, true, new Padding(0.5f, 0f)) &&
+                    DataUtils.TryParseAmount(newText, out float newAmount, UnitOfMeasure.Percent) && newAmount >= 0) {
+                    Project.current.settings.RecordUndo().researchSpeedBonus = newAmount;
                 }
             }
 

--- a/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
@@ -199,6 +199,13 @@ namespace Yafc {
                     Project.current.settings.RecordUndo().researchSpeedBonus = newAmount;
                 }
             }
+            using (gui.EnterRow()) {
+                gui.BuildText("Research productivity bonus (project-wide setting): ");
+                if (gui.BuildTextInput(DataUtils.FormatAmount(Project.current.settings.researchProductivity, UnitOfMeasure.Percent), out string newText, null, Icon.None, true, new Padding(0.5f, 0f)) &&
+                    DataUtils.TryParseAmount(newText, out float newAmount, UnitOfMeasure.Percent) && newAmount >= 0) {
+                    Project.current.settings.RecordUndo().researchProductivity = newAmount;
+                }
+            }
 
             if (gui.BuildButton("Done")) {
                 Close();

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -5,6 +5,7 @@ using System.Numerics;
 using SDL2;
 using Yafc.Blueprints;
 using Yafc.Model;
+using Yafc.Parser;
 using Yafc.UI;
 
 namespace Yafc {
@@ -797,7 +798,12 @@ goodsHaveNoProduction:;
                 }
 
                 int numberOfShownRecipes = 0;
-                if (type != ProductDropdownType.Product && allProduction.Length > 0) {
+                if (goods.name == SpecialNames.ResearchUnit) {
+                    if (gui.BuildButton("Add technology") && gui.CloseDropdown()) {
+                        SelectMultiObjectPanel.Select(Database.technologies.all, "Select technology", r => context.AddRecipe(r, DefaultVariantOrdering), checkMark: r => context.recipes.Any(rr => rr.recipe == r));
+                    }
+                }
+                else if (type != ProductDropdownType.Product && allProduction.Length > 0) {
                     gui.BuildInlineObjectListAndButton(allProduction, comparer, addRecipe, "Add production recipe", 6, true, recipeExists);
                     numberOfShownRecipes += allProduction.Length;
                     if (link == null) {

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -703,7 +703,7 @@ goodsHaveNoProduction:;
             }
 
             Goods? selectedFuel = null;
-            async void addRecipe(Recipe rec) {
+            async void addRecipe(RecipeOrTechnology rec) {
                 if (variants == null) {
                     CreateLink(context, goods);
                 }
@@ -827,6 +827,12 @@ goodsHaveNoProduction:;
                 if (type != ProductDropdownType.Fuel && type != ProductDropdownType.Ingredient && fuelUseList.Length > 0) {
                     gui.BuildInlineObjectListAndButton(fuelUseList, DataUtils.AlreadySortedRecipe, (x) => { selectedFuel = goods; addRecipe(x); }, "Add fuel usage", type == ProductDropdownType.Product ? 6 : 3, true, recipeExists);
                     numberOfShownRecipes += fuelUseList.Length;
+                }
+
+                if (type != ProductDropdownType.Fuel && type != ProductDropdownType.Ingredient && Database.allSciencePacks.Contains(goods)
+                    && gui.BuildButton("Add consumption technology") && gui.CloseDropdown()) {
+                    // Select from the technologies that consume this science pack.
+                    SelectMultiObjectPanel.Select(Database.technologies.all.Where(t => t.ingredients.Select(i => i.goods).Contains(goods)), "Add technology", addRecipe, checkMark: recipeExists);
                 }
 
                 if (type == ProductDropdownType.Product && allProduction.Length > 0) {

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -625,7 +625,7 @@ goodsHaveNoProduction:;
 
                 gui.BuildText("Auto modules", Font.subheader);
                 ModuleFillerParametersScreen.BuildSimple(gui, model.modules);
-                if (gui.BuildButton("More settings") && gui.CloseDropdown()) {
+                if (gui.BuildButton("Module settings") && gui.CloseDropdown()) {
                     ModuleFillerParametersScreen.Show(model.modules);
                 }
             }

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -109,8 +109,8 @@ namespace Yafc {
                                 view.AddDesiredProductAtLevel(recipe.subgroup);
                             }
 
-                            if (recipe.subgroup != null && imgui.BuildButton("Add raw recipe") && imgui.CloseDropdown()) {
-                                SelectMultiObjectPanel.Select(Database.recipes.all, "Select raw recipe", r => recipe.subgroup.AddRecipe(r, DefaultVariantOrdering), checkMark: r => recipe.subgroup.recipes.Any(rr => rr.recipe == r));
+                            if (recipe.subgroup != null) {
+                                BuildRecipeButton(imgui, recipe.subgroup);
                             }
 
                             if (recipe.subgroup != null && imgui.BuildButton("Unpack nested table").WithTooltip(imgui, recipe.subgroup.expanded ? "Shortcut: right-click" : "Shortcut: Expand, then right-click") && imgui.CloseDropdown()) {
@@ -179,9 +179,7 @@ namespace Yafc {
             }
 
             public override void BuildMenu(ImGui gui) {
-                if (gui.BuildButton("Add recipe") && gui.CloseDropdown()) {
-                    SelectMultiObjectPanel.Select(Database.recipes.all, "Select raw recipe", r => view.model.AddRecipe(r, DefaultVariantOrdering), checkMark: r => view.model.recipes.Any(rr => rr.recipe == r));
-                }
+                BuildRecipeButton(gui, view.model);
 
                 gui.BuildText("Export inputs and outputs to blueprint with constant combinators:", wrap: true);
                 using (gui.EnterRow()) {
@@ -226,6 +224,21 @@ namespace Yafc {
 
                         view.model.AddRecipe(recipe, DefaultVariantOrdering);
 goodsHaveNoProduction:;
+                    }
+                }
+            }
+
+            /// <summary>
+            /// Build the "Add raw recipe" button and handle its clicks.
+            /// </summary>
+            /// <param name="table">The table that will receive the new recipes or technologies, if any are selected</param>
+            private static void BuildRecipeButton(ImGui gui, ProductionTable table) {
+                if (gui.BuildButton("Add raw recipe").WithTooltip(gui, "Ctrl-click to add a technology instead") && gui.CloseDropdown()) {
+                    if (MainScreen.Instance.InputSystem.control) {
+                        SelectMultiObjectPanel.Select(Database.technologies.all, "Select technology", r => table.AddRecipe(r, DefaultVariantOrdering), checkMark: r => table.recipes.Any(rr => rr.recipe == r));
+                    }
+                    else {
+                        SelectMultiObjectPanel.Select(Database.recipes.all, "Select raw recipe", r => table.AddRecipe(r, DefaultVariantOrdering), checkMark: r => table.recipes.Any(rr => rr.recipe == r));
                     }
                 }
             }
@@ -683,8 +696,8 @@ goodsHaveNoProduction:;
             }
 
             var comparer = DataUtils.GetRecipeComparerFor(goods);
-            HashSet<Recipe> allRecipes = new HashSet<Recipe>(context.recipes.Select(x => x.recipe));
-            bool recipeExists(Recipe rec) {
+            HashSet<RecipeOrTechnology> allRecipes = new HashSet<RecipeOrTechnology>(context.recipes.Select(x => x.recipe));
+            bool recipeExists(RecipeOrTechnology rec) {
                 return allRecipes.Contains(rec);
             }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -16,8 +16,8 @@ Date: soon
     Features:
         - Add the option to specify how many beacons, with what modules, should be applied on a per-building-type
           basis, in addition to the global and per-recipe-row settings.
-        - Allow adding technologies to the tables as science-pack-voiding recipes, by ctrl-clicking on the
-          "Add raw recipe" buttons. Add a setting for research speed bonus, to correctly calculate lab speed/counts.
+        - Allow adding technologies to the tables to produce research units.
+        - Add settings for research speed and productivity bonuses, to correctly calculate lab speed and counts.
     Bugfixes:
         - Fix PageSearch scrollbar not working.
         - Refresh the milestones display after adding or removing milestones.

--- a/changelog.txt
+++ b/changelog.txt
@@ -16,6 +16,8 @@ Date: soon
     Features:
         - Add the option to specify how many beacons, with what modules, should be applied on a per-building-type
           basis, in addition to the global and per-recipe-row settings.
+        - Allow adding technologies to the tables as science-pack-voiding recipes, by ctrl-clicking on the
+          "Add raw recipe" buttons. Add a setting for research speed bonus, to correctly calculate lab speed/counts.
     Bugfixes:
         - Fix PageSearch scrollbar not working.
         - Refresh the milestones display after adding or removing milestones.


### PR DESCRIPTION
This closes #53 and allows you to add technologies to the production table, which produce a new research unit special item.

You can add raw technologies by ctrl-clicking one of the two "Add raw recipe" buttons, or add the research item just like any other product.

For example, you can ask questions like "How much research can I do with lots of prod modules and four (yellow) belts of iron?"
![image](https://github.com/have-fun-was-taken/yafc-ce/assets/21223975/8be23cea-d079-4779-9424-cfce65d41a42)
or you can do any sort of question involving fixed numbers of labs or a particular number of research units per unit time.

There are also new settings, analogous to the mining productivity setting, for research speed and research productivity.