### PR TITLE
build(i18n-gen): Fix Build in Git Worktree Folder

### DIFF
--- a/Yafc.I18n.Generator/SourceGenerator.cs
+++ b/Yafc.I18n.Generator/SourceGenerator.cs
@@ -7,10 +7,7 @@ internal partial class SourceGenerator {
 
     private static void Main() {
         // Find the solution root directory
-        string rootDirectory = Environment.CurrentDirectory;
-        while (!Directory.Exists(Path.Combine(rootDirectory, ".git"))) {
-            rootDirectory = Path.GetDirectoryName(rootDirectory)!;
-        }
+        string rootDirectory = FindSolutionRootDirectory(Environment.CurrentDirectory);
         Environment.CurrentDirectory = rootDirectory;
 
         HashSet<string> keys = [];
@@ -156,6 +153,19 @@ internal partial class SourceGenerator {
         if (!File.Exists(filePath) || File.ReadAllText(filePath) != new StreamReader(newContent, leaveOpen: true).ReadToEnd()) {
             File.WriteAllBytes(filePath, newContent.ToArray());
         }
+    }
+
+    private static string FindSolutionRootDirectory(string startDirectory) {
+        DirectoryInfo? current = new(startDirectory);
+        while (current is not null) {
+            string dotGitPath = Path.Combine(current.FullName, ".git");
+            if (Directory.Exists(dotGitPath) || File.Exists(dotGitPath) || File.Exists(Path.Combine(current.FullName, "FactorioCalc.sln"))) {
+                return current.FullName;
+            }
+            current = current.Parent;
+        }
+
+        throw new DirectoryNotFoundException($"Could not locate repository root from '{startDirectory}'.");
     }
 
     [GeneratedRegex("__(\\d+)__")]

--- a/Yafc.I18n.Generator/Yafc.I18n.Generator.csproj
+++ b/Yafc.I18n.Generator/Yafc.I18n.Generator.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <Target Name="PostBuild" AfterTargets="PostBuildEvent">
-    <Exec Command="dotnet $(OutputPath)/Yafc.I18n.Generator.dll&#xD;&#xA;" />
+    <Exec Command="dotnet &quot;$(TargetPath)&quot;" WorkingDirectory="$(MSBuildProjectDirectory)" />
   </Target>
 
   <ItemGroup>


### PR DESCRIPTION
Fix build failure when `.git` is not a directory

The build fails with `MSB3073` error when the repository is checked out as a submodule or in a worktree, as `Yafc.I18n.Generator` expects a `.git` directory to locate the root.

Changes:

1. Robust Root Discovery: Updated `SourceGenerator.cs` to handle both `.git` files and directories, adding `.sln` as a fallback.
2. Improved Build Task: Refined the PostBuild command in `.csproj` to use quoted `$(TargetPath)` and explicit WorkingDirectory for reliability on Windows.

Verified `dotnet build` now passes in both standard and non-standard Git environments.