### PR TITLE
fix(yafc): Synchronize SummaryView Subscriptions and Initialization

### DIFF
--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -47,7 +47,7 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
     private readonly Dictionary<Type, ProjectPageView> secondaryPageViews = [];
 
     public MainScreen(int display, Project project) : base(default, Preferences.Instance.forceSoftwareRenderer) {
-        summaryView = new SummaryView(project);
+        summaryView = new SummaryView();
         RegisterPageView<ProductionTable>(new ProductionTableView());
         RegisterPageView<AutoPlanner>(new AutoPlannerView());
         RegisterPageView<ProductionSummary>(new ProductionSummaryView());
@@ -200,7 +200,7 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
     }
 
     public void SetSecondaryPage(ProjectPage? page) {
-        if (page == null || page == _activePage) {
+        if (page == null || page == _activePage || page.contentType == typeof(Summary)) {
             ChangePage(ref _secondaryPage, null, ref secondaryPageView, null);
         }
         else {

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -83,6 +83,8 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
             project.AssureFirstPage();
         }
 
+        summaryView.SetProject(project);
+
         // Activate all page solvers for the summary view
         foreach (var page in project.pages) {
             _ = page.SolvePage();

--- a/Yafc/Workspace/SummaryView.cs
+++ b/Yafc/Workspace/SummaryView.cs
@@ -159,6 +159,7 @@ public class SummaryView : ProjectPageView<Summary> {
     private readonly SummaryDataColumn goodsColumn;
     private readonly DataGrid<ProjectPage> leftGrid;
     private readonly DataGrid<ProjectPage> rightGrid;
+    private readonly HashSet<ProjectPage> subscribedPages = [];
 
     private Dictionary<string, GoodDetails> allGoods = [];
 
@@ -210,20 +211,48 @@ public class SummaryView : ProjectPageView<Summary> {
 
     [MemberNotNull(nameof(project))]
     public void SetProject(Project project) {
-        if (this.project != null) {
-            this.project.metaInfoChanged -= Recalculate;
+        if (ReferenceEquals(this.project, project)) {
+            SyncPageSubscriptions();
+            Recalculate();
+            return;
+        }
 
-            foreach (ProjectPage page in this.project.pages) {
-                page.contentChanged -= Recalculate;
-            }
+        if (this.project != null) {
+            this.project.metaInfoChanged -= ProjectMetaInfoChanged;
+            UnsubscribeFromAllPages();
         }
 
         this.project = project;
-        project.metaInfoChanged += Recalculate;
+        project.metaInfoChanged += ProjectMetaInfoChanged;
+        SyncPageSubscriptions();
+
+        Recalculate();
+    }
+
+    private void ProjectMetaInfoChanged() {
+        SyncPageSubscriptions();
+        Recalculate();
+    }
+
+    private void SyncPageSubscriptions() {
+        foreach (ProjectPage page in subscribedPages.Where(page => !project.pages.Contains(page)).ToList()) {
+            page.contentChanged -= Recalculate;
+            _ = subscribedPages.Remove(page);
+        }
 
         foreach (ProjectPage page in project.pages) {
-            page.contentChanged += Recalculate;
+            if (subscribedPages.Add(page)) {
+                page.contentChanged += Recalculate;
+            }
         }
+    }
+
+    private void UnsubscribeFromAllPages() {
+        foreach (ProjectPage page in subscribedPages) {
+            page.contentChanged -= Recalculate;
+        }
+
+        subscribedPages.Clear();
     }
 
     protected override void BuildPageTooltip(ImGui gui, Summary contents) {
@@ -297,6 +326,8 @@ public class SummaryView : ProjectPageView<Summary> {
             }
         }
     }
+
+    protected override void ModelContentsChanged(bool visualOnly) => Recalculate(visualOnly);
 
     private async Task AutoBalance() {
         try {

--- a/Yafc/Workspace/SummaryView.cs
+++ b/Yafc/Workspace/SummaryView.cs
@@ -150,7 +150,7 @@ public class SummaryView : ProjectPageView<Summary> {
         public float sum;
     }
 
-    private Project project;
+    private Project project = null!;
     private SearchQuery searchQuery;
 
     private readonly LinkedScrollArea leftScrollArea;
@@ -195,7 +195,7 @@ public class SummaryView : ProjectPageView<Summary> {
         }
     }
 
-    public SummaryView(Project project) {
+    public SummaryView() {
         tabColumn = new SummaryTabColumn();
         goodsColumn = new SummaryDataColumn(this);
         leftGrid = new DataGrid<ProjectPage>(tabColumn);
@@ -205,8 +205,6 @@ public class SummaryView : ProjectPageView<Summary> {
         leftScrollArea = new LinkedScrollArea(DefaultScrollHeight, BuildLeftScrollArea, horizontal: false, drawVerticalScrollbar: false);
         rightScrollArea = new LinkedScrollArea(DefaultScrollHeight, BuildRightScrollArea, horizontal: true, drawVerticalScrollbar: true);
         leftScrollArea.Link(rightScrollArea);
-
-        SetProject(project);
     }
 
     [MemberNotNull(nameof(project))]

--- a/Yafc/Workspace/SummaryView.cs
+++ b/Yafc/Workspace/SummaryView.cs
@@ -325,6 +325,7 @@ public class SummaryView : ProjectPageView<Summary> {
         }
     }
 
+    // SetProject can recalculate before SetModel attaches the persisted showOnlyIssues value, which affects column width.
     protected override void ModelContentsChanged(bool visualOnly) => Recalculate(visualOnly);
 
     private async Task AutoBalance() {


### PR DESCRIPTION
Keep `SummaryView` subscribed to the active project pages and prevent it from recalculating before the main screen initializes the active project context.

## Triggering Steps
1. Open a project and open the Summary view.
2. Add or remove production pages, or switch to a different project.
3. Modify the contents of the current project pages and observe the Summary view.
4. Start the app and open an existing project with visible production-table data.

## Expected Behavior
The Summary view should subscribe only to pages in the current project, update when current pages change, release subscriptions for deleted pages or previous projects, and avoid recalculating until the active project context is initialized.

## Actual Behavior
The Summary view can miss updates for newly added pages or keep stale subscriptions to deleted pages or a previous project. During startup, the first version of this fix could also recalculate while `Project.current` was still uninitialized, which could crash when existing production-table data reached amount parsing.

## Detailed Explanation
`SummaryView` previously subscribed to the project pages that existed when it was initialized or rebound. It did not reliably synchronize those subscriptions when pages were added or removed, and project switching could leave the view subscribed to pages from the old project.

The subscription fix introduced an immediate recalculation in `SummaryView.SetProject`. That exposed an initialization-order problem: `MainScreen` constructed `SummaryView` before `MainScreen.SetProject` assigned `Project.current` and called `DataUtils.SetupForProject(project)`. For projects with existing nonzero production-table links or flows, the early recalculation could reach `DataUtils.TryParseAmount`, which assumes `Project.current` is initialized.

## Tactical Fix
`SummaryView` now tracks subscribed pages explicitly and resynchronizes those subscriptions when project metadata changes. It removes subscriptions for pages that are no longer present, subscribes to newly added pages, and rebinds cleanly when the active project changes.

As a stop-the-bleeding initialization fix, `SummaryView` construction no longer attaches a project or recalculates. `MainScreen.SetProject` attaches the Summary view only after `Project.current` and project data utilities are initialized. Summary pages are also not opened as secondary views, which avoids creating unattached secondary `SummaryView` instances through the generic secondary-view factory.

## Follow-Up Direction
A medium-sized follow-up would make `SummaryView` calculate strictly from its attached `Project` instead of indirectly relying on `Project.current` through amount formatting and parsing helpers. This is likely a moderate change across a small set of files, roughly on the order of several dozen to a couple hundred lines, depending on test coverage.

A larger architectural follow-up would introduce an explicit project context or project-scoped amount formatting/parsing service and gradually reduce hidden `Project.current` dependencies. That would require a formal design proposal because it would touch broader application lifecycle and utility APIs across multiple subprojects.