### PR TITLE
feat: Retain scroll when switching tabs

### DIFF
--- a/Yafc.Model.Tests/Serialization/SerializationTreeChangeDetection.cs
+++ b/Yafc.Model.Tests/Serialization/SerializationTreeChangeDetection.cs
@@ -125,6 +125,7 @@ public class SerializationTreeChangeDetection {
             [nameof(ProjectPage.icon)] = typeof(FactorioObject),
             [nameof(ProjectPage.name)] = typeof(string),
             [nameof(ProjectPage.guid)] = typeof(Guid),
+            [nameof(ProjectPage.scroll)] = typeof(float?),
             [nameof(ProjectPage.contentType)] = typeof(Type),
             [nameof(ProjectPage.content)] = typeof(ProjectPageContents),
         },

--- a/Yafc.Model/Model/ProjectPage.cs
+++ b/Yafc.Model/Model/ProjectPage.cs
@@ -13,6 +13,7 @@ public class ProjectPage : ModelObject<Project> {
     public ProjectPageContents content { get; }
     public bool active { get; private set; }
     public bool visible { get; internal set; }
+    public float? scroll { get; set; }
     [SkipSerialization] public string? modelError { get; set; }
     public bool deleted { get; private set; }
     [SkipSerialization]
@@ -40,11 +41,13 @@ public class ProjectPage : ModelObject<Project> {
 
     public void GenerateNewGuid() => guid = Guid.NewGuid();
 
-    public void SetActive(bool active) {
-        this.active = active;
-        if (active) {
-            _ = CheckSolve();
-        }
+    public void SetActive() {
+        this.active = true;
+        _ = CheckSolve();
+    }
+
+    public void SetInactive() {
+        this.active = false;
     }
 
     public void SetToRecalculate() {
@@ -63,6 +66,13 @@ public class ProjectPage : ModelObject<Project> {
             _ = CheckSolve();
         }
         contentChanged?.Invoke(visualOnly);
+    }
+
+    public Task SolvePage() {
+        if (IsSolutionStale()) {
+            return RunSolveJob();
+        }
+        return Task.CompletedTask;
     }
 
     private Task CheckSolve() {

--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@ Version:
 Date:
     Features:
         - Support tables without a header recipe.
+        - Retain scroll when switching tabs.
     Fixes:
         - Support craft-fluid and scripted research triggers.
         - Consider quality restrictions when analyzing craft-item or build-item technology triggers.


### PR DESCRIPTION
 Retain scroll when switching tabs. Fixes #546.

~~Scroll is not serialized so not kept on project reload, but is kept during a session.~~ Update: It now is serialized and kept on save. Scrolling itself doesn't change the project enough however to allow a save, so you do need to make an actual modification to the tables between saves.

I had to add a small hack to redraw the page before we set the scroll, if this is not done, you can only scroll to the length of the previous active page.

Tested this several tabs, some longer, some shorter, tested opening a second page, testing switching away to another page, changing scroll, and go back.