### PR TITLE
fix(core): apply Enter-edited module amounts in module customization

### DIFF
--- a/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -13,11 +13,13 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
     private RecipeRow? recipe;
     private ProjectModuleTemplate? template;
     private ModuleTemplateBuilder? modules;
+    private bool closeRequestedByEnter;
 
     public static void Show(RecipeRow recipe) {
         Instance.template = null;
         Instance.recipe = recipe;
         Instance.modules = recipe.modules?.GetBuilder();
+        Instance.closeRequestedByEnter = false;
         Instance.completionCallback = (hasResult, builder) => {
             if (hasResult) {
                 recipe.RecordUndo().modules = builder?.Build(recipe);
@@ -30,6 +32,7 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
         Instance.recipe = null;
         Instance.template = template;
         Instance.modules = template.template.GetBuilder();
+        Instance.closeRequestedByEnter = false;
         Instance.completionCallback = (hasResult, builder) => {
             if (hasResult) {
                 template.RecordUndo().template = builder!.Build(template);
@@ -196,21 +199,33 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
             }
         }
 
+        if (closeRequestedByEnter) {
+            closeRequestedByEnter = false;
+            CloseWithResult(modules);
+            return;
+        }
+
         gui.AllocateSpacing(3f);
         using (gui.EnterRow(allocator: RectAllocator.RightRow)) {
             if (template == null && gui.BuildButton(LSs.Cancel)) {
                 Close();
+                return;
             }
             if (template != null && gui.BuildButton(LSs.PartialCancel)) {
                 Close();
+                return;
             }
             if (gui.BuildButton(LSs.Done)) {
+                closeRequestedByEnter = false;
                 CloseWithResult(modules);
+                return;
             }
 
             gui.allocator = RectAllocator.LeftRow;
             if (modules != null && recipe != null && gui.BuildRedButton(LSs.ModuleCustomizationRemove)) {
+                closeRequestedByEnter = false;
                 CloseWithResult(null);
+                return;
             }
         }
     }
@@ -306,5 +321,8 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
         }
     }
 
-    protected override void ReturnPressed() => CloseWithResult(modules);
+    protected override void ReturnPressed() {
+        closeRequestedByEnter = true;
+        contents.Rebuild();
+    }
 }

--- a/changelog.txt
+++ b/changelog.txt
@@ -32,6 +32,7 @@ Date:
         - Remove incorrect speed bonus for quality mining drills.
         - Show beacons added by the per-page settings on each row they affect.
         - Fix the temperature overlay for fluids with non-64px icons.
+        - In Module customization, pressing Enter after editing module amounts now applies the changes like clicking Done.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.16.0
 Date: October 24th 2025


### PR DESCRIPTION
1. defer Enter-triggered close in ModuleCustomizationScreen so delayed text input is committed first
2. harden close flow to avoid duplicate/ordering issues between Enter and footer button actions
3. update unreleased changelog.txt with the Enter behavior fix

Resolve Enter Didn't Apply Module Amount Changes
Fixes #572

Tested in my local build.
