### PR TITLE
refactor(model): Isolate SDL2 Clipboard From Blueprint Utilities

### DIFF
--- a/Yafc.Model/Blueprints/BlueprintUtilities.cs
+++ b/Yafc.Model/Blueprints/BlueprintUtilities.cs
@@ -2,23 +2,12 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
-using SDL2;
 using Yafc.Model;
 
 namespace Yafc.Blueprints;
 
 public static class BlueprintUtilities {
-    private static string ExportBlueprint(BlueprintString blueprint, bool copyToClipboard) {
-        string result = blueprint.ToBpString();
-
-        if (copyToClipboard) {
-            _ = SDL.SDL_SetClipboardText(result);
-        }
-
-        return result;
-    }
-
-    public static string ExportConstantCombinators(string name, IReadOnlyList<(IObjectWithQuality<Goods> item, int amount)> goods, bool copyToClipboard = true) {
+    public static string ExportConstantCombinators(string name, IReadOnlyList<(IObjectWithQuality<Goods> item, int amount)> goods) {
         int combinatorCount = ((goods.Count - 1) / Database.constantCombinatorCapacity) + 1;
         int offset = -combinatorCount / 2;
         BlueprintString blueprint = new BlueprintString(name);
@@ -48,10 +37,10 @@ public static class BlueprintUtilities {
             last = entity;
         }
 
-        return ExportBlueprint(blueprint, copyToClipboard);
+        return blueprint.ToBpString();
     }
 
-    public static string ExportRequesterChests(string name, IReadOnlyList<(IObjectWithQuality<Item> item, int amount)> goods, EntityContainer chest, bool copyToClipboard = true) {
+    public static string ExportRequesterChests(string name, IReadOnlyList<(IObjectWithQuality<Item> item, int amount)> goods, EntityContainer chest) {
         if (chest.logisticSlotsCount <= 0) {
             throw new ArgumentException("Chest does not have logistic slots");
         }
@@ -84,7 +73,7 @@ public static class BlueprintUtilities {
             }
         }
 
-        return ExportBlueprint(blueprint, copyToClipboard);
+        return blueprint.ToBpString();
     }
 
     private class PlacedEntity {
@@ -105,7 +94,7 @@ public static class BlueprintUtilities {
         public List<PlacedEntity> Placements { get; set; } = new();
     }
 
-    public static string ExportRecipiesAsBlueprint(string name, IEnumerable<RecipeRow> recipies, bool includeFuel, bool copyToClipboard = true) {
+    public static string ExportRecipiesAsBlueprint(string name, IEnumerable<RecipeRow> recipies, bool includeFuel) {
         // Sort buildings largest to smallest (by height then width) for better packing
         var entities = recipies
             .Where(r => r.entity is not null && r.recipe is not null)
@@ -196,6 +185,6 @@ public static class BlueprintUtilities {
             buildingIndex += 1;
         }
 
-        return ExportBlueprint(blueprint, copyToClipboard);
+        return blueprint.ToBpString();
     }
 }

--- a/Yafc/Windows/ShoppingListScreen.cs
+++ b/Yafc/Windows/ShoppingListScreen.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using SDL2;
 using Yafc.Blueprints;
 using Yafc.I18n;
 using Yafc.Model;
@@ -204,12 +205,12 @@ public class ShoppingListScreen : PseudoScreen {
         if (Database.objectsByTypeName.TryGetValue("Entity.constant-combinator", out var combinator)
             && gui.BuildFactorioObjectButtonWithText(combinator) == Click.Left && gui.CloseDropdown()) {
 
-            _ = BlueprintUtilities.ExportConstantCombinators(LSs.ShoppingList, ExportGoods<Goods>());
+            _ = SDL.SDL_SetClipboardText(BlueprintUtilities.ExportConstantCombinators(LSs.ShoppingList, ExportGoods<Goods>()));
         }
 
         foreach (var container in Database.allContainers) {
             if (container.logisticMode == "requester" && gui.BuildFactorioObjectButtonWithText(container) == Click.Left && gui.CloseDropdown()) {
-                _ = BlueprintUtilities.ExportRequesterChests(LSs.ShoppingList, ExportGoods<Item>(), container);
+                _ = SDL.SDL_SetClipboardText(BlueprintUtilities.ExportRequesterChests(LSs.ShoppingList, ExportGoods<Item>(), container));
             }
         }
     }

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -323,7 +323,7 @@ goodsHaveNoProduction:;
                 goods.Add((flow.goods, rounded));
             }
 
-            _ = BlueprintUtilities.ExportConstantCombinators(view.projectPage!.name, goods); // null-forgiving: An active view always has an active page.
+            _ = SDL.SDL_SetClipboardText(BlueprintUtilities.ExportConstantCombinators(view.projectPage!.name, goods)); // null-forgiving: An active view always has an active page.
         }
     }
 
@@ -656,7 +656,7 @@ goodsHaveNoProduction:;
                     .GetRecipesRecursive()
                     .DistinctBy(row => (row.entity, row.recipe, includeFuel ? row.fuel : null));
 
-                _ = BlueprintUtilities.ExportRecipiesAsBlueprint(view.projectPage!.name, uniqueEntites, includeFuel);
+                _ = SDL.SDL_SetClipboardText(BlueprintUtilities.ExportRecipiesAsBlueprint(view.projectPage!.name, uniqueEntites, includeFuel));
             }
         }
     }


### PR DESCRIPTION
Decouples Yafc.Model from SDL2 side-effects by converting blueprint exporting methods into pure functions. The clipboard interaction is now delegated to the UI layer callers.

- Remove SDL2 dependency and copyToClipboard parameters from BlueprintUtilities
- Convert Export* methods to return string instead of performing I/O
- Update ShoppingListScreen and ProductionTableView to handle the clipboard side-effect
- Inline and remove redundant ExportBlueprint private helper

Close #575 