### PR TITLE
feat: Track heat temperature variants from reactors

### DIFF
--- a/Yafc.Model.Tests/Model/ProductionTableContentTests.cs
+++ b/Yafc.Model.Tests/Model/ProductionTableContentTests.cs
@@ -189,11 +189,11 @@ public class ProductionTableContentTests {
         }
 
         // Ignoring quality, we have:
-        // 2 recipes, 2 mechanics, 3 electric crafters and 3 burner crafters (with 3 fuels), and 9 modules (plus no modules)
+        // 2 recipes, 1 mechanic, 3 electric crafters and 3 burner crafters (with 3 fuels), and 9 modules (plus no modules)
         // Considering quality, we have:
-        // 4 recipes, 2 mechanics, 6 electric crafters and 6 burner crafters (with 6 fuels), and 18 modules (plus no modules)
+        // 4 recipes, 1 mechanic, 6 electric crafters and 6 burner crafters (with 6 fuels), and 18 modules (plus no modules)
         // All combinations should be tested
-        Assert.Equal((4 + 2) * (6 + 6 * 6) * (18 + 1), testCount);
+        Assert.Equal((4 + 1) * (6 + 6 * 6) * (18 + 1), testCount);
     }
 
     /// <summary>

--- a/Yafc.Model/Analysis/CostAnalysis.cs
+++ b/Yafc.Model/Analysis/CostAnalysis.cs
@@ -202,7 +202,7 @@ public class CostAnalysis(bool onlyCurrentMilestones) : Analysis {
                 logisticsCost = CostPerSecond * recipe.time / (stackSize * bestContainerSlotsPerTile);
             }
 
-            if (singleUsedFuel == Database.electricity.target || singleUsedFuel == Database.voidEnergy.target || singleUsedFuel == Database.heat.target) {
+            if (singleUsedFuel?.isPower == true) {
                 singleUsedFuel = null;
             }
 
@@ -286,6 +286,18 @@ public class CostAnalysis(bool onlyCurrentMilestones) : Analysis {
             for (int i = 1; i < fluids.Count; i++) {
                 var cur = fluids[i];
                 var constraint = workspaceSolver.MakeConstraint(double.NegativeInfinity, 0, "fluid-" + name + "-" + prev.temperature);
+                constraint.SetCoefficient(variables[prev], 1);
+                constraint.SetCoefficient(variables[cur], -1);
+                prev = cur;
+            }
+        }
+
+        if (Database.heatVariants != null) {
+            var prev = Database.heatVariants[0];
+
+            for (int i = 1; i < Database.heatVariants.Count; i++) {
+                var cur = Database.heatVariants[i];
+                var constraint = workspaceSolver.MakeConstraint(double.NegativeInfinity, 0, "heat-" + prev.temperature);
                 constraint.SetCoefficient(variables[prev], 1);
                 constraint.SetCoefficient(variables[cur], -1);
                 prev = cur;

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -486,6 +486,9 @@ public class Special : Goods {
     internal string? virtualSignal { get; set; }
     internal bool power;
     internal bool isVoid;
+    public int temperature { get; internal set; }
+    internal List<Special>? variants { get; set; }
+    internal Special Clone() => (Special)MemberwiseClone();
     public override bool isPower => power;
     public override string type => isPower ? "Power" : "Special";
     public override UnitOfMeasure flowUnitOfMeasure => isVoid ? UnitOfMeasure.None : isPower ? UnitOfMeasure.Megawatt : UnitOfMeasure.PerSecond;

--- a/Yafc.Model/Data/Database.cs
+++ b/Yafc.Model/Data/Database.cs
@@ -12,6 +12,7 @@ public static class Database {
     public static Item[] allSciencePacks { get; internal set; } = null!;
     public static Dictionary<string, FactorioObject> objectsByTypeName { get; internal set; } = null!;
     public static Dictionary<string, List<Fluid>> fluidVariants { get; internal set; } = null!;
+    public static List<Special>? heatVariants { get; internal set; }
     public static IObjectWithQuality<Goods> voidEnergy { get; internal set; } = null!;
     public static IObjectWithQuality<Item> science { get; internal set; } = null!;
     public static IObjectWithQuality<Item> itemInput { get; internal set; } = null!;
@@ -80,6 +81,19 @@ public static class Database {
             var prev = variants[0];
             for (int i = 1; i < variants.Count; i++) {
                 var cur = variants[i];
+                if (cur.temperature >= temperature) {
+                    return cur.temperature - temperature > temperature - prev.temperature ? prev : cur;
+                }
+
+                prev = cur;
+            }
+            return prev;
+        }
+
+        if (heatVariants != null && heatVariants[0].typeDotName.StartsWith(baseId + "@", StringComparison.Ordinal)) {
+            var prev = heatVariants[0];
+            for (int i = 1; i < heatVariants.Count; i++) {
+                var cur = heatVariants[i];
                 if (cur.temperature >= temperature) {
                     return cur.temperature - temperature > temperature - prev.temperature ? prev : cur;
                 }

--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -105,26 +105,90 @@ internal partial class FactorioDataDeserializer {
             fluidVariants[fluid.typeDotName] = fluid.variants;
 
             foreach (var variant in fluid.variants) {
-                AddTemperatureToFluidIcon(variant);
+                AddTemperatureToIcon(variant, variant.temperature);
                 variant.name += "@" + variant.temperature;
             }
         }
     }
 
-    private static void AddTemperatureToFluidIcon(Fluid fluid) {
-        string iconStr = fluid.temperature + "d";
+    private static void AddTemperatureToIcon(FactorioObject obj, int temperature) {
+        string iconStr = temperature + "d";
 
         // Calculate the size/position of the overlay digits to correspond to the size of the first icon layer.
-        int size = fluid.iconSpec?.FirstOrDefault()?.size ?? 64;
+        int size = obj.iconSpec?.FirstOrDefault()?.size ?? 64;
         int shift = 7 * size / 32;
         int xoffset = 12 * size / 32;
         int yoffset = size / -2;
 
-        fluid.iconSpec =
+        obj.iconSpec =
         [
-            .. fluid.iconSpec ?? [],
+            .. obj.iconSpec ?? [],
             .. iconStr.Take(4).Select((x, n) => new FactorioIconPart("__.__/" + x) { size = size, y = yoffset, x = (n * shift) - xoffset, scale = 0.28f }),
         ];
+    }
+
+    /// <summary>
+    /// Gets or creates a heat <see cref="Special"/> for the given temperature. On the first call, assigns the
+    /// temperature to the existing base heat object. On subsequent calls with a different temperature, splits
+    /// heat into separate variant objects (via <see cref="SplitHeat"/>), similar to how
+    /// <see cref="GetFluidFixedTemp"/> handles fluid temperature variants.
+    /// </summary>
+    /// <param name="temperature">The max temperature from a reactor's heat_buffer.</param>
+    /// <returns>The heat variant for this temperature, either existing or newly created.</returns>
+    private Special GetHeatFixedTemp(int temperature) {
+        if (heat.temperature == temperature) {
+            return heat;
+        }
+
+        string idWithTemp = SpecialNames.Heat + "@" + temperature;
+
+        if (heat.temperature == 0) {
+            // First reactor parsed: assign its temperature to the base heat object.
+            heat.temperature = temperature;
+            registeredObjects[(typeof(Special), idWithTemp)] = heat;
+            return heat;
+        }
+
+        if (registeredObjects.TryGetValue((typeof(Special), idWithTemp), out var existing)) {
+            return (Special)existing;
+        }
+
+        // A different temperature than what we've seen before: create a new variant.
+        var split = SplitHeat(heat, temperature);
+        allObjects.Add(split);
+        registeredObjects[(typeof(Special), idWithTemp)] = split;
+        return split;
+    }
+
+    /// <summary>
+    /// Creates a new heat variant by cloning the base heat object with a different temperature.
+    /// Adds the clone to the shared variants list and registers it as a heat fuel.
+    /// </summary>
+    private Special SplitHeat(Special basic, int temperature) {
+        basic.variants ??= [basic];
+        var copy = basic.Clone();
+        copy.temperature = temperature;
+        copy.variants!.Add(copy); // null-forgiving: Clone copies the non-null variants list.
+        fuels.Add(SpecialNames.Heat, copy);
+        return copy;
+    }
+
+    /// <summary>
+    /// Finalizes heat variants after all reactors have been parsed. Sorts variants by temperature,
+    /// appends temperature suffixes to their names, and overlays temperature digits on their icons.
+    /// Does nothing if only a single heat temperature exists (no splitting occurred).
+    /// </summary>
+    private void UpdateSplitHeats() {
+        if (heat.temperature == 0 || heat.variants == null) {
+            return;
+        }
+
+        heat.variants.Sort((a, b) => a.temperature.CompareTo(b.temperature));
+
+        foreach (var variant in heat.variants) {
+            AddTemperatureToIcon(variant, variant.temperature);
+            variant.name += "@" + variant.temperature;
+        }
     }
 
     /// <summary>
@@ -198,6 +262,7 @@ internal partial class FactorioDataDeserializer {
         rocketCapacity = raw.Get<LuaTable>("utility-constants").Get<LuaTable>("default").Get("rocket_lift_weight", 1000000);
         defaultItemWeight = raw.Get<LuaTable>("utility-constants").Get<LuaTable>("default").Get("default_item_weight", 100);
         UpdateSplitFluids();
+        UpdateSplitHeats();
         UpdateRecipeIngredientFluids(errorCollector);
         CalculateMaps(netProduction);
         var iconRenderTask = renderIcons ? Task.Run(RenderIcons) : Task.CompletedTask;

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
@@ -24,7 +24,6 @@ internal partial class FactorioDataDeserializer {
     private readonly Dictionary<string, FactorioObject> formerAliases = [];
 
     private readonly Recipe generatorProduction;
-    private readonly Recipe reactorProduction;
     private readonly Special voidEnergy;
     private readonly Special heat;
     private readonly Special electricity;
@@ -109,11 +108,6 @@ internal partial class FactorioDataDeserializer {
         generatorProduction.products = [new Product(electricity, 1f)];
         generatorProduction.flags |= RecipeFlags.ScaleProductionWithPower;
         generatorProduction.ingredients = [];
-
-        reactorProduction = CreateSpecialRecipe(heat, SpecialNames.ReactorRecipe, LSs.SpecialRecipeGenerating);
-        reactorProduction.products = [new Product(heat, 1f)];
-        reactorProduction.flags |= RecipeFlags.ScaleProductionWithPower;
-        reactorProduction.ingredients = [];
 
         voidEntityEnergy = new EntityEnergy { type = EntityEnergyType.Void, effectivity = float.PositiveInfinity };
         laborEntityEnergy = new EntityEnergy { type = EntityEnergyType.Labor, effectivity = float.PositiveInfinity };
@@ -322,6 +316,7 @@ internal partial class FactorioDataDeserializer {
         Database.qualities = new FactorioIdRange<Quality>(firstQuality, firstLocation, allObjects);
         Database.locations = new FactorioIdRange<Location>(firstLocation, firstTrigger, allObjects);
         Database.fluidVariants = fluidVariants;
+        Database.heatVariants = heat.variants;
 
         Database.allModules = [.. allModules];
         Database.allBeacons = [.. Database.entities.all.OfType<EntityBeacon>()];
@@ -529,6 +524,11 @@ internal partial class FactorioDataDeserializer {
 
                         if (entity.energy.type == EntityEnergyType.FluidHeat) {
                             fuelList = fuelList.Where(x => x is Fluid f && entity.energy.acceptedTemperature.Contains(f.temperature) && f.temperature > entity.energy.workingTemperature.min);
+                        }
+
+                        if (entity.energy.type == EntityEnergyType.Heat && heat.variants != null) {
+                            fuelList = fuelList.Where(x => x is Special s
+                                && s.temperature >= entity.energy.workingTemperature.min);
                         }
 
                         var fuelListArr = fuelList.ToArray();
@@ -740,6 +740,12 @@ internal partial class FactorioDataDeserializer {
         foreach (var (_, list) in fluidVariants) {
             foreach (var fluid in list) {
                 fluid.locName = LSs.FluidNameWithTemperature.L(fluid.locName, fluid.temperature);
+            }
+        }
+
+        if (heat.variants != null) {
+            foreach (var heatVariant in heat.variants) {
+                heatVariant.locName = LSs.FluidNameWithTemperature.L(heatVariant.locName, heatVariant.temperature);
             }
         }
 

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
@@ -522,7 +522,20 @@ internal partial class FactorioDataDeserializer {
                 _ = table.Get("consumption", out usesPower);
                 reactor.basePower = ParseEnergy(usesPower);
                 reactor.baseCraftingSpeed = reactor.basePower;
-                recipeCrafters.Add(reactor, SpecialNames.ReactorRecipe);
+
+                int maxTemp = table.Get<LuaTable>("heat_buffer").Get("max_temperature", 1000);
+                var heatVariant = GetHeatFixedTemp(maxTemp);
+
+                string reactorCategory = SpecialNames.ReactorRecipe + "@" + maxTemp;
+                var reactorRecipe = CreateSpecialRecipe(heatVariant, reactorCategory, LSs.SpecialRecipeGenerating);
+                if (reactorRecipe.products == null) {
+                    reactorRecipe.products = [new Product(heatVariant, 1f)];
+                    reactorRecipe.flags |= RecipeFlags.ScaleProductionWithPower;
+                    reactorRecipe.ingredients = [];
+                }
+                recipeCrafters.Add(reactor, reactorCategory);
+
+                formerAliases.TryAdd("Mechanics." + SpecialNames.ReactorRecipe + "." + SpecialNames.Heat, reactorRecipe);
                 break;
             case "rocket-silo":
                 goto case "furnace";

--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@ Version:
 Date:
     Features:
         - Pressing Ctrl + LeftClick on the Close icon of the page now deletes it instead of closing. LeftClick wihout Ctrl closes it as usual.
+        - Track heat temperature variants from different reactor types.
     Fixes:
         - Improve spoilage recipe handling: dedicated spoilage entity with clock icon, better cost calculation, and marked as automatable.
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Different reactors can produce heat at different max temperatures. Heat variants are now modeled as separate Special goods objects (following the fluid temperature pattern), with per-temperature reactor recipes, temperature-filtered fuel lists, temperature digits on icons, and cost analysis constraints.

One caveat: When upgrading projects with ProductionTables that use heat, they will have all of them set to 500°C (or the closest to 0°C there is available in the modpack) irrespective of if they do allow for 500°C or not. But these can just be reselected, making this a one time manual migration.

Also I'm only checking min temp for fuel usage, as I'm not aware of any that has a max temp set.

<img width="1231" height="1271" alt="image" src="https://github.com/user-attachments/assets/ecd22d5b-e0a5-446e-b660-bae65a7916ff" />
