### PR TITLE
refactor(model): Decouple Domain Operations From Direct UI Input

### DIFF
--- a/Docs/Architecture/Key use cases of features/README.md
+++ b/Docs/Architecture/Key use cases of features/README.md
@@ -1,3 +1,3 @@
-The purpose of this folder is to list the key use cases of the features in Yafc. 
-This information justifies why a feature is present in the first place, and helps to keep it relevant when changing it. 
+The purpose of this folder is to list the key use cases of the features in Yafc.
+This information justifies why a feature is present in the first place, and helps to keep it relevant when changing it.
 Not all features are listed - the feature is added here mostly if its usefulness was questioned.

--- a/Docs/Architecture/Key use cases of features/UndoRedo.md
+++ b/Docs/Architecture/Key use cases of features/UndoRedo.md
@@ -1,7 +1,7 @@
-The Undo and Redo functionality has the following key use cases where it drastically improves a common operation:  
+The Undo and Redo functionality has the following key use cases where it drastically improves a common operation:
 
-Key use case:  
-*Helping to fix a silently broken sheet*. The sheet is silently broken when there is no explicit error but the result is unreasonable due to linking or not specifying overproduction. It can be made worse by one noticing it only further down the line, when it's not obvious what broke it. Without Undo, fixing a large sheet may require rebuilding whole sections from scratch. The larger the sheet the harder it is to debug because one is not told clearly what the solver breaks on. In this scenario, having Undo would save a lot of time by pointing out where exactly the sheet broke.  
+Key use case:
+*Helping to fix a silently broken sheet*. The sheet is silently broken when there is no explicit error but the result is unreasonable due to linking or not specifying overproduction. It can be made worse by one noticing it only further down the line, when it's not obvious what broke it. Without Undo, fixing a large sheet may require rebuilding whole sections from scratch. The larger the sheet the harder it is to debug because one is not told clearly what the solver breaks on. In this scenario, having Undo would save a lot of time by pointing out where exactly the sheet broke.
 
-Less common, but still important:  
+Less common, but still important:
 *Comparing two different recipes for the same product*. In a production chain, one can compare two recipes for one product by adding both to the sheet and repeating Undo/Redo on the "enable recipe" setting for the one that is used when both are enabled. The alternative to this use case is to clone the sheet and do the setups in two separate sheets, but it takes more time and makes it harder to spot the differences.

--- a/Yafc.Model.Tests/Model/ProjectTests.cs
+++ b/Yafc.Model.Tests/Model/ProjectTests.cs
@@ -26,6 +26,58 @@ public class ProjectTests {
         => Project.ReadFromFile("", new(), false).PerformAutoSave();
 
     [Fact]
+    public void Save_FlushesSuspendedUndoBatchBeforeMarkingVersionSaved() {
+        string path = CreateTestProjectPath();
+        try {
+            Project project = new Project();
+            project.Save(path);
+            project.undo.Suspend();
+
+            project.preferences.RecordUndo().time = 60;
+            project.Save(path);
+
+            Assert.Equal(0u, project.unsavedChangesCount);
+
+            project.preferences.RecordUndo().time = 3600;
+
+            Assert.True(project.unsavedChangesCount > 0);
+
+            Assert.Contains("\"time\": 60", File.ReadAllText(path));
+        }
+        finally {
+            DeleteProjectAndAutosaves(path);
+        }
+    }
+
+    [Fact]
+    public void PerformAutoSave_FlushesSuspendedUndoBatchBeforeMarkingVersionAutosaved() {
+        string path = CreateTestProjectPath();
+        try {
+            Project project = new Project();
+            project.Save(path);
+            project.undo.Suspend();
+
+            project.preferences.RecordUndo().time = 60;
+            project.PerformAutoSave();
+            project.preferences.RecordUndo().time = 3600;
+            project.PerformAutoSave();
+
+            Assert.Contains("\"time\": 3600", File.ReadAllText(Project.GenerateAutosavePath(path, 2)));
+        }
+        finally {
+            DeleteProjectAndAutosaves(path);
+        }
+    }
+
+    [Fact]
+    public void PerformAutoSave_NewUnattachedProject_DoesNotFlushSuspendedUndoBatch()
+        => AssertPerformAutoSaveDoesNotFlushSuspendedUndoBatch(new Project());
+
+    [Fact]
+    public void PerformAutoSave_LoadedWithEmptyString_DoesNotFlushSuspendedUndoBatch()
+        => AssertPerformAutoSaveDoesNotFlushSuspendedUndoBatch(Project.ReadFromFile("", new(), false));
+
+    [Fact]
     public void AutosaveInDotYafcDirectory_DoesNotModifyDirectory()
         // Use Path.Combine to generate host-native path separators. (GenerateAutosavePath coincidentally converts separators.)
         => Assert.Equal(Path.Combine("home", ".yafc", "ProjectName-autosave-1.yafc"), Project.GenerateAutosavePath("home/.yafc/ProjectName.yafc", 1));
@@ -34,4 +86,36 @@ public class ProjectTests {
     public void AutosaveInDotYafcDirectoryWithNoExtension_DoesNotModifyDirectory()
         // Use Path.Combine to generate host-native path separators. (GenerateAutosavePath coincidentally converts separators.)
         => Assert.Equal(Path.Combine("home", ".yafc", "ProjectName-autosave-4.yafc"), Project.GenerateAutosavePath("home/.yafc/ProjectName", 4));
+
+    private static string CreateTestProjectPath() {
+        string directory = Path.Combine(AppContext.BaseDirectory, "ProjectTestFiles");
+        _ = Directory.CreateDirectory(directory);
+        return Path.Combine(directory, Guid.NewGuid() + ".yafc");
+    }
+
+    private static void DeleteProjectAndAutosaves(string path) {
+        File.Delete(path);
+        for (int i = 1; i <= 5; i++) {
+            File.Delete(Project.GenerateAutosavePath(path, i));
+        }
+    }
+
+    private static void AssertPerformAutoSaveDoesNotFlushSuspendedUndoBatch(Project project) {
+        project.undo.Suspend();
+
+        project.preferences.RecordUndo().time = 60;
+
+        Assert.True(project.undo.HasChangesPending(project.preferences));
+        Assert.False(project.undo.CanUndo);
+
+        project.PerformAutoSave();
+
+        Assert.True(project.undo.HasChangesPending(project.preferences));
+        Assert.False(project.undo.CanUndo);
+
+        project.preferences.RecordUndo().time = 3600;
+        project.undo.Resume();
+
+        Assert.True(project.undo.CanUndo);
+    }
 }

--- a/Yafc.Model.Tests/Serialization/UndoSystemTests.cs
+++ b/Yafc.Model.Tests/Serialization/UndoSystemTests.cs
@@ -1,0 +1,61 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Threading;
+using Xunit;
+
+namespace Yafc.Model.Tests;
+
+public class UndoSystemTests {
+    [Fact]
+    public void ImmediateScheduler_FlushCommitsAfterMutation() {
+        var project = new Project(new ImmediateUndoBatchScheduler());
+        float changedValue = -1f;
+        project.settings.changed += _ => changedValue = project.settings.miningProductivity;
+
+        project.settings.RecordUndo().miningProductivity = 1.25f;
+        project.undo.FlushPendingChanges();
+
+        Assert.Equal(1.25f, changedValue);
+        Assert.True(project.undo.CanUndo);
+    }
+
+    [Fact]
+    public void ImmediateScheduler_CanUndoFlushesAfterMutation() {
+        var project = new Project(new ImmediateUndoBatchScheduler());
+
+        project.RecordUndo().yafcVersion = "immediate";
+
+        Assert.True(project.undo.CanUndo);
+        Assert.False(project.undo.HasChangesPending(project));
+    }
+
+    [Fact]
+    public void ScheduledCommit_CompletesPendingBatch() {
+        var scheduler = new DeferredUndoBatchScheduler();
+        var project = new Project(scheduler);
+
+        project.RecordUndo().yafcVersion = "scheduled";
+
+        Assert.False(project.undo.CanUndo);
+        Assert.True(project.undo.HasChangesPending(project));
+
+        scheduler.RunNext();
+
+        Assert.True(project.undo.CanUndo);
+        Assert.False(project.undo.HasChangesPending(project));
+
+        project.undo.PerformUndo();
+        Assert.Null(project.yafcVersion);
+    }
+
+    private sealed class DeferredUndoBatchScheduler : IUndoBatchScheduler {
+        private readonly Queue<Action> callbacks = [];
+
+        public int PendingCount => callbacks.Count;
+
+        public void ScheduleOnGestureFinish(SendOrPostCallback callback, object state)
+            => callbacks.Enqueue(() => callback(state));
+
+        public void RunNext() => callbacks.Dequeue()();
+    }
+}

--- a/Yafc.Model.Tests/Serialization/UndoSystemTests.cs
+++ b/Yafc.Model.Tests/Serialization/UndoSystemTests.cs
@@ -48,6 +48,33 @@ public class UndoSystemTests {
         Assert.Null(project.yafcVersion);
     }
 
+    [Fact]
+    public void FlushPendingChanges_InvalidatesPreviouslyScheduledCommit() {
+        var scheduler = new DeferredUndoBatchScheduler();
+        var project = new Project(scheduler);
+
+        project.RecordUndo().yafcVersion = "flushed";
+        project.undo.FlushPendingChanges();
+        project.RecordUndo().yafcVersion = "scheduled";
+
+        Assert.Equal(2, scheduler.PendingCount);
+        Assert.False(project.undo.CanUndo);
+        Assert.True(project.undo.HasChangesPending(project));
+
+        scheduler.RunNext();
+
+        Assert.False(project.undo.CanUndo);
+        Assert.True(project.undo.HasChangesPending(project));
+
+        scheduler.RunNext();
+
+        Assert.True(project.undo.CanUndo);
+        Assert.False(project.undo.HasChangesPending(project));
+
+        project.undo.PerformUndo();
+        Assert.Equal("flushed", project.yafcVersion);
+    }
+
     private sealed class DeferredUndoBatchScheduler : IUndoBatchScheduler {
         private readonly Queue<Action> callbacks = [];
 

--- a/Yafc.Model.Tests/Serialization/UndoSystemTests.cs
+++ b/Yafc.Model.Tests/Serialization/UndoSystemTests.cs
@@ -7,6 +7,37 @@ namespace Yafc.Model.Tests;
 
 public class UndoSystemTests {
     [Fact]
+    public void DefaultImmediateSchedulers_DoNotSharePendingCallbacks() {
+        IUndoBatchScheduler previousDefaultScheduler = UndoSystem.DefaultScheduler;
+        UndoSystem.DefaultScheduler = new ImmediateUndoBatchScheduler();
+
+        try {
+            var first = new Project();
+            var second = new Project();
+            int firstChanges = 0;
+            int secondChanges = 0;
+            first.settings.changed += _ => firstChanges++;
+            second.settings.changed += _ => secondChanges++;
+
+            first.settings.RecordUndo().miningProductivity = 1f;
+            second.settings.RecordUndo().miningProductivity = 2f;
+
+            Assert.True(second.undo.CanUndo);
+
+            Assert.Equal(0, firstChanges);
+            Assert.Equal(1, secondChanges);
+
+            first.undo.FlushPendingChanges();
+
+            Assert.Equal(1, firstChanges);
+            Assert.True(first.undo.CanUndo);
+        }
+        finally {
+            UndoSystem.DefaultScheduler = previousDefaultScheduler;
+        }
+    }
+
+    [Fact]
     public void ImmediateScheduler_FlushCommitsAfterMutation() {
         var project = new Project(new ImmediateUndoBatchScheduler());
         float changedValue = -1f;

--- a/Yafc.Model/Blueprints/Blueprint.cs
+++ b/Yafc.Model/Blueprints/Blueprint.cs
@@ -5,9 +5,16 @@ using System.IO.Compression;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using Yafc.Model;
-using Yafc.UI;
 
 namespace Yafc.Blueprints;
+
+/// <summary>Specifies the serialisation format used when exporting a blueprint string.</summary>
+public enum BlueprintFormat {
+    /// <summary>Produces a compressed, Base64-encoded Factorio blueprint string (the default game format).</summary>
+    CompressedBase64,
+    /// <summary>Produces raw JSON without compression, useful for debugging or tooling.</summary>
+    RawJson,
+}
 
 [Serializable]
 public class BlueprintString(string blueprintName) {
@@ -15,8 +22,8 @@ public class BlueprintString(string blueprintName) {
     private static readonly byte[] header = [0x78, 0xDA];
     private static readonly JsonSerializerOptions jsonSerializerOptions = new() { DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull };
 
-    public string ToBpString() {
-        if (InputSystem.Instance.control) {
+    public string ToBpString(BlueprintFormat format = BlueprintFormat.CompressedBase64) {
+        if (format == BlueprintFormat.RawJson) {
             return ToJson();
         }
 

--- a/Yafc.Model/Blueprints/BlueprintUtilities.cs
+++ b/Yafc.Model/Blueprints/BlueprintUtilities.cs
@@ -7,7 +7,10 @@ using Yafc.Model;
 namespace Yafc.Blueprints;
 
 public static class BlueprintUtilities {
-    public static string ExportConstantCombinators(string name, IReadOnlyList<(IObjectWithQuality<Goods> item, int amount)> goods) {
+    public static string ExportConstantCombinators(
+        string name,
+        IReadOnlyList<(IObjectWithQuality<Goods> item, int amount)> goods,
+        BlueprintFormat format = BlueprintFormat.CompressedBase64) {
         int combinatorCount = ((goods.Count - 1) / Database.constantCombinatorCapacity) + 1;
         int offset = -combinatorCount / 2;
         BlueprintString blueprint = new BlueprintString(name);
@@ -37,10 +40,14 @@ public static class BlueprintUtilities {
             last = entity;
         }
 
-        return blueprint.ToBpString();
+        return blueprint.ToBpString(format);
     }
 
-    public static string ExportRequesterChests(string name, IReadOnlyList<(IObjectWithQuality<Item> item, int amount)> goods, EntityContainer chest) {
+    public static string ExportRequesterChests(
+        string name,
+        IReadOnlyList<(IObjectWithQuality<Item> item, int amount)> goods,
+        EntityContainer chest,
+        BlueprintFormat format = BlueprintFormat.CompressedBase64) {
         if (chest.logisticSlotsCount <= 0) {
             throw new ArgumentException("Chest does not have logistic slots");
         }
@@ -73,7 +80,7 @@ public static class BlueprintUtilities {
             }
         }
 
-        return blueprint.ToBpString();
+        return blueprint.ToBpString(format);
     }
 
     private class PlacedEntity {
@@ -94,7 +101,11 @@ public static class BlueprintUtilities {
         public List<PlacedEntity> Placements { get; set; } = new();
     }
 
-    public static string ExportRecipiesAsBlueprint(string name, IEnumerable<RecipeRow> recipies, bool includeFuel) {
+    public static string ExportRecipiesAsBlueprint(
+        string name,
+        IEnumerable<RecipeRow> recipies,
+        bool includeFuel,
+        BlueprintFormat format = BlueprintFormat.CompressedBase64) {
         // Sort buildings largest to smallest (by height then width) for better packing
         var entities = recipies
             .Where(r => r.entity is not null && r.recipe is not null)
@@ -185,6 +196,6 @@ public static class BlueprintUtilities {
             buildingIndex += 1;
         }
 
-        return blueprint.ToBpString();
+        return blueprint.ToBpString(format);
     }
 }

--- a/Yafc.Model/Model/Project.cs
+++ b/Yafc.Model/Model/Project.cs
@@ -185,6 +185,8 @@ public partial class Project : ModelObject {
     }
 
     public void Save(string fileName) {
+        undo.FlushPendingChanges();
+
         if (lastSavedVersion == projectVersion && fileName == attachedFileName) {
             return;
         }
@@ -205,7 +207,13 @@ public partial class Project : ModelObject {
     }
 
     public void PerformAutoSave() {
-        if (!string.IsNullOrWhiteSpace(attachedFileName) && lastAutoSavedVersion != projectVersion) {
+        if (string.IsNullOrWhiteSpace(attachedFileName)) {
+            return;
+        }
+
+        undo.FlushPendingChanges();
+
+        if (lastAutoSavedVersion != projectVersion) {
             autosaveIndex = (autosaveIndex % AutosaveRollingLimit) + 1;
             var fileName = GenerateAutosavePath(attachedFileName, autosaveIndex);
 

--- a/Yafc.Model/Model/Project.cs
+++ b/Yafc.Model/Model/Project.cs
@@ -35,7 +35,11 @@ public partial class Project : ModelObject {
 
     public event Action<bool>? saveStateChanged;
 
-    public Project() : base(new UndoSystem()) {
+    public Project() : this(new UndoSystem()) { }
+
+    internal Project(IUndoBatchScheduler scheduler) : this(new UndoSystem(scheduler)) { }
+
+    private Project(UndoSystem undo) : base(undo) {
         settings = new ProjectSettings(this);
         preferences = new ProjectPreferences(this);
         base.undo.versionChanged += () => saveStateChanged?.Invoke(unsavedChangesCount > 0);

--- a/Yafc.Model/Serialization/IUndoBatchScheduler.cs
+++ b/Yafc.Model/Serialization/IUndoBatchScheduler.cs
@@ -1,0 +1,20 @@
+﻿using System.Threading;
+
+namespace Yafc.Model;
+
+/// <summary>
+/// Defines the scheduling contract for committing undo batches. The host application provides an
+/// implementation that determines the appropriate moment to finalize a pending undo batch (e.g., when
+/// the user releases the mouse after a drag gesture). A default <see cref="ImmediateUndoBatchScheduler"/>
+/// is used in headless or test scenarios.
+/// </summary>
+public interface IUndoBatchScheduler {
+    /// <summary>
+    /// Schedules <paramref name="callback"/> to be invoked when the current interaction gesture is
+    /// complete. If no gesture is in progress the callback should be dispatched immediately or
+    /// asynchronously on the appropriate thread.
+    /// </summary>
+    /// <param name="callback">The callback to invoke once the gesture finishes.</param>
+    /// <param name="state">An opaque state object forwarded to <paramref name="callback"/>.</param>
+    void ScheduleOnGestureFinish(SendOrPostCallback callback, object state);
+}

--- a/Yafc.Model/Serialization/ImmediateUndoBatchScheduler.cs
+++ b/Yafc.Model/Serialization/ImmediateUndoBatchScheduler.cs
@@ -1,0 +1,13 @@
+﻿using System.Threading;
+
+namespace Yafc.Model;
+
+/// <summary>
+/// An <see cref="IUndoBatchScheduler"/> that invokes the callback synchronously and immediately,
+/// without waiting for any interaction gesture to finish. This implementation is suitable for
+/// headless execution, unit tests, and any context where no UI event loop is present.
+/// </summary>
+public sealed class ImmediateUndoBatchScheduler : IUndoBatchScheduler {
+    /// <inheritdoc />
+    public void ScheduleOnGestureFinish(SendOrPostCallback callback, object state) => callback(state);
+}

--- a/Yafc.Model/Serialization/ImmediateUndoBatchScheduler.cs
+++ b/Yafc.Model/Serialization/ImmediateUndoBatchScheduler.cs
@@ -1,13 +1,34 @@
-﻿using System.Threading;
+﻿using System.Collections.Generic;
+using System.Threading;
 
 namespace Yafc.Model;
 
 /// <summary>
-/// An <see cref="IUndoBatchScheduler"/> that invokes the callback synchronously and immediately,
-/// without waiting for any interaction gesture to finish. This implementation is suitable for
-/// headless execution, unit tests, and any context where no UI event loop is present.
+/// An <see cref="IUndoBatchScheduler"/> that queues callbacks until the owning
+/// <see cref="UndoSystem"/> reaches a headless flush point. This preserves the UI scheduler's
+/// post-mutation commit semantics without requiring a UI event loop.
 /// </summary>
 public sealed class ImmediateUndoBatchScheduler : IUndoBatchScheduler {
+    private readonly Queue<(SendOrPostCallback Callback, object State)> callbacks = [];
+    private bool isDraining;
+
     /// <inheritdoc />
-    public void ScheduleOnGestureFinish(SendOrPostCallback callback, object state) => callback(state);
+    public void ScheduleOnGestureFinish(SendOrPostCallback callback, object state) => callbacks.Enqueue((callback, state));
+
+    internal void RunPendingCallbacks() {
+        if (isDraining) {
+            return;
+        }
+
+        isDraining = true;
+        try {
+            while (callbacks.Count > 0) {
+                var (callback, state) = callbacks.Dequeue();
+                callback(state);
+            }
+        }
+        finally {
+            isDraining = false;
+        }
+    }
 }

--- a/Yafc.Model/Serialization/UndoSystem.cs
+++ b/Yafc.Model/Serialization/UndoSystem.cs
@@ -1,11 +1,28 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.IO;
-using Yafc.UI;
 
 namespace Yafc.Model;
 
 public class UndoSystem {
+    /// <summary>
+    /// Gets or sets the fallback scheduler used when <see cref="UndoSystem()" /> is called without
+    /// an explicit scheduler argument. Set this to a UI-aware implementation (e.g.
+    /// <c>GestureFinishUndoBatchScheduler</c>) before creating any <see cref="Project"/> instances
+    /// in an interactive session. Defaults to <see cref="ImmediateUndoBatchScheduler"/>.
+    /// </summary>
+    public static IUndoBatchScheduler DefaultScheduler { get; set; } = new ImmediateUndoBatchScheduler();
+
+    private readonly IUndoBatchScheduler _scheduler;
+
+    /// <summary>Initialises a new <see cref="UndoSystem"/> using <see cref="DefaultScheduler"/>.</summary>
+    public UndoSystem() : this(DefaultScheduler) { }
+
+    /// <summary>Initialises a new <see cref="UndoSystem"/> with an explicit <paramref name="scheduler"/>.</summary>
+    public UndoSystem(IUndoBatchScheduler scheduler) {
+        _scheduler = scheduler;
+    }
+
     public uint version { get; private set; } = 2;
     private bool undoBatchVisualOnly = true;
     private readonly List<UndoSnapshot> currentUndoBatch = [];
@@ -67,7 +84,7 @@ public class UndoSystem {
     }
 
     private void Schedule() {
-        InputSystem.Instance.DispatchOnGestureFinish(MakeUndoBatch, this);
+        _scheduler.ScheduleOnGestureFinish(MakeUndoBatch, this);
         scheduled = true;
     }
 

--- a/Yafc.Model/Serialization/UndoSystem.cs
+++ b/Yafc.Model/Serialization/UndoSystem.cs
@@ -20,7 +20,7 @@ public class UndoSystem {
 
     /// <summary>Initialises a new <see cref="UndoSystem"/> with an explicit <paramref name="scheduler"/>.</summary>
     public UndoSystem(IUndoBatchScheduler scheduler) {
-        _scheduler = scheduler;
+        _scheduler = scheduler ?? throw new ArgumentNullException(nameof(scheduler));
     }
 
     public uint version {
@@ -47,14 +47,13 @@ public class UndoSystem {
             throw new InvalidOperationException("Do not record an undo event while deserializing.");
         }
 
-        if (changedList.Count == 0) {
-            version++;
+        bool isFirstChangeInBatch = changedList.Count == 0;
 
-            if (!suspended && !scheduled) {
-                Schedule();
-            }
+        if (isFirstChangeInBatch) {
+            version++;
         }
 
+        bool shouldSchedule = isFirstChangeInBatch && !suspended && !scheduled;
         undoBatchVisualOnly &= visualOnly;
 
         if (target.objectVersion == version) {
@@ -65,38 +64,77 @@ public class UndoSystem {
         target.objectVersion = version;
 
         if (visualOnly && undo.Count > 0 && undo.Peek().Contains(target)) {
+            if (shouldSchedule) {
+                Schedule();
+            }
+
             return;
         }
 
         var builder = target.GetUndoBuilder();
         currentUndoBatch.Add(builder.MakeUndoSnapshot(target));
+
+        if (shouldSchedule) {
+            Schedule();
+        }
     }
 
     private static void MakeUndoBatch(object? state) {
         UndoSystem system = (UndoSystem)state!; // null-forgiving: Only called by the instance method Schedule, which passes its this.
-        system.scheduled = false;
-        bool visualOnly = system.undoBatchVisualOnly;
+        system.CommitUndoBatch();
+    }
 
-        for (int i = 0; i < system.changedList.Count; i++) {
-            system.changedList[i].ThisChanged(visualOnly);
+    private void CommitUndoBatch() {
+        scheduled = false;
+        bool visualOnly = undoBatchVisualOnly;
+
+        for (int i = 0; i < changedList.Count; i++) {
+            changedList[i].ThisChanged(visualOnly);
         }
 
-        system.changedList.Clear();
+        changedList.Clear();
 
-        if (system.currentUndoBatch.Count == 0) {
+        if (currentUndoBatch.Count == 0) {
             return;
         }
 
-        UndoBatch batch = new UndoBatch([.. system.currentUndoBatch], visualOnly);
-        system.undo.Push(batch);
-        system.undoBatchVisualOnly = true;
-        system.redo.Clear();
-        system.currentUndoBatch.Clear();
+        UndoBatch batch = new UndoBatch([.. currentUndoBatch], visualOnly);
+        undo.Push(batch);
+        undoBatchVisualOnly = true;
+        redo.Clear();
+        currentUndoBatch.Clear();
     }
 
     private void Schedule() {
-        _scheduler.ScheduleOnGestureFinish(MakeUndoBatch, this);
         scheduled = true;
+        _scheduler.ScheduleOnGestureFinish(MakeUndoBatch, this);
+    }
+
+    /// <summary>Commits the current pending undo batch immediately, if one exists.</summary>
+    public void FlushPendingChanges() {
+        if (changedList.Count == 0) {
+            return;
+        }
+
+        if (_scheduler is ImmediateUndoBatchScheduler immediateScheduler) {
+            immediateScheduler.RunPendingCallbacks();
+
+            if (changedList.Count == 0) {
+                return;
+            }
+        }
+
+        CommitUndoBatch();
+    }
+
+    internal void FlushPendingChangesIfImmediateScheduler() {
+        if (!suspended && _scheduler is ImmediateUndoBatchScheduler immediateScheduler) {
+            immediateScheduler.RunPendingCallbacks();
+
+            if (changedList.Count > 0) {
+                CommitUndoBatch();
+            }
+        }
     }
 
     public void Suspend() => suspended = true;
@@ -106,6 +144,7 @@ public class UndoSystem {
 
         if (!scheduled && changedList.Count > 0) {
             Schedule();
+            FlushPendingChangesIfImmediateScheduler();
         }
     }
 
@@ -115,9 +154,16 @@ public class UndoSystem {
         }
     }
 
-    public bool CanUndo => !(undo.Count == 0 || changedList.Count > 0);
+    public bool CanUndo {
+        get {
+            FlushPendingChangesIfImmediateScheduler();
+            return !(undo.Count == 0 || changedList.Count > 0);
+        }
+    }
 
     public void PerformRedo() {
+        FlushPendingChangesIfImmediateScheduler();
+
         if (redo.Count == 0 || changedList.Count > 0) {
             return;
         }
@@ -127,7 +173,10 @@ public class UndoSystem {
 
     public void RecordChange() => version++;
 
-    public bool HasChangesPending(ModelObject obj) => changedList.Contains(obj);
+    public bool HasChangesPending(ModelObject obj) {
+        FlushPendingChangesIfImmediateScheduler();
+        return changedList.Contains(obj);
+    }
 }
 internal readonly struct UndoSnapshot(ModelObject target, object?[]? managed, byte[]? unmanaged) {
     internal readonly ModelObject target = target;

--- a/Yafc.Model/Serialization/UndoSystem.cs
+++ b/Yafc.Model/Serialization/UndoSystem.cs
@@ -40,6 +40,7 @@ public class UndoSystem {
     private readonly Stack<UndoBatch> redo = new Stack<UndoBatch>();
     private bool suspended;
     private bool scheduled;
+    private uint scheduleGeneration;
     private uint _version = 2;
 
     internal void CreateUndoSnapshot(ModelObject target, bool visualOnly) {
@@ -80,7 +81,13 @@ public class UndoSystem {
     }
 
     private static void MakeUndoBatch(object? state) {
-        UndoSystem system = (UndoSystem)state!; // null-forgiving: Only called by the instance method Schedule, which passes its this.
+        ScheduledUndoBatch scheduledBatch = (ScheduledUndoBatch)state!; // null-forgiving: Only called by Schedule, which passes a state instance.
+        UndoSystem system = scheduledBatch.system;
+
+        if (scheduledBatch.generation != system.scheduleGeneration) {
+            return;
+        }
+
         system.CommitUndoBatch();
     }
 
@@ -107,7 +114,7 @@ public class UndoSystem {
 
     private void Schedule() {
         scheduled = true;
-        _scheduler.ScheduleOnGestureFinish(MakeUndoBatch, this);
+        _scheduler.ScheduleOnGestureFinish(MakeUndoBatch, new ScheduledUndoBatch(this, ++scheduleGeneration));
     }
 
     /// <summary>Commits the current pending undo batch immediately, if one exists.</summary>
@@ -124,6 +131,7 @@ public class UndoSystem {
             }
         }
 
+        scheduleGeneration++;
         CommitUndoBatch();
     }
 
@@ -132,9 +140,15 @@ public class UndoSystem {
             immediateScheduler.RunPendingCallbacks();
 
             if (changedList.Count > 0) {
+                scheduleGeneration++;
                 CommitUndoBatch();
             }
         }
+    }
+
+    private sealed class ScheduledUndoBatch(UndoSystem system, uint generation) {
+        public readonly UndoSystem system = system;
+        public readonly uint generation = generation;
     }
 
     public void Suspend() => suspended = true;

--- a/Yafc.Model/Serialization/UndoSystem.cs
+++ b/Yafc.Model/Serialization/UndoSystem.cs
@@ -16,12 +16,15 @@ public class UndoSystem {
     private readonly IUndoBatchScheduler _scheduler;
 
     /// <summary>Initialises a new <see cref="UndoSystem"/> using <see cref="DefaultScheduler"/>.</summary>
-    public UndoSystem() : this(DefaultScheduler) { }
+    public UndoSystem() : this(CreateDefaultScheduler()) { }
 
     /// <summary>Initialises a new <see cref="UndoSystem"/> with an explicit <paramref name="scheduler"/>.</summary>
     public UndoSystem(IUndoBatchScheduler scheduler) {
         _scheduler = scheduler ?? throw new ArgumentNullException(nameof(scheduler));
     }
+
+    private static IUndoBatchScheduler CreateDefaultScheduler()
+        => DefaultScheduler is ImmediateUndoBatchScheduler ? new ImmediateUndoBatchScheduler() : DefaultScheduler;
 
     public uint version {
         get => _version;

--- a/Yafc/GestureFinishUndoBatchScheduler.cs
+++ b/Yafc/GestureFinishUndoBatchScheduler.cs
@@ -1,0 +1,16 @@
+﻿using System.Threading;
+using Yafc.Model;
+using Yafc.UI;
+
+namespace Yafc;
+
+/// <summary>
+/// An <see cref="IUndoBatchScheduler"/> that delegates to <see cref="InputSystem.DispatchOnGestureFinish"/>.
+/// Undo batches are committed once the user releases the current mouse button (or immediately if no
+/// mouse button is being held). This implementation is appropriate for interactive UI sessions.
+/// </summary>
+internal sealed class GestureFinishUndoBatchScheduler : IUndoBatchScheduler {
+    /// <inheritdoc />
+    public void ScheduleOnGestureFinish(SendOrPostCallback callback, object state)
+        => InputSystem.Instance.DispatchOnGestureFinish(callback, state);
+}

--- a/Yafc/Program.cs
+++ b/Yafc/Program.cs
@@ -15,6 +15,11 @@ public static class Program {
     private static void Main(string[] args) {
         YafcLib.RegisterDefaultAnalysis();
 
+        // Wire up the UI-aware undo batch scheduler so that undo batches are committed on gesture-finish
+        // (mouse-up) rather than immediately. This must be set before any Project is loaded or created,
+        // including any that Ui.Start() might trigger during initialization.
+        UndoSystem.DefaultScheduler = new GestureFinishUndoBatchScheduler();
+
         try {
             Ui.Start();
         }

--- a/Yafc/Utils/BlueprintClipboardContext.cs
+++ b/Yafc/Utils/BlueprintClipboardContext.cs
@@ -1,0 +1,13 @@
+﻿using Yafc.Blueprints;
+using Yafc.UI;
+
+namespace Yafc;
+
+public static class BlueprintClipboardContext {
+    /// <summary>
+    /// Gets the blueprint format requested for clipboard export based on the current keyboard modifiers.
+    /// Hold Ctrl to export raw JSON; otherwise export compressed Base64.
+    /// </summary>
+    public static BlueprintFormat RequestedFormat
+        => InputSystem.Instance.control ? BlueprintFormat.RawJson : BlueprintFormat.CompressedBase64;
+}

--- a/Yafc/Windows/ShoppingListScreen.cs
+++ b/Yafc/Windows/ShoppingListScreen.cs
@@ -204,13 +204,19 @@ public class ShoppingListScreen : PseudoScreen {
         gui.BuildText(LSs.ShoppingListExportBlueprintHint, TextBlockDisplayStyle.WrappedText);
         if (Database.objectsByTypeName.TryGetValue("Entity.constant-combinator", out var combinator)
             && gui.BuildFactorioObjectButtonWithText(combinator) == Click.Left && gui.CloseDropdown()) {
-
-            _ = SDL.SDL_SetClipboardText(BlueprintUtilities.ExportConstantCombinators(LSs.ShoppingList, ExportGoods<Goods>()));
+            _ = SDL.SDL_SetClipboardText(BlueprintUtilities.ExportConstantCombinators(
+                LSs.ShoppingList,
+                ExportGoods<Goods>(),
+                format: BlueprintClipboardContext.RequestedFormat));
         }
 
         foreach (var container in Database.allContainers) {
             if (container.logisticMode == "requester" && gui.BuildFactorioObjectButtonWithText(container) == Click.Left && gui.CloseDropdown()) {
-                _ = SDL.SDL_SetClipboardText(BlueprintUtilities.ExportRequesterChests(LSs.ShoppingList, ExportGoods<Item>(), container));
+                _ = SDL.SDL_SetClipboardText(BlueprintUtilities.ExportRequesterChests(
+                    LSs.ShoppingList,
+                    ExportGoods<Item>(),
+                    container,
+                    format: BlueprintClipboardContext.RequestedFormat));
             }
         }
     }

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -322,8 +322,10 @@ goodsHaveNoProduction:;
 
                 goods.Add((flow.goods, rounded));
             }
-
-            _ = SDL.SDL_SetClipboardText(BlueprintUtilities.ExportConstantCombinators(view.projectPage!.name, goods)); // null-forgiving: An active view always has an active page.
+            _ = SDL.SDL_SetClipboardText(BlueprintUtilities.ExportConstantCombinators(
+                view.projectPage!.name, // null-forgiving: An active view always has an active page.
+                goods,
+                format: BlueprintClipboardContext.RequestedFormat));
         }
     }
 
@@ -597,7 +599,8 @@ goodsHaveNoProduction:;
                             }
 
                             BlueprintString bp = new BlueprintString(recipe.recipe.target.locName) { blueprint = { entities = { entity } } };
-                            _ = SDL.SDL_SetClipboardText(bp.ToBpString());
+                            BlueprintFormat bpFormat = BlueprintClipboardContext.RequestedFormat;
+                            _ = SDL.SDL_SetClipboardText(bp.ToBpString(bpFormat));
                         }
                     }
 
@@ -656,7 +659,11 @@ goodsHaveNoProduction:;
                     .GetRecipesRecursive()
                     .DistinctBy(row => (row.entity, row.recipe, includeFuel ? row.fuel : null));
 
-                _ = SDL.SDL_SetClipboardText(BlueprintUtilities.ExportRecipiesAsBlueprint(view.projectPage!.name, uniqueEntites, includeFuel));
+                _ = SDL.SDL_SetClipboardText(BlueprintUtilities.ExportRecipiesAsBlueprint(
+                    view.projectPage!.name, // null-forgiving: An active view always has an active page.
+                    uniqueEntites,
+                    includeFuel,
+                    format: BlueprintClipboardContext.RequestedFormat));
             }
         }
     }


### PR DESCRIPTION
Introduce `IUndoBatchScheduler` to decouple `UndoSystem` from `InputSystem.Instance.DispatchOnGestureFinish` logic:
- Add `IUndoBatchScheduler` and `ImmediateUndoBatchScheduler` for headless/test execution in the model layer.
- Add `GestureFinishUndoBatchScheduler` in the UI layer to wrap input system behavior.
- Use explicit dependency injection for the scheduler in `UndoSystem` and configure `UndoSystem.DefaultScheduler` during app startup in `Program.cs`.

Decouple hardware key state from `Blueprint.cs`:
- Introduce `BlueprintFormat` enum (`CompressedBase64`, `RawJson`) to make format intent explicit instead of checking `InputSystem.Instance.control`.
- Update `Blueprint.ToBpString()` and `BlueprintUtilities` to accept the `BlueprintFormat` parameter.
- Move UI evaluation (`InputSystem.Instance.control`) appropriately to UI callers (`ProductionTableView`, `ShoppingListScreen`) to drive intent.

Close #577 