### PR TITLE
Fix fixed amounts

### DIFF
--- a/Yafc.Model.Tests/Model/ProductionTableContentTests.cs
+++ b/Yafc.Model.Tests/Model/ProductionTableContentTests.cs
@@ -17,13 +17,14 @@ public class ProductionTableContentTests {
         ProductionTable table = (ProductionTable)page.content;
         table.AddRecipe(Database.recipes.all.Single(r => r.name == "recipe").With(Quality.Normal), DataUtils.DeterministicComparer);
         RecipeRow row = table.GetAllRecipes().Single();
+        row.showTotalIO = true;
 
         table.modules.beacon = Database.allBeacons.Single().With(Quality.Normal);
         table.modules.beaconModule = Database.allModules.Single(m => m.name == "speed-module").With(Quality.Normal);
         table.modules.beaconsPerBuilding = 2;
         table.modules.autoFillPayback = MathF.Sqrt(float.MaxValue);
 
-        RunTest(row, testCombinations, (3 * 3 + 3 * 1) * (9 + 2) * 6); // Crafter&fuel * modules * available fixed values
+        RunTest(row, testCombinations, (3 * 3 + 3 * 1) * (9 + 2) * 8); // Crafter&fuel * modules * available fixed values
 
         // Cycle through all crafters (3 burner, 3 electric), fuels (3+1), and internal modules (9 + empty + default), and call assert for each combination.
         // assert will ensure the currently fixed value has not changed by more than 0.01%.

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -357,13 +357,15 @@ public sealed class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<Pr
             if (SerializationMap.IsDeserializing || fixedBuildings == 0 || _fuel == value) {
                 _fuel = value;
             }
-            else if (fixedProduct != null && (fuel.FuelResult() == fixedProduct || value.FuelResult() == fixedProduct)) {
+            else if (fixedProduct != null) {
+                // We're changing the fuel and there's a fixed product. Make sure the amount doesn't change.
+                // (This usually has no effect, but the test for "will it have an effect?" isn't worth the extra effort.)
+
                 if (Products.SingleOrDefault(p => p.Goods == fixedProduct, false) is not RecipeRowProduct product) {
                     fixedBuildings = 0; // We couldn't find the Product corresponding to fixedProduct. Just clear the fixed amount.
                     _fuel = value;
                 }
                 else {
-                    // We're changing the fuel and at least one of the current or new fuel burns to the fixed product
                     float oldAmount = product.Amount;
 
                     _fuel = value;
@@ -748,7 +750,7 @@ public sealed class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<Pr
             // Step 4 is only performed after step 1 and when the possibly-changed entity accepts the old fuel.
             //      If the entity does not accept the old fuel, a caller must set an appropriate fuel.
 
-            if (row.fixedProduct != null && row.fixedProduct == row.fuel.FuelResult()) {
+            if (row.fixedProduct != null && (row.fixedProduct == row.fuel.FuelResult() || row.fixedProduct == Database.itemOutput)) {
                 oldFuel = row.fuel;
                 row.fuel = Database.voidEnergy; // step 1
             }

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -494,7 +494,11 @@ public sealed class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<Pr
                 return [];
             }
             else if (hierarchyEnabled) {
-                return BuildIngredients(false).Select(RecipeRowIngredient.FromSolver);
+                var result = BuildIngredients(false).Select(RecipeRowIngredient.FromSolver);
+                if (fixedIngredient == Database.itemInput || showTotalIO) {
+                    result = result.Append(new(Database.itemInput, result.Where(i => i.Goods.Is<Item>()).Sum(i => i.Amount), null, null));
+                }
+                return result;
             }
             else {
                 return Enumerable.Repeat(new RecipeRowIngredient(null, 0, null, null), recipe.target.ingredients.Length);
@@ -523,7 +527,11 @@ public sealed class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<Pr
                 return [];
             }
             else if (hierarchyEnabled) {
-                return BuildProducts(false).Select(RecipeRowProduct.FromSolver);
+                var result = BuildProducts(false).Select(RecipeRowProduct.FromSolver);
+                if (fixedProduct == Database.itemOutput || showTotalIO) {
+                    result = result.Append(new(Database.itemOutput, result.Where(p => p.Goods.Is<Item>()).Sum(p => p.Amount), null, null));
+                }
+                return result;
             }
             else {
                 return Enumerable.Repeat(new RecipeRowProduct(null, 0, null, null), recipe.target.products.Length);

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -673,11 +673,6 @@ goodsHaveNoProduction:;
                     grid.Next();
                     view.BuildGoodsIcon(gui, goods, link, amount, ProductDropdownType.Ingredient, recipe, recipe.linkRoot, HintLocations.OnProducingRecipes, variants);
                 }
-                if (recipe.fixedIngredient == Database.itemInput || recipe.showTotalIO) {
-                    grid.Next();
-                    view.BuildGoodsIcon(gui, recipe.hierarchyEnabled ? Database.itemInput : null, null, recipe.Ingredients.Where(i => i.Goods?.target is Item).Sum(i => i.Amount),
-                        ProductDropdownType.Ingredient, recipe, recipe.linkRoot, HintLocations.None);
-                }
             }
             grid.Dispose();
         }
@@ -711,11 +706,6 @@ goodsHaveNoProduction:;
                             ExtraSpoilInformation = gui => gui.BuildText(LSs.ProductionTableOutputFixedSpoilage.L(DataUtils.FormatAmount(percentSpoiled.Value, UnitOfMeasure.Percent)))
                         });
                     }
-                }
-                if (recipe.fixedProduct == Database.itemOutput || recipe.showTotalIO) {
-                    grid.Next();
-                    view.BuildGoodsIcon(gui, recipe.hierarchyEnabled ? Database.itemOutput : null, null, recipe.Products.Where(i => i.Goods?.target is Item).Sum(i => i.Amount),
-                        ProductDropdownType.Product, recipe, recipe.linkRoot, HintLocations.None);
                 }
             }
             grid.Dispose();

--- a/changelog.txt
+++ b/changelog.txt
@@ -23,6 +23,7 @@ Version:
 Date:
     Features:
     Fixes:
+        - Fixed production amounts will stay fixed on the "Total Output" object.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.18.0
 Date: April 7th 2026


### PR DESCRIPTION
If you set a fixed amount on the [O] "Total item production" item and then change the fuel to one that produces a different amount of spent fuel, the supposedly-fixed amount changes. This fixes that, and updates the tests to help make sure it stays fixed.