### PR TITLE
Obey spent fuel deletion behavior

### DIFF
--- a/Yafc.Model.Tests/Model/ProductionTableContentTests.cs
+++ b/Yafc.Model.Tests/Model/ProductionTableContentTests.cs
@@ -155,20 +155,9 @@ public class ProductionTableContentTests {
                             }
                         }
 
-                        foreach (var (display, solver) in row.Products.Zip(row.ProductsForSolver
-                            // ProductsForSolver doesn't include the spent fuel. Append an entry for the spent fuel, in the case that the spent
-                            // fuel is not a recipe product.
-                            // If the spent fuel is also a recipe product, this value will ignored in favor of the recipe-product value.
-                            .Append(new(row.fuel.FuelResult(), 0, null, 0, null)))) {
-
+                        foreach (var (display, solver) in row.Products.Zip(row.ProductsForSolver)) {
                             var (solverGoods, solverAmount, _, _, _) = solver;
                             var (displayGoods, displayAmount, _, _) = display;
-
-                            if (solverGoods == row.fuel.FuelResult()) {
-                                // ProductsForSolver doesn't include the spent fuel (in either the real or test-specific result)
-                                // Add the spent fuel amount to the value given to the solver.
-                                solverAmount += row.parameters.fuelUsagePerSecondPerRecipe;
-                            }
 
                             try {
                                 // If this fails, something weird went wrong

--- a/Yafc.Model.Tests/Model/ProductionTableContentTests.lua
+++ b/Yafc.Model.Tests/Model/ProductionTableContentTests.lua
@@ -46,6 +46,7 @@ data = {
         energy_source = {
           type = "burner",
           fuel_categories = { "chemical" },
+          burnt_result_inventory = 1,
         },
         energy_usage = "75kW",
         crafting_categories = { "crafting" },
@@ -63,6 +64,7 @@ data = {
         energy_source = {
           type = "burner",
           fuel_categories = { "chemical" },
+          burnt_result_inventory = 1,
         },
         energy_usage = "150kW",
         module_specification = {
@@ -83,6 +85,7 @@ data = {
         energy_source = {
           type = "burner",
           fuel_categories = { "chemical" },
+          burnt_result_inventory = 0, -- Test with burnt-result deletion too
         },
         energy_usage = "250kW",
         module_specification = {

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -546,6 +546,12 @@ public class Entity : FactorioObject {
     internal List<Entity> sourceEntities { get; set; } = null!;
     internal string? autoplaceControl { get; set; }
     public float heatingPower { get; internal set; }
+    /// <summary>
+    /// If <see langword="false"/>, this entity does not produce burnt results when burning item fuels.<br/>
+    /// This is initialized to <see langword="true"/> if <c>entity.burner.burnt_result_inventory</c> (burner generators) or
+    /// <c>entity.energy_source.burnt_result_inventory</c> (everything else) is present and non-zero.
+    /// </summary>
+    public bool hasBurntInventory { get; internal set; }
     public int width { get; internal set; }
     public int height { get; internal set; }
     public int size { get; internal set; }

--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -512,7 +512,7 @@ match:
                 links.ingredients[ingredient.LinkIndex] = link as ProductionLink;
             }
 
-            links.fuel = links.spentFuel = null;
+            links.fuel = null;
 
             if (recipe.fuel != null) {
                 float fuelAmount = recipe.parameters.fuelUsagePerSecondPerRecipe;
@@ -521,16 +521,6 @@ match:
                     links.fuel = link as ProductionLink;
                     link.flags |= ProductionLink.Flags.HasConsumption;
                     AddLinkCoefficient(constraints[link.solverIndex], recipeVar, link, recipe, -fuelAmount);
-                }
-
-                if (recipe.fuel.FuelResult() is IObjectWithQuality<Item> spentFuel && recipe.FindLink(spentFuel, out link)) {
-                    links.spentFuel = link as ProductionLink;
-                    link.flags |= ProductionLink.Flags.HasProduction;
-                    AddLinkCoefficient(constraints[link.solverIndex], recipeVar, link, recipe, fuelAmount);
-
-                    if (spentFuel.target.Cost() > 0f) {
-                        objCoefficients[i] += fuelAmount * spentFuel.target.Cost();
-                    }
                 }
             }
         }
@@ -730,10 +720,6 @@ match:
 
         if (recipe.links.fuel != null) {
             sources.Add(recipe.links.fuel);
-        }
-
-        if (recipe.links.spentFuel != null) {
-            targets.Add(recipe.links.spentFuel);
         }
     }
 

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -549,7 +549,11 @@ public sealed class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<Pr
         }
 
         float factor = forSolver ? 1 : (float)recipesPerSecond; // The solver needs the products for one recipe, to produce recipesPerSecond.
-        IObjectWithQuality<Item>? spentFuel = fuel.FuelResult();
+        IObjectWithQuality<Item>? spentFuel = null;
+        if (entity?.target.hasBurntInventory ?? true) {
+            // Only generate spent fuels if there's an inventory slot to put them in. If the entity is not set, assume there's a slot.
+            spentFuel = fuel.FuelResult();
+        }
 
         List<float> upgradeProbabilities = [1];
         if (parameters.activeEffects.qualityMod > 0) {

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -227,12 +227,12 @@ internal class RecipeLinks {
     public required ProductionLink?[] ingredients;
     public ProductionQualityLink products = new();
     public ProductionLink? fuel;
-    public ProductionLink? spentFuel;
 }
 
 /// <summary>
 /// Stores the production links for each pair of (a) index into <see cref="RecipeOrTechnology.products"/> and (b) quality level.
 /// The index is the same value as the index into the old <c><see cref="ProductionLink"/>?[]</c> field.
+/// If the recipe row has a linked spent fuel, that link is after all recipe-declared products.
 /// </summary>
 internal sealed class ProductionQualityLink {
     private readonly Dictionary<(int, Quality), IProductionLink?> _links = [];
@@ -550,7 +550,6 @@ public sealed class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<Pr
 
         float factor = forSolver ? 1 : (float)recipesPerSecond; // The solver needs the products for one recipe, to produce recipesPerSecond.
         IObjectWithQuality<Item>? spentFuel = fuel.FuelResult();
-        bool handledFuel = spentFuel == null || forSolver; // If we're running the solver or there's no spent fuel, it's already handled.
 
         List<float> upgradeProbabilities = [1];
         if (parameters.activeEffects.qualityMod > 0) {
@@ -568,7 +567,8 @@ public sealed class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<Pr
             }
         }
 
-        for (int i = 0; i < recipe.target.products.Length; i++) {
+        int i = 0;
+        for (; i < recipe.target.products.Length; i++) {
             Product product = recipe.target.products[i];
 
             Quality quality = recipe.quality;
@@ -581,10 +581,10 @@ public sealed class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<Pr
                 for (int j = 0; j < upgradeProbabilities.Count; j++) {
                     // The result amount for this quality is the normal output amount times the probability of this quality,
                     float amount = baseAmount * upgradeProbabilities[j];
-                    if (!handledFuel && product.goods.With(quality) == spentFuel) {
+                    if (product.goods.With(quality) == spentFuel) {
                         // ... plus the spent fuel, if applicable.
                         amount += parameters.fuelUsagePerSecondPerRecipe;
-                        handledFuel = true;
+                        spentFuel = null; // Done thinking about spent fuel
                     }
 
                     if (amount > 0) {
@@ -595,10 +595,9 @@ public sealed class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<Pr
             }
         }
 
-        if (!handledFuel) {
-            // null-forgiving (both): handledFuel is always false when running the solver.
-            // equivalently: We do not enter this block when a non-null Goods is required.
-            yield return (spentFuel!, parameters.fuelUsagePerSecondPerRecipe * factor, links.spentFuel, 0, null);
+        if (spentFuel != null) {
+            var link = links.products[i, spentFuel.quality];
+            yield return (spentFuel, parameters.fuelUsagePerSecondPerRecipe * factor, link, i, null);
         }
     }
 

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
@@ -115,6 +115,8 @@ internal partial class FactorioDataDeserializer {
                     fuelUsers.Add(entity, energySource.Get("fuel_category", "chemical"));
                 }
 
+                entity.hasBurntInventory = energySource.Get("burnt_inventory_size", 0) != 0;
+
                 break;
             case "heat":
                 energy.type = EntityEnergyType.Heat;

--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,7 @@ Date:
     Fixes:
         - Fixed production amounts will stay fixed on the "Total Output" object.
         - Fix intermittent crashes when unloading Lua.
+        - Burner entities with no space for burnt results now correctly delete the burnt result.
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.18.0
 Date: April 7th 2026


### PR DESCRIPTION
Entities that do not have a burnt_result_inventory don't create spent fuel when burning items. This PR removes knowledge of spent fuels from the solver, and prevents the model from generating spent fuels for such entities.