### PR TITLE
fix: Read explicit declarations of pumped fluids.

### DIFF
--- a/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
@@ -475,7 +475,9 @@ internal partial class FactorioDataDeserializer {
                 pump.basePower = ParseEnergy(usesPower);
                 pump.baseCraftingSpeed = table.Get("pumping_speed", 20f) / 20f;
 
-                if (table.Get("fluid_box", out LuaTable? fluidBox) && fluidBox.Get("fluid", out string? fluidName)) {
+                if ((table.Get("fluid_box", out LuaTable? fluidBox) && fluidBox.Get("filter", out string? fluidName)) // 1.1 and 2.0
+                    || table.Get("fluid", out fluidName)) { // simpler structure for 1.1 only
+
                     var pumpingFluid = GetFluidFixedTemp(fluidName, 0);
                     string recipeCategory = SpecialNames.PumpingRecipe + pumpingFluid.name;
                     recipe = CreateSpecialRecipe(pumpingFluid, recipeCategory, LSs.SpecialRecipePumping);

--- a/changelog.txt
+++ b/changelog.txt
@@ -27,6 +27,7 @@ Date:
         - Support RecipePrototype.additional_categories  (added in 2.0.49)
     Fixes:
         - Improve spoilage recipe handling: dedicated spoilage entity with clock icon, better cost calculation, and marked as automatable.
+        - Fix fluid result for Angel's seafloor pump and other pumps that don't pump the tile-defined fluid.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.17.0
 Date: March 4th 2026


### PR DESCRIPTION
As mentioned [on discord](https://discord.com/channels/560199483065892894/1210135763422027837/1457500880935850068), some offshore pumps have the wrong fluid output. This fixes that for Seablock (1.1), Angel's (2.0), and Periodic Madness (2.0).