### PR TITLE
refactor(model): Decouple DependencyNode From UI and Improve API Safety

### DIFF
--- a/Yafc.Model.Tests/Analysis/DependencyNodeTests.cs
+++ b/Yafc.Model.Tests/Analysis/DependencyNodeTests.cs
@@ -1,0 +1,41 @@
+﻿using System.Linq;
+using Xunit;
+
+namespace Yafc.Model.Tests;
+
+/// <summary>
+/// Tests for the <see cref="DependencyNode"/> type hierarchy.
+/// </summary>
+public class DependencyNodeTests {
+    /// <summary>
+    /// Guards against adding a new <see cref="DependencyNode"/> concrete subtype without updating
+    /// <c>DependencyNodeDrawExtensions.Draw</c> in <c>Yafc/Windows/DependencyNodeDrawExtensions.cs</c>.
+    /// <para>
+    /// If this test fails, a matching <c>case</c> MUST be added to the <c>switch</c> statement
+    /// in <c>DependencyNodeDrawExtensions.Draw</c>; otherwise an <see cref="System.Diagnostics.UnreachableException"/>
+    /// will be thrown at runtime when the new subtype is rendered.
+    /// </para>
+    /// </summary>
+    [Fact]
+    public void DependencyNode_ConcreteSubtypeCount_MatchesKnownHandledTypes() {
+        // Scan the entire assembly (not just direct nested types) to catch any deeply nested
+        // or non-nested concrete subtypes that would miss the depth-1 GetNestedTypes search.
+        // NOTE: This test guards only the model-layer type inventory. It cannot verify that
+        // DependencyNodeDrawExtensions.Draw (Yafc project) handles every subtype: a developer
+        // can satisfy this test by bumping the expected count without touching Draw, which would
+        // compile successfully but throw UnreachableException at runtime on the first render.
+        // The UnreachableException default branch in Draw() is the runtime safety net.
+        var concreteSubtypes = typeof(DependencyNode).Assembly
+            .GetTypes()
+            .Where(t => t.IsSealed && t.IsSubclassOf(typeof(DependencyNode)))
+            .ToList();
+
+        // If this assertion fails, add or remove a corresponding 'case' in
+        // DependencyNodeDrawExtensions.Draw (Yafc/Windows/DependencyNodeDrawExtensions.cs)
+        // and update this expected count.
+        Assert.Equal(3, concreteSubtypes.Count);
+        Assert.Contains(typeof(DependencyNode.AndNode), concreteSubtypes);
+        Assert.Contains(typeof(DependencyNode.OrNode), concreteSubtypes);
+        Assert.Contains(typeof(DependencyNode.ListNode), concreteSubtypes);
+    }
+}

--- a/Yafc.Model/Analysis/DependencyNode.cs
+++ b/Yafc.Model/Analysis/DependencyNode.cs
@@ -2,9 +2,6 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using System.Numerics;
-using Yafc.I18n;
-using Yafc.UI;
 
 namespace Yafc.Model;
 
@@ -34,13 +31,13 @@ public abstract class DependencyNode {
         Location = 11 | OneTimeInvestment,
     }
 
-    private DependencyNode() { } // All derived classes should be nested classes
+    private DependencyNode() { } // Enforces that all concrete subtypes must be nested classes in this file.
 
     /// <summary>
     /// Creates a <see cref="DependencyNode"/> from a list of dependencies. <paramref name="flags"/> contains the require-any/-all
     /// behavior and information about how the dependencies should be described. (e.g. "Crafter", "Ingredient", etc.)
     /// </summary>
-    public static DependencyNode Create(IEnumerable<FactorioObject> elements, Flags flags) => new ListNode(elements, flags);
+    public static DependencyNode Create(IEnumerable<FactorioObject> elements, Flags flags) => ListNode.CreateFromObjects(elements, flags);
 
     /// <summary>
     /// Creates a <see cref="DependencyNode"/> that is satisfied if all of its child nodes are satisfied.
@@ -105,19 +102,21 @@ public abstract class DependencyNode {
     internal abstract AutomationStatus IsAutomatable(Func<FactorioId, AutomationStatus> isAutomatable, AutomationStatus automationState);
 
     /// <summary>
-    /// Instructs this dependency tree to draw itself on the specified <see cref="ImGui"/>.
-    /// </summary>
-    /// <param name="gui">The drawing destination.</param>
-    /// <param name="builder">A delegate that will draw the passed dependency information onto the passed <see cref="ImGui"/>.</param>
-    public abstract void Draw(ImGui gui, Action<ImGui, IReadOnlyList<FactorioId>, Flags> builder);
-
-    /// <summary>
     /// A <see cref="DependencyNode"/> that requires all of its children.
     /// </summary>
-    private sealed class AndNode : DependencyNode {
+    public sealed class AndNode : DependencyNode {
         private readonly DependencyNode[] dependencies;
 
-        private AndNode(DependencyNode[] dependencies) => this.dependencies = dependencies; // Use Create
+        /// <summary>Gets the child nodes that must all be satisfied.
+        /// Always contains at least two elements; single-element inputs are normalized to the child itself by the factory method.</summary>
+        public IReadOnlyList<DependencyNode> Children => dependencies;
+
+        // Do not call directly; use AndNode.Create(IEnumerable<DependencyNode>) to ensure
+        // nested AndNodes are flattened and duplicates are removed.
+        private AndNode(DependencyNode[] dependencies) {
+            System.Diagnostics.Debug.Assert(dependencies.Length >= 2, "AndNode must have at least two children; use Create() which enforces this invariant.");
+            this.dependencies = dependencies;
+        }
 
         /// <summary>
         /// Returns a <see cref="DependencyNode"/> that requires all of the children specified in <paramref name="dependencies"/>.
@@ -133,13 +132,16 @@ public abstract class DependencyNode {
                     realDependencies.Add(item);
                 }
             }
+            // Distinct() uses reference equality; structural equality is not implemented, so only
+            // the exact same DependencyNode instance will be deduplicated here.
             realDependencies = [.. realDependencies.Distinct()];
 
             if (realDependencies.Count == 0) {
-                throw new ArgumentException($"Must not join zero nodes with an 'and'. Instead, create an empty DependencyList to explain what expected dependencies are missing.");
+                throw new ArgumentException("Must not join zero nodes with an 'and'. Instead, create an empty DependencyList to explain what expected dependencies are missing.", nameof(dependencies));
             }
 
-            // Prevent single-child nodes, so the drawing and preceding unpacking code doesn't have to handle that.
+            // A single-child And node is semantically equivalent to the child itself;
+            // return it directly to keep the tree normalized and avoid redundant nesting.
             if (realDependencies.Count == 1) {
                 return realDependencies[0];
             }
@@ -168,26 +170,24 @@ public abstract class DependencyNode {
         }
         internal override AutomationStatus IsAutomatable(Func<FactorioId, AutomationStatus> isAutomatable, AutomationStatus automationState)
             => dependencies.Min(d => d.IsAutomatable(isAutomatable, automationState));
-
-        public override void Draw(ImGui gui, Action<ImGui, IReadOnlyList<FactorioId>, Flags> builder) {
-            bool previousChildWasOr = false;
-            foreach (DependencyNode dependency in dependencies) {
-                if (dependency is OrNode && previousChildWasOr) {
-                    gui.AllocateSpacing(.5f);
-                }
-                dependency.Draw(gui, builder);
-                previousChildWasOr = dependency is OrNode;
-            }
-        }
     }
 
     /// <summary>
     /// A <see cref="DependencyNode"/> that requires at least one of its children.
     /// </summary>
-    private sealed class OrNode : DependencyNode {
+    public sealed class OrNode : DependencyNode {
         private readonly DependencyNode[] dependencies;
 
-        private OrNode(DependencyNode[] dependencies) => this.dependencies = dependencies; // Use Create
+        /// <summary>Gets the child nodes of which at least one must be satisfied.
+        /// Always contains at least two elements; single-element inputs are normalized to the child itself by the factory method.</summary>
+        public IReadOnlyList<DependencyNode> Children => dependencies;
+
+        // Do not call directly; use OrNode.Create(IEnumerable<DependencyNode>) to ensure
+        // nested OrNodes are flattened and duplicates are removed.
+        private OrNode(DependencyNode[] dependencies) {
+            System.Diagnostics.Debug.Assert(dependencies.Length >= 2, "OrNode must have at least two children; use Create() which enforces this invariant.");
+            this.dependencies = dependencies;
+        }
 
         /// <summary>
         /// Returns a <see cref="DependencyNode"/> that requires at least one of the children specified in <paramref name="dependencies"/>.
@@ -203,13 +203,16 @@ public abstract class DependencyNode {
                     realDependencies.Add(item);
                 }
             }
+            // Distinct() uses reference equality; structural equality is not implemented, so only
+            // the exact same DependencyNode instance will be deduplicated here.
             realDependencies = [.. realDependencies.Distinct()];
 
             if (realDependencies.Count == 0) {
-                throw new ArgumentException($"Must not join zero nodes with an 'or'. Instead, create an empty DependencyList to explain what expected dependencies are missing.");
+                throw new ArgumentException("Must not join zero nodes with an 'or'. Instead, create an empty DependencyList to explain what expected dependencies are missing.", nameof(dependencies));
             }
 
-            // Prevent single-child nodes, so the drawing and preceding unpacking code doesn't have to handle that.
+            // A single-child Or node is semantically equivalent to the child itself;
+            // return it directly to keep the tree normalized and avoid redundant nesting.
             if (realDependencies.Count == 1) {
                 return realDependencies[0];
             }
@@ -223,32 +226,32 @@ public abstract class DependencyNode {
         internal override Bits AggregateBits(Func<FactorioId, Bits> getBits) => dependencies.Min(d => d.AggregateBits(getBits));
         internal override AutomationStatus IsAutomatable(Func<FactorioId, AutomationStatus> isAutomatable, AutomationStatus automationState)
             => dependencies.Max(d => d.IsAutomatable(isAutomatable, automationState));
-
-        public override void Draw(ImGui gui, Action<ImGui, IReadOnlyList<FactorioId>, Flags> builder) {
-            Vector2 offset = new(.4f, 0);
-            using (gui.EnterGroup(new(1f, 0, 0, 0))) {
-                bool isFirst = true;
-                foreach (var dependency in dependencies) {
-                    if (!isFirst) {
-                        using (gui.EnterGroup(new(1, .25f))) {
-                            gui.BuildText(LSs.DependencyOrBar, Font.productionTableHeader);
-                        }
-                        gui.DrawRectangle(gui.lastRect - offset, SchemeColor.GreyAlt);
-                    }
-                    isFirst = false;
-                    dependency.Draw(gui, builder);
-                }
-            }
-            gui.DrawRectangle(gui.lastRect.LeftPart(.2f) + offset, SchemeColor.GreyAlt);
-        }
     }
 
     /// <summary>
     /// A <see cref="DependencyNode"/> that matches the behavior of a legacy <see cref="DependencyList"/>.
     /// </summary>
-    /// <param name="dependencies">The <see cref="DependencyList"/> whose behavior should be matched by this <see cref="ListNode"/>.</param>
-    private sealed class ListNode(IEnumerable<FactorioObject> elements, Flags flags) : DependencyNode {
-        private readonly ReadOnlyCollection<FactorioId> elements = elements.Select(e => e.id).Distinct().ToList().AsReadOnly();
+    public sealed class ListNode : DependencyNode {
+        private readonly ReadOnlyCollection<FactorioId> elements;
+        private readonly Flags flags;
+
+        /// <summary>Gets the <see cref="FactorioId"/>s of the dependency objects in this list.
+        /// Duplicate IDs are guaranteed to have been removed.</summary>
+        public IReadOnlyList<FactorioId> Elements => elements;
+
+        /// <summary>Gets the <see cref="Flags"/> that describe the require-any/-all behavior and how to describe the dependencies.</summary>
+        public Flags NodeFlags => flags;
+
+        // Do not call directly; use DependencyNode.Create() or the implicit conversion operator.
+        // This internal factory delegates instantiation so the constructor can remain private
+        // (consistent with AndNode/OrNode, enforcing that creation occurs via factory methods),
+        // since C# outer classes cannot directly access private constructors of nested types.
+        internal static ListNode CreateFromObjects(IEnumerable<FactorioObject> elements, Flags flags) => new ListNode(elements, flags);
+
+        private ListNode(IEnumerable<FactorioObject> elements, Flags flags) {
+            this.elements = elements.Select(e => e.id).Distinct().ToList().AsReadOnly();
+            this.flags = flags;
+        }
 
         internal override IEnumerable<FactorioId> Flatten() => elements;
 
@@ -290,8 +293,9 @@ public abstract class DependencyNode {
             if (!flags.HasFlags(Flags.OneTimeInvestment)) {
                 if (flags.HasFlags(Flags.RequireEverything)) {
                     foreach (FactorioId element in elements) {
-                        if (getAutomation(element) < automationState) {
-                            automationState = getAutomation(element);
+                        AutomationStatus status = getAutomation(element);
+                        if (status < automationState) {
+                            automationState = status;
                         }
                     }
                 }
@@ -299,8 +303,9 @@ public abstract class DependencyNode {
                     AutomationStatus localHighest = AutomationStatus.NotAutomatable;
 
                     foreach (FactorioId element in elements) {
-                        if (getAutomation(element) > localHighest) {
-                            localHighest = getAutomation(element);
+                        AutomationStatus status = getAutomation(element);
+                        if (status > localHighest) {
+                            localHighest = status;
                         }
                     }
 
@@ -327,7 +332,6 @@ public abstract class DependencyNode {
             return automationState;
         }
 
-        public override void Draw(ImGui gui, Action<ImGui, IReadOnlyList<FactorioId>, Flags> builder) => builder(gui, elements, flags);
     }
 
     public static implicit operator DependencyNode((IEnumerable<FactorioObject> elements, Flags flags) value)

--- a/Yafc/Windows/DependencyNodeDrawExtensions.cs
+++ b/Yafc/Windows/DependencyNodeDrawExtensions.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.Numerics;
+using Yafc.I18n;
+using Yafc.Model;
+using Yafc.UI;
+
+namespace Yafc;
+
+/// <summary>
+/// Extension methods for rendering a <see cref="DependencyNode"/> dependency tree using ImGui.
+/// Keeps all UI/rendering logic out of the domain model layer.
+/// </summary>
+internal static class DependencyNodeDrawExtensions {
+    /// <summary>
+    /// Draws the dependency tree rooted at <paramref name="node"/> onto <paramref name="gui"/>.
+    /// Uses C# type pattern matching against the public sealed node types to dispatch
+    /// rendering without coupling the domain model to any UI library.
+    /// </summary>
+    /// <param name="node">The root of the dependency (sub-)tree to draw.</param>
+    /// <param name="gui">The drawing destination.</param>
+    /// <param name="builder">A delegate that will draw the passed dependency information onto the passed <see cref="ImGui"/>.</param>
+    internal static void Draw(this DependencyNode node, ImGui gui, Action<ImGui, IReadOnlyList<FactorioId>, DependencyNode.Flags> builder) {
+        ArgumentNullException.ThrowIfNull(node);
+        ArgumentNullException.ThrowIfNull(gui);
+        ArgumentNullException.ThrowIfNull(builder);
+        switch (node) {
+            case DependencyNode.AndNode andNode:
+                bool previousChildWasOr = false;
+                foreach (DependencyNode dependency in andNode.Children) {
+                    // Add visual spacing between two consecutive OrNode blocks so they are
+                    // visually separated.
+                    if (dependency is DependencyNode.OrNode && previousChildWasOr) {
+                        gui.AllocateSpacing(.5f);
+                    }
+                    dependency.Draw(gui, builder);
+                    previousChildWasOr = dependency is DependencyNode.OrNode;
+                }
+                break;
+
+            case DependencyNode.OrNode orNode:
+                Vector2 offset = new(.4f, 0);
+                using (gui.EnterGroup(new(1f, 0, 0, 0))) {
+                    bool isFirst = true;
+                    foreach (DependencyNode dependency in orNode.Children) {
+                        if (!isFirst) {
+                            using (gui.EnterGroup(new(1, .25f))) {
+                                gui.BuildText(LSs.DependencyOrBar, Font.productionTableHeader);
+                            }
+                            gui.DrawRectangle(gui.lastRect - offset, SchemeColor.GreyAlt);
+                        }
+                        isFirst = false;
+                        dependency.Draw(gui, builder);
+                    }
+                }
+                // NOTE: relies on EnterGroup.Dispose() updating gui.lastRect to the group's
+                // allocated rect before returning. This contract was present in the original
+                // OrNode.Draw implementation and is preserved here verbatim.
+                gui.DrawRectangle(gui.lastRect.LeftPart(.2f) + offset, SchemeColor.GreyAlt);
+                break;
+
+            case DependencyNode.ListNode listNode:
+                builder(gui, listNode.Elements, listNode.NodeFlags);
+                break;
+
+            // NOTE: If a new DependencyNode concrete subtype is added to DependencyNode.cs,
+            // a corresponding case MUST be added here. The private base constructor prevents
+            // external subclassing; any internal addition will cause this exception to be
+            // thrown at runtime and should be caught immediately by integration tests.
+            default:
+                throw new UnreachableException($"Unknown DependencyNode subtype: {node.GetType()}");
+        }
+    }
+}


### PR DESCRIPTION
Remove ImGui dependencies from `DependencyNode` by moving all rendering logic
into a new `DependencyNodeDrawExtensions` class in the UI layer. This
eliminates coupling to `System.Numerics`, `Yafc.I18n`, and `Yafc.UI` in the
domain model, allowing it to be tested and consumed headlessly.

To support this decoupling without adding Visitor boilerplate, the nested node
types (`AndNode`, `OrNode`, `ListNode`) have been made `public sealed`. Their
constructors are strictly encapsulated behind internal static factory methods
to preserve the closed-hierarchy invariant, meaning external code can inspect
the tree via pattern matching but cannot mutate or construct arbitrary nodes.

Additional improvements included in this refactor:
- Add guard clauses and design-by-contract assertions to tree constructors to
  prevent silent misuse (e.g., rejecting empty `AndNode`/`OrNode`s explicitly).
- Automatically simplify single-element `AndNode`/`OrNode` inputs by returning
  the child directly, reducing redundant tree depth.
- Fix an existing bug where `ListNode.IsAutomatable` double-called the delegate
  instead of reading a cached value.
- Add an exhaustive test (`DependencyNode_ConcreteSubtypeCount_MatchesKnownHandledTypes`)
  to ensure the domain layer's known concrete subtypes remain correctly tracked.

Close #580 