### PR TITLE
fix(#556): Remove incorrect speed bonus for quality mining drills.

### DIFF
--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -706,7 +706,8 @@ public class EntityCrafter : EntityWithModules {
         get => _craftingSpeed * (1 + (factorioType == "lab" ? Project.current.settings.researchSpeedBonus : 0));
         internal set => _craftingSpeed = value;
     }
-    public virtual float CraftingSpeed(Quality quality) => factorioType is "agricultural-tower" or "electric-energy-interface" ? baseCraftingSpeed : quality.ApplyStandardBonus(baseCraftingSpeed);
+    public virtual float CraftingSpeed(Quality quality) => factorioType is "agricultural-tower" or "electric-energy-interface" or "mining-drill"
+        ? baseCraftingSpeed : quality.ApplyStandardBonus(baseCraftingSpeed);
     public EffectReceiver effectReceiver { get; internal set; } = null!;
 
     public override int BlueprintModuleInventory => factorioType switch {

--- a/changelog.txt
+++ b/changelog.txt
@@ -28,6 +28,7 @@ Date:
         - Support craft-fluid and scripted research triggers.
         - Consider quality restrictions when analyzing craft-item or build-item technology triggers.
         - Fix loading recent versions of K2.
+        - Remove incorrect speed bonus for quality mining drills.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.16.0
 Date: October 24th 2025


### PR DESCRIPTION
This fixes #556, but it doesn't consider what sort of changes might be more flexible for implementing #522.

Mining drills and pumpjacks are both in `data.raw["mining-drill"]`.