### PR TITLE
Handle research trigger 'craft-item'

### DIFF
--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -83,6 +83,8 @@ public enum RecipeFlags {
     UsesMiningProductivity = 1 << 0,
     UsesFluidTemperature = 1 << 2,
     ScaleProductionWithPower = 1 << 3,
+    /// <summary>Set when the technology has a research trigger to craft an item</summary>
+    HasResearchTriggerCraft = 1 << 4,
 }
 
 public abstract class RecipeOrTechnology : FactorioObject {

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -500,7 +500,15 @@ public class ObjectTooltip : Tooltip {
     }
 
     private void BuildTechnology(Technology technology, ImGui gui) {
-        BuildRecipe(technology, gui);
+        bool isResearchTriggerCraft = (technology.flags & RecipeFlags.HasResearchTriggerCraft) == RecipeFlags.HasResearchTriggerCraft;
+        if (isResearchTriggerCraft) {
+            BuildCommon(technology, gui);
+
+        }
+        else {
+            BuildRecipe(technology, gui);
+        }
+
         if (technology.hidden && !technology.enabled) {
             using (gui.EnterGroup(contentPadding)) {
                 gui.BuildText("This technology is hidden from the list and cannot be researched.", TextBlockDisplayStyle.WrappedText);
@@ -511,6 +519,15 @@ public class ObjectTooltip : Tooltip {
             BuildSubHeader(gui, "Prerequisites");
             using (gui.EnterGroup(contentPadding)) {
                 BuildIconRow(gui, technology.prerequisites, 1);
+            }
+        }
+
+        if (isResearchTriggerCraft) {
+            BuildSubHeader(gui, "Item crafting required");
+            using (gui.EnterGroup(contentPadding)) {
+                using var grid = gui.EnterInlineGrid(3f);
+                grid.Next();
+                _ = gui.BuildFactorioObjectWithAmount(technology.ingredients[0].goods, technology.ingredients[0].amount, ButtonDisplayStyle.ProductionTableUnscaled);
             }
         }
 


### PR DESCRIPTION
While checking for the Space Age changes of #320, I noticed 'new' errors when loading a project. Which was triggered by the (lack of) support of the new [research triggers](https://lua-api.factorio.com/latest/concepts/ResearchTrigger.html).

Adding the `craft-item` type was fairly easy (I was fiddling a bit and it worked):
_\<removed outdated screenshot, see comments for newer one\>_

So I cleaned the code a little and made this PR.

Note that supporting `mine-entity` was also easy, but for some reason it makes most of the items inaccessible... So I did not include it in this PR. We need to take a better look.
The other types, I did not try as their implementation was not directly apparent to me (and `craft-fluid` is not in use, so I could not try/test)
