### PR TITLE
Cost breakdown UI

### DIFF
--- a/Yafc.Model/Analysis/CostAnalysis.cs
+++ b/Yafc.Model/Analysis/CostAnalysis.cs
@@ -10,6 +10,19 @@ using Yafc.I18n;
 
 namespace Yafc.Model;
 
+/// <summary>
+/// Breakdown of logistics cost components for a recipe.
+/// </summary>
+public record RecipeLogisticsBreakdown(
+    float TimeSizeCost,
+    float PowerCost,
+    float ItemTransportCost,
+    float FluidTransportCost,
+    float PollutionCost,
+    float MiningPenalty,
+    float TotalCost
+);
+
 public class CostAnalysis(bool onlyCurrentMilestones) : Analysis {
     private readonly ILogger logger = Logging.GetLogger<CostAnalysis>();
 
@@ -41,6 +54,176 @@ public class CostAnalysis(bool onlyCurrentMilestones) : Analysis {
 
     private bool ShouldInclude(FactorioObject obj) => onlyCurrentMilestones ? obj.IsAutomatableWithCurrentMilestones() : obj.IsAutomatable();
 
+    /// <summary>
+    /// Finds the inventory slots per tile of the most space-efficient accessible container.
+    /// </summary>
+    private float GetBestContainerSlotsPerTile() {
+        float bestSlotsPerTile = 1f;
+        foreach (var container in Database.allContainers) {
+            float area = container.width * container.height;
+            if (ShouldInclude(container) && area > 0) {
+                float slotsPerTile = container.inventorySize / area;
+                if (slotsPerTile > bestSlotsPerTile) {
+                    bestSlotsPerTile = slotsPerTile;
+                }
+            }
+        }
+
+        return bestSlotsPerTile;
+    }
+
+    /// <summary>
+    /// The most favorable statistics across a recipe's crafters, and the fuel to use if they all agree on a single one.
+    /// </summary>
+    private readonly record struct CrafterStats(float MinEmissions, int MinSize, float MinPower, Goods? SingleUsedFuel, float SingleUsedFuelAmount);
+
+    private CrafterStats FindCrafterStats(Recipe recipe) {
+        // TODO incorporate fuel selection. Now just select fuel if it only uses 1 fuel
+        Goods? singleUsedFuel = null;
+        float singleUsedFuelAmount = 0f;
+        float minEmissions = 100f;
+        int minSize = 15;
+        float minPower = 1000f;
+
+        foreach (var crafter in recipe.crafters) {
+            foreach ((_, float e) in crafter.energy.emissions) {
+                minEmissions = MathF.Min(e, minEmissions);
+            }
+
+            if (crafter.energy.type == EntityEnergyType.Heat) {
+                break;
+            }
+
+            if (crafter.size < minSize) {
+                minSize = crafter.size;
+            }
+
+            float power = crafter.energy.type == EntityEnergyType.Void ? 0f : recipe.time * crafter.basePower / (crafter.baseCraftingSpeed * crafter.energy.effectivity);
+
+            if (power < minPower) {
+                minPower = power;
+            }
+
+            foreach (var fuel in crafter.energy.fuels) {
+                if (!ShouldInclude(fuel)) {
+                    continue;
+                }
+
+                if (fuel.fuelValue <= 0f) {
+                    singleUsedFuel = null;
+                    break;
+                }
+
+                float amount = power / fuel.fuelValue;
+
+                if (singleUsedFuel == null) {
+                    singleUsedFuel = fuel;
+                    singleUsedFuelAmount = amount;
+                }
+                else if (singleUsedFuel == fuel) {
+                    singleUsedFuelAmount = MathF.Min(singleUsedFuelAmount, amount);
+                }
+                else {
+                    singleUsedFuel = null;
+                    break;
+                }
+            }
+
+            if (singleUsedFuel == null) {
+                break;
+            }
+        }
+
+        return new CrafterStats(minEmissions, minSize, minPower, singleUsedFuel, singleUsedFuelAmount);
+    }
+
+    /// <summary>
+    /// Computes the logistics cost breakdown for a recipe.
+    /// </summary>
+    public RecipeLogisticsBreakdown ComputeLogisticsBreakdown(Project project, Recipe recipe)
+        => ComputeLogisticsBreakdown(project, recipe, FindCrafterStats(recipe), GetBestContainerSlotsPerTile());
+
+    private static RecipeLogisticsBreakdown ComputeLogisticsBreakdown(Project project, Recipe recipe, CrafterStats crafterStats, float bestContainerSlotsPerTile) {
+        float minEmissions = crafterStats.MinEmissions;
+        float minPower = crafterStats.MinPower;
+
+        if (minPower < 0f) {
+            minPower = 0f;
+        }
+
+        int size = Math.Max(crafterStats.MinSize, (recipe.ingredients.Length + recipe.products.Length) / 2);
+        float sizeUsage = CostPerSecond * recipe.time * size;
+        float timeSizeCost = sizeUsage * (1f + (CostPerIngredientPerSize * recipe.ingredients.Length) + (CostPerProductPerSize * recipe.products.Length));
+        float powerCost = CostPerMj * minPower;
+
+        // Special handling for spoilage recipes: cost depends on container efficiency and stack size
+        // Spoilage happens in storage containers where many stacks spoil in parallel
+        if (recipe is Mechanics && recipe.name.StartsWith("spoil.") && recipe.ingredients.Length == 1 && recipe.ingredients[0].goods is Item spoilingItem) {
+            int stackSize = spoilingItem.stackSize;
+            // Cost is based on storage space needed: time / (stackSize * slotsPerTile)
+            // This reflects that larger stacks and better containers reduce infrastructure cost
+            timeSizeCost = CostPerSecond * recipe.time / (stackSize * bestContainerSlotsPerTile);
+            powerCost = 0f;
+        }
+
+        float itemTransportCost = 0f;
+        float fluidTransportCost = 0f;
+
+        foreach (var product in recipe.products) {
+            if (product.goods is Item) {
+                itemTransportCost += product.amount * CostPerItem;
+            }
+            else if (product.goods is Fluid) {
+                fluidTransportCost += product.amount * CostPerFluid;
+            }
+        }
+
+        foreach (var ingredient in recipe.ingredients) {
+            if (ingredient.goods is Item) {
+                itemTransportCost += ingredient.amount * CostPerItem;
+            }
+            else if (ingredient.goods is Fluid) {
+                fluidTransportCost += ingredient.amount * CostPerFluid;
+            }
+        }
+
+        float miningPenalty = 1f;
+
+        if (recipe.sourceEntity != null && recipe.sourceEntity.mapGenerated) {
+            float totalMining = 0f;
+
+            foreach (var product in recipe.products) {
+                totalMining += product.amount;
+            }
+
+            miningPenalty = MiningPenalty;
+            float totalDensity = recipe.sourceEntity.mapGenDensity / totalMining;
+
+            if (totalDensity < MiningMaxDensityForPenalty) {
+                float extraPenalty = MathF.Log(MiningMaxDensityForPenalty / totalDensity);
+                miningPenalty += Math.Min(extraPenalty, MiningMaxExtraPenaltyForRarity);
+            }
+        }
+
+        float pollutionCost = 0f;
+
+        if (minEmissions >= 0f) {
+            pollutionCost = minEmissions * CostPerPollution * recipe.time * project.settings.PollutionCostModifier;
+        }
+
+        float totalCost = ((timeSizeCost + powerCost + itemTransportCost + fluidTransportCost) * miningPenalty) + pollutionCost;
+
+        return new RecipeLogisticsBreakdown(
+            TimeSizeCost: timeSizeCost,
+            PowerCost: powerCost,
+            ItemTransportCost: itemTransportCost,
+            FluidTransportCost: fluidTransportCost,
+            PollutionCost: pollutionCost,
+            MiningPenalty: miningPenalty,
+            TotalCost: totalCost
+        );
+    }
+
     public override void Compute(Project project, ErrorCollector warnings) {
         var workspaceSolver = DataUtils.CreateSolver();
         var objective = workspaceSolver.Objective();
@@ -48,16 +231,7 @@ public class CostAnalysis(bool onlyCurrentMilestones) : Analysis {
         Stopwatch time = Stopwatch.StartNew();
 
         // Find the best accessible container for spoilage cost calculation
-        float bestContainerSlotsPerTile = 1f;
-        foreach (var container in Database.allContainers) {
-            float area = container.width * container.height;
-            if (ShouldInclude(container) && area > 0) {
-                float slotsPerTile = container.inventorySize / area;
-                if (slotsPerTile > bestContainerSlotsPerTile) {
-                    bestContainerSlotsPerTile = slotsPerTile;
-                }
-            }
-        }
+        float bestContainerSlotsPerTile = GetBestContainerSlotsPerTile();
 
         var variables = Database.goods.CreateMapping<Variable>();
         var constraints = Database.recipes.CreateMapping<Constraint>();
@@ -130,135 +304,31 @@ public class CostAnalysis(bool onlyCurrentMilestones) : Analysis {
                 continue;
             }
 
-            // TODO incorporate fuel selection. Now just select fuel if it only uses 1 fuel
-            Goods? singleUsedFuel = null;
-            float singleUsedFuelAmount = 0f;
-            float minEmissions = 100f;
-            int minSize = 15;
-            float minPower = 1000f;
-
-            foreach (var crafter in recipe.crafters) {
-                foreach ((_, float e) in crafter.energy.emissions) {
-                    minEmissions = MathF.Min(e, minEmissions);
-                }
-
-                if (crafter.energy.type == EntityEnergyType.Heat) {
-                    break;
-                }
-
-                if (crafter.size < minSize) {
-                    minSize = crafter.size;
-                }
-
-                float power = crafter.energy.type == EntityEnergyType.Void ? 0f : recipe.time * crafter.basePower / (crafter.baseCraftingSpeed * crafter.energy.effectivity);
-
-                if (power < minPower) {
-                    minPower = power;
-                }
-
-                foreach (var fuel in crafter.energy.fuels) {
-                    if (!ShouldInclude(fuel)) {
-                        continue;
-                    }
-
-                    if (fuel.fuelValue <= 0f) {
-                        singleUsedFuel = null;
-                        break;
-                    }
-
-                    float amount = power / fuel.fuelValue;
-
-                    if (singleUsedFuel == null) {
-                        singleUsedFuel = fuel;
-                        singleUsedFuelAmount = amount;
-                    }
-                    else if (singleUsedFuel == fuel) {
-                        singleUsedFuelAmount = MathF.Min(singleUsedFuelAmount, amount);
-                    }
-                    else {
-                        singleUsedFuel = null;
-                        break;
-                    }
-                }
-                if (singleUsedFuel == null) {
-                    break;
-                }
-            }
-
-            if (minPower < 0f) {
-                minPower = 0f;
-            }
-
-            int size = Math.Max(minSize, (recipe.ingredients.Length + recipe.products.Length) / 2);
-            float sizeUsage = CostPerSecond * recipe.time * size;
-            float logisticsCost = (sizeUsage * (1f + (CostPerIngredientPerSize * recipe.ingredients.Length) + (CostPerProductPerSize * recipe.products.Length))) + (CostPerMj * minPower);
-
-            // Special handling for spoilage recipes: cost depends on container efficiency and stack size
-            // Spoilage happens in storage containers where many stacks spoil in parallel
-            if (recipe is Mechanics && recipe.name.StartsWith("spoil.") && recipe.ingredients.Length == 1 && recipe.ingredients[0].goods is Item spoilingItem) {
-                int stackSize = spoilingItem.stackSize;
-                // Cost is based on storage space needed: time / (stackSize * slotsPerTile)
-                // This reflects that larger stacks and better containers reduce infrastructure cost
-                logisticsCost = CostPerSecond * recipe.time / (stackSize * bestContainerSlotsPerTile);
-            }
+            var crafterStats = FindCrafterStats(recipe);
+            var singleUsedFuel = crafterStats.SingleUsedFuel;
 
             if (singleUsedFuel?.isPower == true) {
                 singleUsedFuel = null;
             }
+
+            float logisticsCost = ComputeLogisticsBreakdown(project, recipe, crafterStats, bestContainerSlotsPerTile).TotalCost;
 
             var constraint = workspaceSolver.MakeConstraint(double.NegativeInfinity, 0, recipe.name);
             constraints[recipe] = constraint;
 
             foreach (var product in recipe.products) {
                 var var = variables[product.goods];
-                float amount = product.amount;
-                constraint.SetCoefficientCheck(var, amount, ref lastVariable[product.goods]);
-
-                if (product.goods is Item) {
-                    logisticsCost += amount * CostPerItem;
-                }
-                else if (product.goods is Fluid) {
-                    logisticsCost += amount * CostPerFluid;
-                }
+                constraint.SetCoefficientCheck(var, product.amount, ref lastVariable[product.goods]);
             }
 
             if (singleUsedFuel != null) {
                 var var = variables[singleUsedFuel];
-                constraint.SetCoefficientCheck(var, -singleUsedFuelAmount, ref lastVariable[singleUsedFuel]);
+                constraint.SetCoefficientCheck(var, -crafterStats.SingleUsedFuelAmount, ref lastVariable[singleUsedFuel]);
             }
 
             foreach (var ingredient in recipe.ingredients) {
                 var var = variables[ingredient.goods]; // TODO split cost analysis
                 constraint.SetCoefficientCheck(var, -ingredient.amount, ref lastVariable[ingredient.goods]);
-
-                if (ingredient.goods is Item) {
-                    logisticsCost += ingredient.amount * CostPerItem;
-                }
-                else if (ingredient.goods is Fluid) {
-                    logisticsCost += ingredient.amount * CostPerFluid;
-                }
-            }
-
-            if (recipe.sourceEntity != null && recipe.sourceEntity.mapGenerated) {
-                float totalMining = 0f;
-
-                foreach (var product in recipe.products) {
-                    totalMining += product.amount;
-                }
-
-                float miningPenalty = MiningPenalty;
-                float totalDensity = recipe.sourceEntity.mapGenDensity / totalMining;
-
-                if (totalDensity < MiningMaxDensityForPenalty) {
-                    float extraPenalty = MathF.Log(MiningMaxDensityForPenalty / totalDensity);
-                    miningPenalty += Math.Min(extraPenalty, MiningMaxExtraPenaltyForRarity);
-                }
-
-                logisticsCost *= miningPenalty;
-            }
-
-            if (minEmissions >= 0f) {
-                logisticsCost += minEmissions * CostPerPollution * recipe.time * project.settings.PollutionCostModifier;
             }
 
             constraint.SetUb(logisticsCost);

--- a/Yafc/Data/locale/en/yafc.cfg
+++ b/Yafc/Data/locale/en/yafc.cfg
@@ -509,6 +509,8 @@ recipe-cost-products=Product value: ¥__1__
 recipe-cost-logistics=Logistics cost: ¥__1__
 recipe-cost-ctrl-hint=(Hold Ctrl for details)
 recipe-cost-shift-ctrl-hint=(Hold Ctrl+Shift for current milestones)
+; Short for "Not Available" when a value cannot be computed
+not-available=N/A
 ; Detailed logistics breakdown
 recipe-logistics-header=Logistics breakdown
 recipe-logistics-time-size=Time and size: ¥__1__

--- a/Yafc/Data/locale/en/yafc.cfg
+++ b/Yafc/Data/locale/en/yafc.cfg
@@ -501,6 +501,22 @@ cost-analysis-recipe-cost=YAFC cost per recipe: ¥__1__
 cost-analysis-generic-cost=YAFC cost: ¥__1__
 ; __1__ is one of the above cost-analysis-*-cost strings
 cost-analysis-with-current-cost=__1__ (Currently ¥__2__)
+; Recipe cost breakdown tooltip
+recipe-cost-header=Recipe cost breakdown
+recipe-cost-ingredients=Ingredient cost: ¥__1__
+recipe-cost-products=Product value: ¥__1__
+recipe-cost-logistics=Logistics cost: ¥__1__
+recipe-cost-ctrl-hint=(Hold Ctrl for details)
+; Detailed logistics breakdown
+recipe-logistics-header=Logistics breakdown
+recipe-logistics-time-size=Time and size: ¥__1__
+recipe-logistics-power=Power: ¥__1__
+recipe-logistics-item-transport=Item transport: ¥__1__
+recipe-logistics-fluid-transport=Fluid transport: ¥__1__
+recipe-logistics-pollution=Pollution: ¥__1__
+recipe-logistics-mining-penalty=Mining penalty: __1__x
+; Cost suffix for items in recipe tooltip
+recipe-item-cost-suffix= (¥__1__)
 
 ; DependencyNode.cs
 dependency-or-bar=-- OR --

--- a/Yafc/Data/locale/en/yafc.cfg
+++ b/Yafc/Data/locale/en/yafc.cfg
@@ -503,10 +503,12 @@ cost-analysis-generic-cost=YAFC cost: ¥__1__
 cost-analysis-with-current-cost=__1__ (Currently ¥__2__)
 ; Recipe cost breakdown tooltip
 recipe-cost-header=Recipe cost breakdown
+recipe-cost-header-at-milestones=Recipe cost breakdown (current)
 recipe-cost-ingredients=Ingredient cost: ¥__1__
 recipe-cost-products=Product value: ¥__1__
 recipe-cost-logistics=Logistics cost: ¥__1__
 recipe-cost-ctrl-hint=(Hold Ctrl for details)
+recipe-cost-shift-ctrl-hint=(Hold Ctrl+Shift for current milestones)
 ; Detailed logistics breakdown
 recipe-logistics-header=Logistics breakdown
 recipe-logistics-time-size=Time and size: ¥__1__

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -501,10 +501,10 @@ doneDrawing:;
             if (!atMilestones) {
                 gui.BuildText(LSs.RecipeCostShiftCtrlHint, TextBlockDisplayStyle.HintText);
             }
-            gui.BuildText(LSs.RecipeCostIngredients.L(hasInfiniteIngredient ? "N/A" : DataUtils.FormatAmount(ingredientCost, UnitOfMeasure.None)));
-            gui.BuildText(LSs.RecipeCostLogistics.L(isAutomatable ? DataUtils.FormatAmount(recipe.RecipeBaseCost(atMilestones), UnitOfMeasure.None) : "N/A"));
+            gui.BuildText(LSs.RecipeCostIngredients.L(hasInfiniteIngredient ? LSs.NotAvailable.L() : DataUtils.FormatAmount(ingredientCost, UnitOfMeasure.None)));
+            gui.BuildText(LSs.RecipeCostLogistics.L(isAutomatable ? DataUtils.FormatAmount(recipe.RecipeBaseCost(atMilestones), UnitOfMeasure.None) : LSs.NotAvailable.L()));
             gui.AllocateSpacing(0.1f);
-            gui.BuildText(LSs.RecipeCostProducts.L(isAutomatable ? DataUtils.FormatAmount(recipe.ProductCost(atMilestones), UnitOfMeasure.None) : "N/A"));
+            gui.BuildText(LSs.RecipeCostProducts.L(isAutomatable ? DataUtils.FormatAmount(recipe.ProductCost(atMilestones), UnitOfMeasure.None) : LSs.NotAvailable.L()));
             gui.AllocateSpacing(0.5f);
 
             // Logistics breakdown

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -144,15 +144,12 @@ doneDrawing:;
         }
     }
 
-    private static void BuildItem(ImGui gui, IFactorioObjectWrapper item, string? extraText = null, bool showCosts = false) {
+    private static void BuildItem(ImGui gui, IFactorioObjectWrapper item, string? extraText = null, bool showCosts = false, bool atMilestones = false) {
         using (gui.EnterRow()) {
             gui.BuildFactorioObjectIcon(item);
             string costSuffix = "";
             if (showCosts && item.target is Goods goods) {
-                float costPerItem = goods.Cost(true);
-                if (float.IsPositiveInfinity(costPerItem)) {
-                    costPerItem = goods.Cost();
-                }
+                float costPerItem = goods.Cost(atMilestones);
                 if (!float.IsPositiveInfinity(costPerItem)) {
                     costSuffix = LSs.RecipeItemCostSuffix.L(DataUtils.FormatAmount(costPerItem * item.amount, UnitOfMeasure.None));
                 }
@@ -483,39 +480,37 @@ doneDrawing:;
         }
     }
 
-    private static void BuildRecipeCostBreakdown(Recipe recipe, ImGui gui) {
-        // Calculate ingredient cost using milestone-aware costs with fallback
+    private static void BuildRecipeCostBreakdown(Recipe recipe, ImGui gui, bool atMilestones) {
+        bool isAutomatable = atMilestones ? recipe.IsAutomatableWithCurrentMilestones() : recipe.IsAutomatable();
+
+        // Calculate ingredient cost
         float ingredientCost = 0f;
+        bool hasInfiniteIngredient = false;
         foreach (var ingredient in recipe.ingredients) {
-            float itemCost = ingredient.goods.Cost(true);
+            float itemCost = ingredient.goods.Cost(atMilestones);
             if (float.IsPositiveInfinity(itemCost)) {
-                itemCost = ingredient.goods.Cost();
+                hasInfiniteIngredient = true;
             }
-            if (!float.IsPositiveInfinity(itemCost)) {
+            else {
                 ingredientCost += itemCost * ingredient.amount;
             }
         }
 
-        float productValue = recipe.ProductCost(true);
-        if (float.IsPositiveInfinity(productValue)) {
-            productValue = recipe.ProductCost();
-        }
-        float logisticsCost = recipe.RecipeBaseCost(true);
-        if (float.IsPositiveInfinity(logisticsCost)) {
-            logisticsCost = recipe.RecipeBaseCost();
-        }
-
-        BuildSubHeader(gui, LSs.RecipeCostHeader);
+        BuildSubHeader(gui, atMilestones ? LSs.RecipeCostHeaderAtMilestones : LSs.RecipeCostHeader);
         using (gui.EnterGroup(contentPadding)) {
-            gui.BuildText(LSs.RecipeCostIngredients.L(DataUtils.FormatAmount(ingredientCost, UnitOfMeasure.None)));
-            gui.BuildText(LSs.RecipeCostLogistics.L(DataUtils.FormatAmount(logisticsCost, UnitOfMeasure.None)));
+            if (!atMilestones) {
+                gui.BuildText(LSs.RecipeCostShiftCtrlHint, TextBlockDisplayStyle.HintText);
+            }
+            gui.BuildText(LSs.RecipeCostIngredients.L(hasInfiniteIngredient ? "N/A" : DataUtils.FormatAmount(ingredientCost, UnitOfMeasure.None)));
+            gui.BuildText(LSs.RecipeCostLogistics.L(isAutomatable ? DataUtils.FormatAmount(recipe.RecipeBaseCost(atMilestones), UnitOfMeasure.None) : "N/A"));
             gui.AllocateSpacing(0.1f);
-            gui.BuildText(LSs.RecipeCostProducts.L(DataUtils.FormatAmount(productValue, UnitOfMeasure.None)));
+            gui.BuildText(LSs.RecipeCostProducts.L(isAutomatable ? DataUtils.FormatAmount(recipe.ProductCost(atMilestones), UnitOfMeasure.None) : "N/A"));
             gui.AllocateSpacing(0.5f);
 
             // Logistics breakdown
             gui.BuildText(LSs.RecipeLogisticsHeader, Font.subheader);
-            var breakdown = CostAnalysis.Get(true).ComputeLogisticsBreakdown(Project.current, recipe);
+            var breakdown = CostAnalysis.Get(atMilestones).ComputeLogisticsBreakdown(Project.current, recipe);
+
             gui.BuildText(LSs.RecipeLogisticsTimeSize.L(DataUtils.FormatAmount(breakdown.TimeSizeCost, UnitOfMeasure.None)));
             if (breakdown.PowerCost > 0f) {
                 gui.BuildText(LSs.RecipeLogisticsPower.L(DataUtils.FormatAmount(breakdown.PowerCost, UnitOfMeasure.None)));
@@ -537,6 +532,7 @@ doneDrawing:;
 
     private static void BuildRecipe(RecipeOrTechnology recipe, ImGui gui) {
         bool showCosts = InputSystem.Instance.control;
+        bool atMilestones = InputSystem.Instance.shift;
 
         using (gui.EnterGroup(contentPadding, RectAllocator.LeftRow)) {
             gui.BuildIcon(Icon.Time, 2f, SchemeColor.BackgroundText);
@@ -565,7 +561,7 @@ doneDrawing:;
             }
             else {
                 foreach (Ingredient ingredient in recipe.ingredients) {
-                    BuildItem(gui, ingredient, showCosts: showCosts);
+                    BuildItem(gui, ingredient, showCosts: showCosts, atMilestones: atMilestones);
                 }
             }
 
@@ -600,7 +596,7 @@ doneDrawing:;
 
         // Cost breakdown section for recipes (not technologies)
         if (showCosts && recipe is Recipe costRecipe && costRecipe.IsAutomatable()) {
-            BuildRecipeCostBreakdown(costRecipe, gui);
+            BuildRecipeCostBreakdown(costRecipe, gui, atMilestones);
         }
 
         if (recipe is Recipe { products.Length: > 0 } && !(recipe.products.Length == 1 && recipe.products[0].IsSimple)) {
@@ -608,7 +604,7 @@ doneDrawing:;
             using (gui.EnterGroup(contentPadding)) {
                 string? extraText = recipe is Recipe { preserveProducts: true } ? LSs.ProductSuffixPreserved : null;
                 foreach (var product in recipe.products) {
-                    BuildItem(gui, product, extraText, showCosts);
+                    BuildItem(gui, product, extraText, showCosts, atMilestones);
                 }
             }
         }

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -144,10 +144,20 @@ doneDrawing:;
         }
     }
 
-    private static void BuildItem(ImGui gui, IFactorioObjectWrapper item, string? extraText = null) {
+    private static void BuildItem(ImGui gui, IFactorioObjectWrapper item, string? extraText = null, bool showCosts = false) {
         using (gui.EnterRow()) {
             gui.BuildFactorioObjectIcon(item);
-            gui.BuildText(item.text + extraText, TextBlockDisplayStyle.WrappedText);
+            string costSuffix = "";
+            if (showCosts && item.target is Goods goods) {
+                float costPerItem = goods.Cost(true);
+                if (float.IsPositiveInfinity(costPerItem)) {
+                    costPerItem = goods.Cost();
+                }
+                if (!float.IsPositiveInfinity(costPerItem)) {
+                    costSuffix = LSs.RecipeItemCostSuffix.L(DataUtils.FormatAmount(costPerItem * item.amount, UnitOfMeasure.None));
+                }
+            }
+            gui.BuildText(item.text + costSuffix + extraText, TextBlockDisplayStyle.WrappedText);
         }
     }
 
@@ -194,6 +204,9 @@ doneDrawing:;
             }
             else {
                 gui.BuildText(CostAnalysis.GetDisplayCost(target), TextBlockDisplayStyle.WrappedText);
+                if (target is Recipe && !InputSystem.Instance.control) {
+                    gui.BuildText(LSs.RecipeCostCtrlHint, TextBlockDisplayStyle.HintText);
+                }
             }
 
             if (target.IsAccessibleWithCurrentMilestones() && !target.IsAutomatableWithCurrentMilestones()) {
@@ -470,7 +483,61 @@ doneDrawing:;
         }
     }
 
+    private static void BuildRecipeCostBreakdown(Recipe recipe, ImGui gui) {
+        // Calculate ingredient cost using milestone-aware costs with fallback
+        float ingredientCost = 0f;
+        foreach (var ingredient in recipe.ingredients) {
+            float itemCost = ingredient.goods.Cost(true);
+            if (float.IsPositiveInfinity(itemCost)) {
+                itemCost = ingredient.goods.Cost();
+            }
+            if (!float.IsPositiveInfinity(itemCost)) {
+                ingredientCost += itemCost * ingredient.amount;
+            }
+        }
+
+        float productValue = recipe.ProductCost(true);
+        if (float.IsPositiveInfinity(productValue)) {
+            productValue = recipe.ProductCost();
+        }
+        float logisticsCost = recipe.RecipeBaseCost(true);
+        if (float.IsPositiveInfinity(logisticsCost)) {
+            logisticsCost = recipe.RecipeBaseCost();
+        }
+
+        BuildSubHeader(gui, LSs.RecipeCostHeader);
+        using (gui.EnterGroup(contentPadding)) {
+            gui.BuildText(LSs.RecipeCostIngredients.L(DataUtils.FormatAmount(ingredientCost, UnitOfMeasure.None)));
+            gui.BuildText(LSs.RecipeCostLogistics.L(DataUtils.FormatAmount(logisticsCost, UnitOfMeasure.None)));
+            gui.AllocateSpacing(0.1f);
+            gui.BuildText(LSs.RecipeCostProducts.L(DataUtils.FormatAmount(productValue, UnitOfMeasure.None)));
+            gui.AllocateSpacing(0.5f);
+
+            // Logistics breakdown
+            gui.BuildText(LSs.RecipeLogisticsHeader, Font.subheader);
+            var breakdown = CostAnalysis.Get(true).ComputeLogisticsBreakdown(Project.current, recipe);
+            gui.BuildText(LSs.RecipeLogisticsTimeSize.L(DataUtils.FormatAmount(breakdown.TimeSizeCost, UnitOfMeasure.None)));
+            if (breakdown.PowerCost > 0f) {
+                gui.BuildText(LSs.RecipeLogisticsPower.L(DataUtils.FormatAmount(breakdown.PowerCost, UnitOfMeasure.None)));
+            }
+            if (breakdown.ItemTransportCost > 0f) {
+                gui.BuildText(LSs.RecipeLogisticsItemTransport.L(DataUtils.FormatAmount(breakdown.ItemTransportCost, UnitOfMeasure.None)));
+            }
+            if (breakdown.FluidTransportCost > 0f) {
+                gui.BuildText(LSs.RecipeLogisticsFluidTransport.L(DataUtils.FormatAmount(breakdown.FluidTransportCost, UnitOfMeasure.None)));
+            }
+            if (breakdown.PollutionCost > 0f) {
+                gui.BuildText(LSs.RecipeLogisticsPollution.L(DataUtils.FormatAmount(breakdown.PollutionCost, UnitOfMeasure.None)));
+            }
+            if (breakdown.MiningPenalty > 1f) {
+                gui.BuildText(LSs.RecipeLogisticsMiningPenalty.L(DataUtils.FormatAmount(breakdown.MiningPenalty, UnitOfMeasure.None)));
+            }
+        }
+    }
+
     private static void BuildRecipe(RecipeOrTechnology recipe, ImGui gui) {
+        bool showCosts = InputSystem.Instance.control;
+
         using (gui.EnterGroup(contentPadding, RectAllocator.LeftRow)) {
             gui.BuildIcon(Icon.Time, 2f, SchemeColor.BackgroundText);
             gui.BuildText(DataUtils.FormatAmount(recipe.time, UnitOfMeasure.Second));
@@ -498,7 +565,7 @@ doneDrawing:;
             }
             else {
                 foreach (Ingredient ingredient in recipe.ingredients) {
-                    BuildItem(gui, ingredient);
+                    BuildItem(gui, ingredient, showCosts: showCosts);
                 }
             }
 
@@ -531,12 +598,17 @@ doneDrawing:;
             }
         }
 
+        // Cost breakdown section for recipes (not technologies)
+        if (showCosts && recipe is Recipe costRecipe && costRecipe.IsAutomatable()) {
+            BuildRecipeCostBreakdown(costRecipe, gui);
+        }
+
         if (recipe is Recipe { products.Length: > 0 } && !(recipe.products.Length == 1 && recipe.products[0].IsSimple)) {
             BuildSubHeader(gui, LSs.TooltipHeaderRecipeProducts.L(recipe.products.Length));
             using (gui.EnterGroup(contentPadding)) {
                 string? extraText = recipe is Recipe { preserveProducts: true } ? LSs.ProductSuffixPreserved : null;
                 foreach (var product in recipe.products) {
-                    BuildItem(gui, product, extraText);
+                    BuildItem(gui, product, extraText, showCosts);
                 }
             }
         }

--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@ Version:
 Date:
     Features:
         - Allow planet selection for production tables, and complain if the selected recipe or entity can't be used there.
+        - Hold Ctrl in a recipe tooltip to see how its cost is broken down, and Ctrl+Shift to see that breakdown at the current milestones.
     Fixes:
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.20.0


### PR DESCRIPTION
This PR is in spirit similar to https://github.com/shpaass/yafc-ce/pull/509 from ApocDev, but without duplicating the LogisticCost logic and visually better integrated with the rest of the Tooltip.

- Holding Ctrl before hovering over a recipe will show a cost breakdown.
- Holding Ctrl+Shift before hovering over a recipe will show a cost breakdown at current milestones (if the cost are available)

It is split into 3 commits:
1. isolate the LogisticCost logic
2. add the Info to the tooltip
3. allows to toggle between endgame and current milestone cost

Full Cost:
<img width="452" height="1178" alt="image" src="https://github.com/user-attachments/assets/61d6f0ba-dfc4-43e0-bca2-43052322f464" />

At current milestone:
<img width="450" height="892" alt="image" src="https://github.com/user-attachments/assets/4feb7c48-9eba-42e5-815e-d28eeffb7af7" />

Please note anything you would want to change, I'm open to suggestions.
