### PR TITLE
fix: trim unused ImGui build groups

### DIFF
--- a/Yafc.UI/ImGui/ImGuiBuildCache.cs
+++ b/Yafc.UI/ImGui/ImGuiBuildCache.cs
@@ -39,6 +39,18 @@ public partial class ImGui {
     private int buildGroupsIndex = -1;
     private readonly List<BuildGroup> buildGroups = [];
 
+    public void ClearBuildGroupCache() {
+        buildGroups.Clear();
+        buildGroupsIndex = -1;
+    }
+
+    private void TrimUnusedBuildGroups() {
+        int usedCount = buildGroupsIndex + 1;
+        if (usedCount < buildGroups.Count) {
+            buildGroups.RemoveRange(usedCount, buildGroups.Count - usedCount);
+        }
+    }
+
     public bool ShouldBuildGroup(object o, [MaybeNullWhen(false)] out BuildGroup group) {
         buildGroupsIndex++;
         BuildGroup current;

--- a/Yafc.UI/ImGui/ImGuiBuildCache.cs
+++ b/Yafc.UI/ImGui/ImGuiBuildCache.cs
@@ -39,11 +39,6 @@ public partial class ImGui {
     private int buildGroupsIndex = -1;
     private readonly List<BuildGroup> buildGroups = [];
 
-    public void ClearBuildGroupCache() {
-        buildGroups.Clear();
-        buildGroupsIndex = -1;
-    }
-
     private void TrimUnusedBuildGroups() {
         int usedCount = buildGroupsIndex + 1;
         if (usedCount < buildGroups.Count) {

--- a/Yafc.UI/ImGui/ImGuiBuilding.cs
+++ b/Yafc.UI/ImGui/ImGuiBuilding.cs
@@ -253,6 +253,7 @@ public partial class ImGui {
         rebuildRequested = false;
         ClearDrawCommandList();
         _ = DoGui(ImGuiAction.Build);
+        TrimUnusedBuildGroups();
         contentSize = new Vector2(lastContentRect.Right, lastContentRect.Height);
 
         if (boxColor != SchemeColor.None) {


### PR DESCRIPTION
## Summary
Trim unused ImGui build groups so UI caches do not retain stale row objects.

## Detailed explanation
The ImGui build cache can retain `BuildGroup` entries after a later build uses fewer groups than a previous one. Those unused cached groups may continue to hold references to old UI model objects, such as rows from a table or page that is no longer displayed.

## Example UI steps that trigger the issue
1. Open a view backed by a dynamic list or table.
2. Render a larger set of rows or groups.
3. Switch pages, switch projects, or otherwise render a smaller set of groups in the same cached UI structure.

## Expected behavior
After a complete build, cache entries that were not used by the current build should be released so they no longer retain stale objects.

## Actual behavior
Unused `BuildGroup` entries can remain in the cache and continue to reference objects from the previous build.

## Fix
The build cache now trims unused build groups after a complete build. This keeps cache reuse for active groups while releasing stale groups that are no longer part of the current UI tree.
