### PR TITLE
fix: Improve the debugger display of quality-aware objects.

### DIFF
--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.ComponentModel;
+using System.Diagnostics;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
@@ -906,6 +907,7 @@ public static class ObjectWithQuality {
     /// Represents a <see cref="FactorioObject"/> with an attached <see cref="Quality"/> modifier.
     /// </summary>
     /// <typeparam name="T">The concrete type of the quality-modified object.</typeparam>
+    [DebuggerDisplay("{DebuggerDisplay,nq}", Type = "{DebuggerType,nq}")]
     private sealed class ConcreteObjectWithQuality<T>(T target, Quality quality) : IObjectWithQuality<T> where T : FactorioObject {
         /// <inheritdoc/>
         public T target { get; } = target ?? throw new ArgumentNullException(nameof(target));
@@ -915,6 +917,12 @@ public static class ObjectWithQuality {
         string IFactorioObjectWrapper.text => ((IFactorioObjectWrapper)target).text;
         FactorioObject IFactorioObjectWrapper.target => target;
         float IFactorioObjectWrapper.amount => ((IFactorioObjectWrapper)target).amount;
+
+        // The debugger is already displaying these as the value and type; don't display them again.
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private string DebuggerDisplay => $"{{{target.typeDotName} ({quality})}}";
+        [DebuggerBrowsable(DebuggerBrowsableState.Never)]
+        private static string DebuggerType => $"{typeof(T).FullName} with quality";
     }
 }
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -34,6 +34,8 @@ Date:
         - Fix the temperature overlay for fluids with non-64px icons.
         - In Module customization, pressing Enter after editing module amounts now applies the changes like clicking Done.
         - Fix initial New Page was not displayed in tab bar after creating new project.
+    Internal changes:
+        - Remove boilerplate from the debugger display of quality-aware objects.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.16.0
 Date: October 24th 2025


### PR DESCRIPTION
While debugging the test failure in #569, I got tired of the noise that Visual Studio puts in the watch window, so I added some code to improve that. The on-hover display of variable values in VS is improved in the same way. (The recipe in the tests is just named "recipe". Normal use would show something more like "Recipe.iron-plate (normal)".)
![Untitled](https://github.com/user-attachments/assets/9e473c15-f45c-40f0-8f4d-d0c63cdddc75)

I hope users of VSCode will see similar improvements.