### PR TITLE
feat: support RecipePrototype.additional_categories

### DIFF
--- a/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
@@ -36,6 +36,14 @@ internal partial class FactorioDataDeserializer {
             recipe.specialType = FactorioObjectSpecialType.Recycling;
         }
         recipeCategories.Add(recipeCategory, recipe);
+        if (table.Get("additional_categories", out LuaTable? additional_categories)) {
+            foreach (var category in additional_categories.ArrayElements<string>()) {
+                recipeCategories.Add(category, recipe);
+                if (recipeCategory == "recycling") {
+                    recipe.specialType = FactorioObjectSpecialType.Recycling;
+                }
+            }
+        }
         AllowedEffects allowedEffects = AllowedEffects.None;
         if (table.Get("allow_consumption", true)) {
             allowedEffects |= AllowedEffects.Consumption;

--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,7 @@ Date:
     Features:
         - Pressing Ctrl + LeftClick on the Close icon of the page now deletes it instead of closing. LeftClick wihout Ctrl closes it as usual.
         - Track heat temperature variants from different reactor types.
+        - Support RecipePrototype.additional_categories  (added in 2.0.49)
     Fixes:
         - Improve spoilage recipe handling: dedicated spoilage entity with clock icon, better cost calculation, and marked as automatable.
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
Read additional_categories in addition to category, this will enable the corresponding crafting machines without any further changes. Tested using PyBlock beta.

If using additional_categories it's unlikely to fall back to recycling-or-handcrafting, so that check is simplified in the added code.