### PR TITLE
feat: Show result of spending fuel in item explorer

### DIFF
--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -391,6 +391,7 @@ public class Item : Goods {
     }
 
     public Item? fuelResult { get; internal set; }
+    public Item[] fuelResultOf { get; internal set; } = [];
     public int stackSize { get; internal set; }
     public Entity? placeResult { get; internal set; }
     public Entity? plantResult { get; internal set; }

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
@@ -436,6 +436,7 @@ internal partial class FactorioDataDeserializer {
         // Because actual recipe availability may be different than just "all recipes from that category" because of item slot limit and fluid usage restriction, calculate it here
         DataBucket<RecipeOrTechnology, EntityCrafter> actualRecipeCrafters = new DataBucket<RecipeOrTechnology, EntityCrafter>();
         DataBucket<Goods, Entity> usageAsFuel = new DataBucket<Goods, Entity>();
+        DataBucket<Item, Item> fuelResults = new DataBucket<Item, Item>();
         List<Recipe> allRecipes = [];
         List<Mechanics> allMechanics = [];
 
@@ -502,6 +503,7 @@ internal partial class FactorioDataDeserializer {
                         entityPlacers.Add(GetObject<Entity>(plantResultName), item, true);
                     }
                     if (item.fuelResult != null) {
+                        fuelResults.Add(item.fuelResult, item);
                         miscSources.Add(item.fuelResult, item);
                     }
 
@@ -583,6 +585,7 @@ internal partial class FactorioDataDeserializer {
                         if (item.placeResult != null) {
                             item.FallbackLocalization(item.placeResult, LSs.LocalizationFallbackDescriptionItemToBuild);
                         }
+                        item.fuelResultOf = fuelResults.GetArray(item);
                     }
                     else if (o is Fluid fluid && fluid.variants != null) {
                         if (fluid.locDescr == null) {

--- a/Yafc/Data/locale/en/yafc.cfg
+++ b/Yafc/Data/locale/en/yafc.cfg
@@ -301,6 +301,7 @@ neie-building-hours-suffix=__1__bh
 neie-building-hours-description=Building-hours.\nAmount of building-hours required for all researches assuming crafting speed of 1.
 fuel-value-can-be-used=Fuel value __1__ can be used for:
 fuel-value-zero-can-be-used=Can be used to fuel:
+result-of-spending-fuel=Result of spending fuel:
 neie-show-special-recipes=Show special recipes (barreling / voiding)
 neie-show-locked-recipes=There are more recipes, but they are locked based on current milestones.
 neie-show-inaccessible-recipes=There are more recipes, but they are inaccessible.

--- a/Yafc/Windows/NeverEnoughItemsPanel.cs
+++ b/Yafc/Windows/NeverEnoughItemsPanel.cs
@@ -267,6 +267,19 @@ public class NeverEnoughItemsPanel : PseudoScreen, IComparer<NeverEnoughItemsPan
                 gui.DrawRectangle(gui.lastRect, SchemeColor.Primary);
             }
         }
+        if (production && current is Item item && item.fuelResultOf.Length > 0) {
+            using (gui.EnterGroup(new Padding(0.5f), RectAllocator.LeftAlign)) {
+                gui.BuildText(LSs.ResultOfSpendingFuel);
+                using var grid = gui.EnterInlineGrid(3f);
+                foreach (var fuelResult in item.fuelResultOf) {
+                    grid.Next();
+                    _ = gui.BuildFactorioObjectButton(fuelResult, ButtonDisplayStyle.NeieSmall);
+                }
+            }
+            if (gui.isBuilding) {
+                gui.DrawRectangle(gui.lastRect, SchemeColor.Primary);
+            }
+        }
     }
 
     private void ChangeShowStatus(EntryStatus status) {


### PR DESCRIPTION
This PR adds a panel to the left half of Never Enough Items, similar to showing fuel value on the right side:

Showing how to get an Item by burning something else.

This helps to show where Tired Auogs come from.

<img width="1411" height="1130" alt="image" src="https://github.com/user-attachments/assets/c1b2b3c6-f4b6-45d9-8053-1a03c0dabd6a" />
