### PR TITLE
C# shim to fix Nonstandard Beacons on Windows

### DIFF
--- a/Yafc.Parser/LuaContext.cs
+++ b/Yafc.Parser/LuaContext.cs
@@ -107,6 +107,12 @@ internal partial class LuaContext : IDisposable {
     private static partial void lua_pushcclosure(IntPtr state, IntPtr callback, int n);
     [LibraryImport(LUA)]
     [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static partial void lua_pushvalue(IntPtr state, int index);
+    [LibraryImport(LUA)]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
+    private static partial void lua_replace(IntPtr state, int index);
+    [LibraryImport(LUA)]
+    [UnmanagedCallConv(CallConvs = [typeof(System.Runtime.CompilerServices.CallConvCdecl)])]
     private static partial void lua_createtable(IntPtr state, int narr, int nrec);
 
     [LibraryImport(LUA)]
@@ -154,6 +160,7 @@ internal partial class LuaContext : IDisposable {
         RegisterApi(Log, "raw_log");
         RegisterApi(Require, "require");
         RegisterApi(SourceFixups, "yafc_sourcefixups");
+        RegisterApi(StringFormat, "yafc_format");
         RegisterApi(DebugTraceback, "debug", "traceback");
         RegisterApi(CompareVersions, "helpers", "compare_versions");
         RegisterApi(EvaluateExpression, "helpers", "evaluate_expression");
@@ -251,6 +258,70 @@ internal partial class LuaContext : IDisposable {
             return 2; // Return the fixed names
         }
         return 2; // This didn't look like one of our names; just return the input values
+    }
+
+    /// <summary>
+    /// The documentation states that %e/%E/%g/%G produce two-digit exponents when possible. Some mods rely on this behavior.
+    /// If this method is called, our Lua build produces three-digit exponents instead. (The Windows build is known to have this bug.) It appears this
+    /// has to do with the underlying C runtime. I was able to build a new Windows Lua library that produced the correct strings, but it also crashed
+    /// (heap corruption) on some modpacks, including AngelBob.
+    /// This is only called for format strings that match the pattern in Sandbox.lua, and only if the C runtime has that bug.
+    /// </summary>
+    private int StringFormat(IntPtr lua) {
+        // The incoming parameters are: string.format, pattern, value1, value2, ...
+        // Outgoing parameters will be: newPattern, value1, newValue2, ...
+        //   On success, all %e-type conversion specifications in the pattern are replaced with %s, and each corresponding value is replaced with a
+        //     correctly-formatted string.
+        //   On failure, at least value could not be converted. The value and its specification were not modified.
+
+        int resultCount = lua_gettop(lua) - 1; // Discard the real string.format when returning
+        string pattern = GetString(2)!; // null-forgiving: The Lua patch guarantees this is a string.
+
+        int currentIndex = 3;
+        for (int i = 0; i < pattern.Length - 1; i++) { // Don't check the last character so we can safely do `pattern[++i]`.
+            if (pattern[i] == '%') {
+                // Found a %. Is this %<something>[eEgG]?
+                if (FindFloatFormatSpecifier().Match(pattern[i..]) is Match { Success: true } match) {
+                    // It is. Run string.format with just this conversion and value.
+                    lua_pushvalue(lua, 1);                  // string.format
+                    lua_pushstring(lua, match.ToString());  // "%...e"
+                    lua_pushvalue(lua, currentIndex);       // value to be formatted
+                    if (lua_pcallk(lua, 2, 1, 0, IntPtr.Zero, IntPtr.Zero) != Result.LUA_OK) {
+                        // Formatting error
+                        Pop(1); // Remove the error message
+                        break; // Let the original string.format regenerate the error
+                    }
+
+                    string result = (string)PopManagedValue(1)!;
+                    // If the formatted string contains an exponent that starts with 0, remove that 0.
+                    // (We know it's a three digit exponent because this shim isn't applied unless 1 converts to "...e+000")
+                    result = result.Replace("e+0", "e+");
+                    result = result.Replace("e-0", "e-");
+                    result = result.Replace("E+0", "E+");
+                    result = result.Replace("E-0", "E-");
+
+                    // Replace the number with our new string, and the substitution with %s.
+                    lua_pushstring(lua, result);
+                    lua_replace(lua, currentIndex);
+                    pattern = pattern[..i] + "%s" + pattern[(i + match.Length)..];
+                    i++;
+                    currentIndex++; // We dealt with this value; move on to the next.
+                }
+                // It's not %...[eEgG] Skip a possible %%. More likely, skip the specifier; e.g. the 's' in "%s"
+                else if (pattern[++i] != '%') {
+                    // It wasn't a %%, so skip the corresponding value, which doesn't need to be fixed.
+                    currentIndex++;
+                    // We don't need to determine the length of this specification. % is not valid in a conversion specification,
+                    // so the next % (if present) must introduce the next one.
+                }
+            }
+        }
+
+        // Replace the old format string
+        lua_pushstring(lua, pattern);
+        lua_replace(lua, 2);
+        // Return the patched values to be passed to the original string.format.
+        return resultCount;
     }
 
     private int CompareVersions(IntPtr lua) {
@@ -635,6 +706,11 @@ internal partial class LuaContext : IDisposable {
 
     [GeneratedRegex("^[0-9]+ ")]
     private static partial Regex FindChunkId();
+
+    // The full list of characters printf accepts between % and e is [-+ #0-9*.l] (https://en.cppreference.com/w/c/io/fprintf)
+    // Lua does not support * or l (https://www.lua.org/manual/5.2/manual.html#pdf-string.format)
+    [GeneratedRegex("^%[-+ #0-9.]*[eEgG]")]
+    private static partial Regex FindFloatFormatSpecifier();
 }
 
 internal class LuaTable : ILocalizable {

--- a/Yafc/Data/Sandbox.lua
+++ b/Yafc/Data/Sandbox.lua
@@ -29,6 +29,22 @@ function log(s)
 	raw_log(s);
 end
 
+-- Test format strings include "%e", "%e%e", "%e%%e", "%%e%s", "%e%" (must not throw index-out-of-range)
+-- Also test when passing non-numbers to %e and friends
+local raw_format = string.format
+if string.format("%e", 1):match("e%+000$") then
+	-- The documentation states that %e/%E/%g/%G produce two-digit exponents when possible. Some mods rely on this behavior.
+    -- Our Lua build just produced a three-digit exponent instead. (The Windows build is known to have this bug.)
+    -- Patch in a shim that does a quick check and delegates to C# if necessary.
+	function string.format(pattern, ...)
+		if type(pattern) == "string" and pattern:match("%%[-+ #0-9.]*[eEgG]") then
+			return raw_format(yafc_format(raw_format, pattern, ...))
+		end
+
+		return raw_format(pattern, ...)
+	end
+end
+
 local raw_getinfo = debug.getinfo
 -- Tests:
 -- 1: Ensure all of the following have the same result both before and after this function declaration:
@@ -57,6 +73,13 @@ function debug.getinfo(thread_or_f, f_or_what, what)
 		result.name = name.name
 		result.namewhat = name.namewhat
 		return result
+	end
+
+	-- If the caller wants info about string.format, hide our shim.
+	if thread_or_f == string.format then
+		return raw_getinfo(raw_format, f_or_what)
+	elseif f_or_what == string.format then
+		return raw_getinfo(thread_or_f, raw_format, what)
 	end
 
 	-- Otherwise, add 1 to f if it's a number, to hide this method from the stack.

--- a/changelog.txt
+++ b/changelog.txt
@@ -28,6 +28,7 @@ Date:
     Fixes:
         - Improve spoilage recipe handling: dedicated spoilage entity with clock icon, better cost calculation, and marked as automatable.
         - Fix fluid result for Angel's seafloor pump and other pumps that don't pump the tile-defined fluid.
+        - Fix loading Nonstandard Beacons on Windows.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.17.0
 Date: March 4th 2026


### PR DESCRIPTION
This is an alternative to #600.

[Nonstandard Beacons](https://mods.factorio.com/mod/zzz-nonstandard-beacons) relies on the documented behavior that, in Lua and C, %e produces two-digit exponents when possible (1e+00 instead of 1e+000). The C runtime used by the existing lua52.dll always produces three-digit exponents.

This PR adds a shim that's installed if the Lua runtime has this bug, and reformats the output of %e and friends to a two-digit exponent. The Linux and OSX-Arm runtimes do not have this bug. The OSX-Intel runtime has not been tested.