### PR TITLE
fix: handle empty blueprint exports from shopping list

### DIFF
--- a/FactorioCalc.sln
+++ b/FactorioCalc.sln
@@ -32,6 +32,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yafc.I18n.Generator", "Yafc
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yafc.Parser.Tests", "Yafc.Parser.Tests\Yafc.Parser.Tests.csproj", "{E7D5C910-550A-4028-A866-C536F1FAD645}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Yafc.Core", "Yafc.Core\Yafc.Core.csproj", "{F29B200A-9A20-4BAA-BEF9-8F92E318BCF8}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -74,6 +76,10 @@ Global
 		{E7D5C910-550A-4028-A866-C536F1FAD645}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{E7D5C910-550A-4028-A866-C536F1FAD645}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{E7D5C910-550A-4028-A866-C536F1FAD645}.Release|Any CPU.Build.0 = Release|Any CPU
+		{F29B200A-9A20-4BAA-BEF9-8F92E318BCF8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{F29B200A-9A20-4BAA-BEF9-8F92E318BCF8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{F29B200A-9A20-4BAA-BEF9-8F92E318BCF8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{F29B200A-9A20-4BAA-BEF9-8F92E318BCF8}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/Yafc.Core/IntegerMath.cs
+++ b/Yafc.Core/IntegerMath.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace Yafc.Core;
+
+public static class IntegerMath {
+    public static int CeilingDivide(int dividend, int divisor) {
+        ArgumentOutOfRangeException.ThrowIfNegative(dividend);
+        ArgumentOutOfRangeException.ThrowIfNegativeOrZero(divisor);
+
+        int quotient = Math.DivRem(dividend, divisor, out int remainder);
+        return remainder == 0 ? quotient : quotient + 1;
+    }
+}

--- a/Yafc.Core/IntegerMath.cs
+++ b/Yafc.Core/IntegerMath.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 
 namespace Yafc.Core;
 

--- a/Yafc.Core/Yafc.Core.csproj
+++ b/Yafc.Core/Yafc.Core.csproj
@@ -1,0 +1,9 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+
+</Project>

--- a/Yafc.Model.Tests/Blueprints/BlueprintUtilitiesTests.cs
+++ b/Yafc.Model.Tests/Blueprints/BlueprintUtilitiesTests.cs
@@ -32,9 +32,38 @@ public class BlueprintUtilitiesTests {
         AssertEmptyBlueprint(blueprintString, "empty");
     }
 
+    [Fact]
+    public void ExportConstantCombinators_WithEmptyGoodsAndRawJson_ReturnsEmptyBlueprint() {
+        string blueprintString = BlueprintUtilities.ExportConstantCombinators(
+            "empty",
+            Array.Empty<(IObjectWithQuality<Goods> item, int amount)>(),
+            BlueprintFormat.RawJson);
+
+        AssertEmptyBlueprintJson(blueprintString, "empty");
+    }
+
+    [Fact]
+    public void ExportRequesterChests_WithEmptyGoodsAndRawJson_ReturnsEmptyBlueprint() {
+        EntityContainer chest = new() {
+            logisticSlotsCount = 10,
+        };
+
+        string blueprintString = BlueprintUtilities.ExportRequesterChests(
+            "empty",
+            Array.Empty<(IObjectWithQuality<Item> item, int amount)>(),
+            chest,
+            BlueprintFormat.RawJson);
+
+        AssertEmptyBlueprintJson(blueprintString, "empty");
+    }
+
     private static void AssertEmptyBlueprint(string blueprintString, string name) {
         Assert.StartsWith("0", blueprintString);
-        using JsonDocument document = JsonDocument.Parse(DecodeBlueprintString(blueprintString));
+        AssertEmptyBlueprintJson(DecodeBlueprintString(blueprintString), name);
+    }
+
+    private static void AssertEmptyBlueprintJson(string blueprintJson, string name) {
+        using JsonDocument document = JsonDocument.Parse(blueprintJson);
         JsonElement blueprint = document.RootElement.GetProperty("blueprint");
 
         Assert.Equal("blueprint", blueprint.GetProperty("item").GetString());

--- a/Yafc.Model.Tests/Blueprints/BlueprintUtilitiesTests.cs
+++ b/Yafc.Model.Tests/Blueprints/BlueprintUtilitiesTests.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+using System.Text.Json;
+using Xunit;
+using Yafc.Blueprints;
+
+namespace Yafc.Model.Tests.Blueprints;
+
+public class BlueprintUtilitiesTests {
+    [Fact]
+    public void ExportConstantCombinators_WithEmptyGoods_ReturnsEmptyBlueprint() {
+        string blueprintString = BlueprintUtilities.ExportConstantCombinators(
+            "empty",
+            Array.Empty<(IObjectWithQuality<Goods> item, int amount)>());
+
+        AssertEmptyBlueprint(blueprintString, "empty");
+    }
+
+    [Fact]
+    public void ExportRequesterChests_WithEmptyGoods_ReturnsEmptyBlueprint() {
+        EntityContainer chest = new() {
+            logisticSlotsCount = 10,
+        };
+
+        string blueprintString = BlueprintUtilities.ExportRequesterChests(
+            "empty",
+            Array.Empty<(IObjectWithQuality<Item> item, int amount)>(),
+            chest);
+
+        AssertEmptyBlueprint(blueprintString, "empty");
+    }
+
+    private static void AssertEmptyBlueprint(string blueprintString, string name) {
+        Assert.StartsWith("0", blueprintString);
+        using JsonDocument document = JsonDocument.Parse(DecodeBlueprintString(blueprintString));
+        JsonElement blueprint = document.RootElement.GetProperty("blueprint");
+
+        Assert.Equal("blueprint", blueprint.GetProperty("item").GetString());
+        Assert.Equal(name, blueprint.GetProperty("label").GetString());
+        Assert.Empty(blueprint.GetProperty("entities").EnumerateArray());
+    }
+
+    private static string DecodeBlueprintString(string blueprintString) {
+        byte[] compressed = Convert.FromBase64String(blueprintString[1..]);
+        using MemoryStream input = new MemoryStream(compressed);
+        using ZLibStream zlib = new ZLibStream(input, CompressionMode.Decompress);
+        using MemoryStream output = new MemoryStream();
+        zlib.CopyTo(output);
+        return Encoding.UTF8.GetString(output.ToArray());
+    }
+}

--- a/Yafc.Model/Blueprints/BlueprintUtilities.cs
+++ b/Yafc.Model/Blueprints/BlueprintUtilities.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
+using Yafc.Core;
 using Yafc.Model;
 
 namespace Yafc.Blueprints;
@@ -11,11 +12,7 @@ public static class BlueprintUtilities {
         string name,
         IReadOnlyList<(IObjectWithQuality<Goods> item, int amount)> goods,
         BlueprintFormat format = BlueprintFormat.CompressedBase64) {
-        if (goods.Count == 0) {
-            return ExportEmptyBlueprint(name, format);
-        }
-
-        int combinatorCount = ((goods.Count - 1) / Database.constantCombinatorCapacity) + 1;
+        int combinatorCount = IntegerMath.CeilingDivide(goods.Count, Database.constantCombinatorCapacity);
         int offset = -combinatorCount / 2;
         BlueprintString blueprint = new BlueprintString(name);
         int index = 0;
@@ -56,11 +53,7 @@ public static class BlueprintUtilities {
             throw new ArgumentException("Chest does not have logistic slots");
         }
 
-        if (goods.Count == 0) {
-            return ExportEmptyBlueprint(name, format);
-        }
-
-        int combinatorCount = ((goods.Count - 1) / chest.logisticSlotsCount) + 1;
+        int combinatorCount = IntegerMath.CeilingDivide(goods.Count, chest.logisticSlotsCount);
         int offset = -chest.size * combinatorCount / 2;
         BlueprintString blueprint = new BlueprintString(name);
         int index = 0;
@@ -90,9 +83,6 @@ public static class BlueprintUtilities {
 
         return blueprint.ToBpString(format);
     }
-
-    private static string ExportEmptyBlueprint(string name, BlueprintFormat format)
-        => new BlueprintString(name).ToBpString(format);
 
     private class PlacedEntity {
         public RecipeRow Recipe { get; }

--- a/Yafc.Model/Blueprints/BlueprintUtilities.cs
+++ b/Yafc.Model/Blueprints/BlueprintUtilities.cs
@@ -8,6 +8,10 @@ namespace Yafc.Blueprints;
 
 public static class BlueprintUtilities {
     public static string ExportConstantCombinators(string name, IReadOnlyList<(IObjectWithQuality<Goods> item, int amount)> goods) {
+        if (goods.Count == 0) {
+            return ExportEmptyBlueprint(name);
+        }
+
         int combinatorCount = ((goods.Count - 1) / Database.constantCombinatorCapacity) + 1;
         int offset = -combinatorCount / 2;
         BlueprintString blueprint = new BlueprintString(name);
@@ -45,6 +49,10 @@ public static class BlueprintUtilities {
             throw new ArgumentException("Chest does not have logistic slots");
         }
 
+        if (goods.Count == 0) {
+            return ExportEmptyBlueprint(name);
+        }
+
         int combinatorCount = ((goods.Count - 1) / chest.logisticSlotsCount) + 1;
         int offset = -chest.size * combinatorCount / 2;
         BlueprintString blueprint = new BlueprintString(name);
@@ -75,6 +83,9 @@ public static class BlueprintUtilities {
 
         return blueprint.ToBpString();
     }
+
+    private static string ExportEmptyBlueprint(string name)
+        => new BlueprintString(name).ToBpString();
 
     private class PlacedEntity {
         public RecipeRow Recipe { get; }

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Yafc.Core;
 using Yafc.I18n;
 using Yafc.UI;
 
@@ -167,12 +168,7 @@ public class ModuleTemplate : ModelObject<ModelObject> {
             moduleCount += element.fixedCount;
         }
 
-        if (moduleCount == 0) {
-            // C# division rounds to zero, causing the round-up math below to return 1 in most cases, instead of 0.
-            return 0;
-        }
-
-        return ((moduleCount - 1) / beacon.target.moduleSlots) + 1;
+        return IntegerMath.CeilingDivide(moduleCount, beacon.target.moduleSlots);
     }
 
     /// <summary>

--- a/Yafc.Model/Yafc.Model.csproj
+++ b/Yafc.Model/Yafc.Model.csproj
@@ -9,6 +9,7 @@
     <ItemGroup>
       <InternalsVisibleTo Include="Yafc.Model.Tests" />
       <PackageReference Include="Google.OrTools" Version="9.15.6755" />
+      <ProjectReference Include="..\Yafc.Core\Yafc.Core.csproj" />
       <ProjectReference Include="..\Yafc.I18n\Yafc.I18n.csproj" />
       <ProjectReference Include="..\Yafc.UI\Yafc.UI.csproj" />
     </ItemGroup>

--- a/Yafc.UI/ImGui/ScrollArea.cs
+++ b/Yafc.UI/ImGui/ScrollArea.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Numerics;
 using SDL2;
+using Yafc.Core;
 
 namespace Yafc.UI;
 
@@ -337,7 +338,7 @@ public class VirtualScrollList<TData>(float height, Vector2 elementSize, Virtual
             elementsPerRow = 1;
         }
 
-        int rowCount = ((_data.Count - 1) / elementsPerRow) + 1;
+        int rowCount = IntegerMath.CeilingDivide(_data.Count, elementsPerRow);
         firstVisibleBlock = CalculateFirstBlock();
         // Scroll up until there are maxRowsVisible, or to the top.
         int firstRow = Math.Max(0, Math.Min(firstVisibleBlock * BufferRows, rowCount - maxRowsVisible));

--- a/Yafc.UI/Yafc.UI.csproj
+++ b/Yafc.UI/Yafc.UI.csproj
@@ -16,6 +16,7 @@
 
     <ItemGroup>
       <ProjectReference Include="..\Yafc.I18n\Yafc.I18n.csproj" />
+      <ProjectReference Include="..\Yafc.Core\Yafc.Core.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using Yafc.Core;
 using Yafc.I18n;
 using Yafc.Model;
 using Yafc.UI;
@@ -56,8 +57,8 @@ public class ObjectTooltip : Tooltip {
                 // If displaying more items per row (up to the user's limit) reduces the number of rows, squish the milestones together slightly.
                 int maxItemsPerRow = Project.current.preferences.maxMilestonesPerTooltipLine;
                 const int minItemsPerRow = 22;
-                int rows = (milestoneCount + maxItemsPerRow - 1) / maxItemsPerRow;
-                int itemsPerRow = Math.Max((milestoneCount + rows - 1) / rows, minItemsPerRow);
+                int rows = IntegerMath.CeilingDivide(milestoneCount, maxItemsPerRow);
+                int itemsPerRow = Math.Max(IntegerMath.CeilingDivide(milestoneCount, rows), minItemsPerRow);
                 // 22.5 is the width of the available area of the tooltip. The original code used spacings from -1 (100% overlap) to 0
                 // (no overlap). At the default max of 28 per row, we allow spacings of -0.196 (19.6% overlap) to 0.023 (2.3% stretch).
                 float spacing = 22.5f / itemsPerRow - 1f;
@@ -125,7 +126,7 @@ doneDrawing:;
             maxRows--;
         }
 
-        int rows = Math.Min(((count - 1 - index) / itemsPerRow) + 1, maxRows);
+        int rows = Math.Min(IntegerMath.CeilingDivide(count - index, itemsPerRow), maxRows);
         for (int i = 0; i < rows; i++) {
             using (gui.EnterRow()) {
                 for (int j = 0; j < itemsPerRow; j++) {

--- a/Yafc/Windows/ShoppingListScreen.cs
+++ b/Yafc/Windows/ShoppingListScreen.cs
@@ -175,7 +175,7 @@ public class ShoppingListScreen : PseudoScreen {
                 Decompose();
             }
 
-            if (gui.BuildButton(LSs.ShoppingListExportBlueprint, SchemeColor.Grey)) {
+            if (gui.BuildButton(LSs.ShoppingListExportBlueprint, SchemeColor.Grey, active: list.data.Count > 0)) {
                 gui.ShowDropDown(ExportBlueprintDropdown);
             }
         }

--- a/Yafc/Windows/ShoppingListScreen.cs
+++ b/Yafc/Windows/ShoppingListScreen.cs
@@ -175,7 +175,7 @@ public class ShoppingListScreen : PseudoScreen {
                 Decompose();
             }
 
-            if (gui.BuildButton(LSs.ShoppingListExportBlueprint, SchemeColor.Grey, active: list.data.Count > 0)) {
+            if (gui.BuildButton(LSs.ShoppingListExportBlueprint, SchemeColor.Grey)) {
                 gui.ShowDropDown(ExportBlueprintDropdown);
             }
         }

--- a/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -1,6 +1,7 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
+using Yafc.Core;
 using Yafc.I18n;
 using Yafc.Model;
 using Yafc.UI;
@@ -307,7 +308,7 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
                 }
             }
             else {
-                int beaconCount = (modules.beaconList.Sum(x => x.fixedCount) - 1) / beacon.target.moduleSlots + 1;
+                int beaconCount = IntegerMath.CeilingDivide(modules.beaconList.Sum(x => x.fixedCount), beacon.target.moduleSlots);
                 effects.AddModules(module, fixedCount * beacon.GetBeaconEfficiency() * beacon.target.GetProfile(beaconCount));
             }
         }

--- a/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -1,4 +1,4 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.Linq;
 using Yafc.Core;

--- a/Yafc/Yafc.csproj
+++ b/Yafc/Yafc.csproj
@@ -41,6 +41,7 @@
     <ProjectReference Include="..\Yafc.Model\Yafc.Model.csproj" />
     <ProjectReference Include="..\Yafc.Parser\Yafc.Parser.csproj" />
     <ProjectReference Include="..\Yafc.UI\Yafc.UI.csproj" />
+    <ProjectReference Include="..\Yafc.Core\Yafc.Core.csproj" />
   </ItemGroup>
   <ItemGroup>
     <Content Include="..\LICENSE">


### PR DESCRIPTION
## Summary
Prevent empty shopping lists from crashing blueprint export.

## Detailed explanation
The shopping list can legitimately produce an empty visible list depending on the selected state, such as Built or Missing. The export UI still allowed blueprint export in that state, while the blueprint exporter assumed at least one item and indexed into the first goods entry.

## Example UI steps that trigger the issue
1. Open a project and open the shopping list.
2. Switch the shopping list view to a state such as Built or Missing where the visible list is empty.
3. Click a blueprint export action, such as exporting constant combinators or requester chests.

## Expected behavior
An empty visible shopping list should not crash the application. Export should either be unavailable in the UI or produce a safe empty blueprint payload.

## Actual behavior
The export action can be invoked with no goods. The exporter then attempts to access the first item in an empty list and throws an out-of-range exception.

## Fix
The exporter now handles empty goods lists explicitly and returns an empty blueprint in the same output format. The shopping list UI also disables export actions when the currently visible list is empty. A regression test covers empty goods export.
