### PR TITLE
refactor: Decouple UI Focus State From Domain Models

### DIFF
--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -592,35 +592,6 @@ public sealed class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<Pr
         }
     }
 
-    private SetKeyboardFocus _focusBuiltCount, _focusFixedCount;
-
-    /// <summary>
-    /// Returns <see cref="SetKeyboardFocus.Always"/> exactly once after each call to <see cref="FocusBuiltCountOnNextDraw"/>, to focus the newly created edit box on that draw cycle.
-    /// </summary>
-    public SetKeyboardFocus ShouldFocusBuiltCountThisTime() {
-        SetKeyboardFocus result = _focusBuiltCount;
-        _focusBuiltCount = SetKeyboardFocus.No;
-        return result;
-    }
-    /// <summary>
-    /// Call when preparing to add a built building count edit box, so the new box will be focused as part of the next draw loop.
-    /// </summary>
-    public void FocusBuiltCountOnNextDraw() => _focusBuiltCount = SetKeyboardFocus.Always;
-
-    /// <summary>
-    /// Returns <see cref="SetKeyboardFocus.Always"/> exactly once after each call to <see cref="FocusFixedCountOnNextDraw"/>, to focus the newly created edit box on that draw cycle.
-    /// </summary>
-    public SetKeyboardFocus ShouldFocusFixedCountThisTime() {
-        SetKeyboardFocus result = _focusFixedCount;
-        _focusFixedCount = SetKeyboardFocus.No;
-        return result;
-    }
-    /// <summary>
-    /// Call when preparing to add or move a fixed count edit box (building, fuel, ingredient, or product), so the new box will be focused as part of the next draw loop.
-    /// </summary>
-    public void FocusFixedCountOnNextDraw() => _focusFixedCount = SetKeyboardFocus.Always;
-
-
     // Computed variables
     internal RecipeParameters parameters { get; set; } = RecipeParameters.Empty;
     public double recipesPerSecond { get; internal set; }

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -12,6 +12,12 @@ namespace Yafc;
 
 public class ProductionTableView : ProjectPageView<ProductionTable> {
     private readonly FlatHierarchy<RecipeRow, ProductionTable> flatHierarchyBuilder;
+    private readonly RecipeRowFocusManager _focusManager = new();
+
+    public override void SetModel(ProjectPage? page) {
+        _focusManager.Clear();
+        base.SetModel(page);
+    }
 
     public ProductionTableView() {
         DataGrid<RecipeRow> grid = new DataGrid<RecipeRow>(new RecipePadColumn(this), new RecipeColumn(this), new EntityColumn(this),
@@ -165,10 +171,12 @@ public class ProductionTableView : ProjectPageView<ProductionTable> {
                         }
 
                         if (recipe.subgroup != null && imgui.BuildRedButton(LSs.ProductionTableDeleteNested).WithTooltip(imgui, recipe.subgroup.expanded ? LSs.ProductionTableShortcutCollapseAndRightClick : LSs.ProductionTableShortcutRightClick) && imgui.CloseDropdown()) {
+                            view._focusManager.CancelFocus(recipe);
                             _ = recipe.owner.RecordUndo().recipes.Remove(recipe);
                         }
 
                         if (recipe.subgroup == null && imgui.BuildRedButton(LSs.ProductionTableDeleteRecipe).WithTooltip(imgui, LSs.ProductionTableShortcutRightClick) && imgui.CloseDropdown()) {
+                            view._focusManager.CancelFocus(recipe);
                             _ = recipe.owner.RecordUndo().recipes.Remove(recipe);
                         }
                     });
@@ -177,6 +185,7 @@ public class ProductionTableView : ProjectPageView<ProductionTable> {
                     unpackNestedTable();
                     break;
                 case Click.Right: // With collapsed or no subgroup
+                    view._focusManager.CancelFocus(recipe);
                     _ = recipe.owner.RecordUndo().recipes.Remove(recipe);
                     break;
             }
@@ -242,6 +251,7 @@ public class ProductionTableView : ProjectPageView<ProductionTable> {
             }
 
             if (gui.BuildRedButton(LSs.ProductionTableClearRecipes) && gui.CloseDropdown()) {
+                view._focusManager.Clear();
                 view.model.RecordUndo().recipes.Clear();
             }
 
@@ -339,7 +349,7 @@ goodsHaveNoProduction:;
                 if (recipe is { fixedBuildings: > 0, fixedFuel: false, fixedIngredient: null, fixedProduct: null, hierarchyEnabled: true }) {
                     DisplayAmount amount = recipe.fixedBuildings;
                     GoodsWithAmountEvent evt = gui.BuildFactorioObjectWithEditableAmount(recipe.entity, amount, ButtonDisplayStyle.ProductionTableUnscaled,
-                        setKeyboardFocus: recipe.ShouldFocusFixedCountThisTime());
+                        setKeyboardFocus: view._focusManager.ConsumeFocus(recipe, RecipeRowFocusTarget.FixedCount));
 
                     if (evt == GoodsWithAmountEvent.TextEditing && amount.Value >= 0) {
                         recipe.RecordUndo().fixedBuildings = amount.Value;
@@ -354,7 +364,7 @@ goodsHaveNoProduction:;
                 if (recipe.builtBuildings != null) {
                     DisplayAmount amount = recipe.builtBuildings.Value;
 
-                    if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.FactorioObjectInput with { ColorGroup = SchemeColorGroup.Grey }, recipe.ShouldFocusBuiltCountThisTime())
+                    if (gui.BuildFloatInput(amount, TextBoxDisplayStyle.FactorioObjectInput with { ColorGroup = SchemeColorGroup.Grey }, view._focusManager.ConsumeFocus(recipe, RecipeRowFocusTarget.BuiltCount))
                         && amount.Value >= 0) {
 
                         recipe.RecordUndo().builtBuildings = (int)amount.Value;
@@ -366,7 +376,7 @@ goodsHaveNoProduction:;
                 // ignore all clicks
             }
             else if (click == Click.Left) {
-                ShowEntityDropdown(gui, recipe);
+                ShowEntityDropdown(gui, recipe, view._focusManager);
             }
             else if (click == Click.Right) {
                 // null-forgiving: We know recipe.recipe.crafters is not empty, so AutoSelect can't return null.
@@ -477,7 +487,7 @@ goodsHaveNoProduction:;
             string extraText(EntityAccumulator x) => DataUtils.FormatAmount(x.AccumulatorCapacity(accumulatorQuality), UnitOfMeasure.Megajoule);
         }
 
-        private static void ShowEntityDropdown(ImGui gui, RecipeRow recipe) {
+        private static void ShowEntityDropdown(ImGui gui, RecipeRow recipe, RecipeRowFocusManager focusManager) {
             Quality quality = recipe.entity?.quality ?? Quality.Normal;
 
             QualitySelectOptions<EntityCrafter> options = null!;
@@ -539,7 +549,7 @@ goodsHaveNoProduction:;
                             recipe.fixedFuel = false;
                             recipe.fixedIngredient = null;
                             recipe.fixedProduct = null;
-                            recipe.FocusFixedCountOnNextDraw();
+                            focusManager.RequestFocus(recipe, RecipeRowFocusTarget.FixedCount);
                         }
                     }
                 }
@@ -560,7 +570,7 @@ goodsHaveNoProduction:;
                     }
                     else if (gui.BuildButton(LSs.ProductionTableSetBuiltBuildingCount) && gui.CloseDropdown()) {
                         recipe.RecordUndo().builtBuildings = Math.Max(0, Convert.ToInt32(Math.Ceiling(recipe.buildingCount)));
-                        recipe.FocusBuiltCountOnNextDraw();
+                        focusManager.RequestFocus(recipe, RecipeRowFocusTarget.BuiltCount);
                     }
                 }
 
@@ -1205,7 +1215,7 @@ goodsHaveNoProduction:;
                                 default:
                                     break;
                             }
-                            recipe.FocusFixedCountOnNextDraw();
+                            _focusManager.RequestFocus(recipe, RecipeRowFocusTarget.FixedCount);
                             targetGui.Rebuild();
                         }
                     }
@@ -1351,7 +1361,7 @@ goodsHaveNoProduction:;
             || (dropdownType == ProductDropdownType.Product && recipe.fixedProduct == goods))) {
 
             evt = gui.BuildFactorioObjectWithEditableAmount(goods, displayAmount, ButtonDisplayStyle.ProductionTableScaled(iconColor, drawTransparent), tooltipOptions: tooltipOptions,
-                setKeyboardFocus: recipe.ShouldFocusFixedCountThisTime());
+                setKeyboardFocus: _focusManager.ConsumeFocus(recipe, RecipeRowFocusTarget.FixedCount));
         }
         else {
             evt = (GoodsWithAmountEvent)gui.BuildFactorioObjectWithAmount(goods, displayAmount, ButtonDisplayStyle.ProductionTableScaled(iconColor, drawTransparent),

--- a/Yafc/Workspace/ProductionTable/RecipeRowFocusManager.cs
+++ b/Yafc/Workspace/ProductionTable/RecipeRowFocusManager.cs
@@ -1,0 +1,75 @@
+﻿using Yafc.Model;
+using Yafc.UI;
+
+namespace Yafc;
+
+/// <summary>
+/// The target element within a <see cref="RecipeRow"/> that should receive keyboard focus.
+/// </summary>
+internal enum RecipeRowFocusTarget {
+    BuiltCount,
+    FixedCount,
+}
+
+/// <summary>
+/// Manages transient keyboard focus requests for <see cref="RecipeRow"/> UI elements,
+/// keeping UI focus state out of the domain model.
+/// </summary>
+internal sealed class RecipeRowFocusManager {
+    private (RecipeRow Row, RecipeRowFocusTarget Target)? _pending;
+
+    /// <summary>
+    /// Requests that the specified element on <paramref name="row"/> receives keyboard focus on its next draw.
+    /// </summary>
+    /// <param name="row">The recipe row whose UI element should receive focus.</param>
+    /// <param name="target">Which focusable element within <paramref name="row"/> should receive focus.</param>
+    /// <remarks>
+    /// Only one pending request is retained at a time. Calling this again before the previous request is
+    /// consumed (via <see cref="ConsumeFocus"/>) will silently overwrite the earlier request. This is safe
+    /// under the assumption that at most one focus request is issued per user gesture per frame.
+    /// Call <see cref="CancelFocus"/> when a row is removed from the table to release the stored reference
+    /// immediately; otherwise the stale request will be silently overwritten on the next call to
+    /// <see cref="RequestFocus"/>.
+    /// </remarks>
+    public void RequestFocus(RecipeRow row, RecipeRowFocusTarget target) {
+        _pending = (row, target);
+    }
+
+    /// <summary>
+    /// Cancels any pending focus request for <paramref name="row"/>, releasing the stored reference.
+    /// Has no effect if <paramref name="row"/> has no pending request.
+    /// </summary>
+    /// <remarks>
+    /// Not calling this when removing a row is safe: the stale request will be silently overwritten by the
+    /// next <see cref="RequestFocus"/> call. However, calling it explicitly releases the reference to the
+    /// removed row immediately, preventing it from being retained in <c>_pending</c> until then.
+    /// </remarks>
+    public void CancelFocus(RecipeRow row) {
+        if (_pending is { Row: var pendingRow } && ReferenceEquals(pendingRow, row)) {
+            _pending = null;
+        }
+    }
+
+    /// <summary>
+    /// Cancels any pending focus request, releasing the stored reference.
+    /// Should be called when the owning view switches its model (e.g. on tab switch) to prevent a stale
+    /// request from being consumed the next time the former model is displayed.
+    /// </summary>
+    public void Clear() => _pending = null;
+
+    /// <summary>
+    /// If <paramref name="row"/> has a pending focus request for <paramref name="target"/>,
+    /// consumes and returns <see cref="SetKeyboardFocus.Always"/>; otherwise returns <see cref="SetKeyboardFocus.No"/>.
+    /// </summary>
+    /// <param name="row">The recipe row to check.</param>
+    /// <param name="target">Which focusable element within <paramref name="row"/> to check.</param>
+    public SetKeyboardFocus ConsumeFocus(RecipeRow row, RecipeRowFocusTarget target) {
+        if (_pending is { Row: var pendingRow, Target: var pendingTarget }
+            && pendingTarget == target && ReferenceEquals(pendingRow, row)) {
+            _pending = null;
+            return SetKeyboardFocus.Always;
+        }
+
+        return SetKeyboardFocus.No;
+    }
+}


### PR DESCRIPTION
Move _focusBuiltCount/_focusFixedCount fields and the four focus methods (FocusXxxOnNextDraw / ShouldFocusXxxThisTime) out of RecipeRow (Yafc.Model) into a new UI-layer RecipeRowFocusManager (Yafc).

- RecipeRowFocusTarget enum is internal (not public)
- RequestFocus / CheckAndConsume replace the old per-row methods
- ShowEntityDropdown receives RecipeRowFocusManager directly instead of the full ProductionTableView, minimising its dependency surface
- WeakReference removed in favour of a plain strong reference; RecipeRow lifetime is bounded by ProductionTableView.model

Close #588 