### PR TITLE
fix(#559): Fit the temperature overlay to the underlying icon.

### DIFF
--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -113,10 +113,17 @@ internal partial class FactorioDataDeserializer {
 
     private static void AddTemperatureToFluidIcon(Fluid fluid) {
         string iconStr = fluid.temperature + "d";
+
+        // Calculate the size/position of the overlay digits to correspond to the size of the first icon layer.
+        int size = fluid.iconSpec?.FirstOrDefault()?.size ?? 64;
+        int shift = 7 * size / 32;
+        int xoffset = 12 * size / 32;
+        int yoffset = size / -2;
+
         fluid.iconSpec =
         [
             .. fluid.iconSpec ?? [],
-            .. iconStr.Take(4).Select((x, n) => new FactorioIconPart("__.__/" + x) { size = 64, y = -32, x = (n * 14) - 24, scale = 0.28f }),
+            .. iconStr.Take(4).Select((x, n) => new FactorioIconPart("__.__/" + x) { size = size, y = yoffset, x = (n * shift) - xoffset, scale = 0.28f }),
         ];
     }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -31,6 +31,7 @@ Date:
         - Fix loading recent versions of K2.
         - Remove incorrect speed bonus for quality mining drills.
         - Show beacons added by the per-page settings on each row they affect.
+        - Fix the temperature overlay for fluids with non-64px icons.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.16.0
 Date: October 24th 2025


### PR DESCRIPTION
This fixes the fluid temperature overlays for Py fluids. None of my test projects contain fluid icons other than 32 or 64 px, but this should react correctly for other sizes too.

![fixed](https://github.com/user-attachments/assets/f99c63fe-88f2-412c-aa82-7ae6aff4a9e1)
