### PR TITLE
Hide placeholder before display entered text in TextInput

### DIFF
--- a/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
+++ b/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
@@ -107,7 +107,8 @@ internal partial class ImGuiTextInputHelper(ImGui gui) : IKeyboardFocus {
                 SchemeColor textColor = (SchemeColor)displayStyle.ColorGroup + 2;
                 string? textToBuild;
 
-                if (focused && !string.IsNullOrEmpty(text)) {
+                // Prefer internal edit buffer when focused so placeholder is hidden immediately
+                if (focused && !string.IsNullOrEmpty(this.text)) {
                     textToBuild = this.text;
                 }
                 else if (string.IsNullOrEmpty(text)) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -40,6 +40,7 @@ Date: October 24th 2025
         - Fix load errors for Pacifist (#535), PlanetsLib, and some planet mods.
         - Fix loading mods where modules spoil into other modules.
         - Modules were not exported correctly in labs or mining drills.
+        - Hide TextInput placeholder before written text is displayed.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.15.0
 Date: September 1st 2025


### PR DESCRIPTION
This pull request makes a minor improvement to the `BuildTextInput` method in `ImGuiTextInputHelper.cs`. The change ensures that when the text input is focused, the internal edit buffer (`this.text`) is preferred over the external `text` parameter, so the placeholder is hidden immediately. This enhances the user experience by making the placeholder disappear as soon as the input gains focus.