### PR TITLE
Prevent Enter from closing the project page settings dialog when the name is empty.

### DIFF
--- a/Yafc/Windows/ProjectPageSettingsPanel.cs
+++ b/Yafc/Windows/ProjectPageSettingsPanel.cs
@@ -79,6 +79,10 @@ namespace Yafc {
         }
 
         protected override void ReturnPressed() {
+            if (string.IsNullOrEmpty(name)) {
+                // Prevent closing with an empty name
+                return;
+            }
             if (editingPage is null) {
                 callback?.Invoke(name, icon);
             }


### PR DESCRIPTION
Fix #188