### PR TITLE
Cache C# data

### DIFF
--- a/Yafc.Model.Tests/LuaDependentTestHelper.cs
+++ b/Yafc.Model.Tests/LuaDependentTestHelper.cs
@@ -83,7 +83,8 @@ internal static class LuaDependentTestHelper {
             }
             context.Exec(bytes, "*", "");
 
-            project = new FactorioDataDeserializer(new(1, 1)).LoadData(null, context.data, (LuaTable)context.defines["prototypes"]!, false, helper, new(), false, false);
+            new FactorioDataDeserializer(new(1, 1)).LoadLuaData(context.data, (LuaTable)context.defines["prototypes"], false, helper, new(), false);
+            project = FactorioDataDeserializer.LoadProject(null, helper, new(), false);
         }
 
         DataUtils.SetupForProject(project);

--- a/Yafc.Model/Analysis/Analysis.cs
+++ b/Yafc.Model/Analysis/Analysis.cs
@@ -6,11 +6,11 @@ using Yafc.I18n;
 namespace Yafc.Model;
 
 public abstract class Analysis {
+    // Renaming either of these fields requires matching changes to the cache reader and writer.
     internal readonly HashSet<FactorioObject> excludedObjects = [];
+    private static readonly List<Analysis> analyses = [];
 
     public abstract void Compute(Project project, ErrorCollector warnings);
-
-    private static readonly List<Analysis> analyses = [];
 
     // TODO don't ignore dependencies
     public static void RegisterAnalysis(Analysis analysis, params Analysis[] dependencies) => analyses.Add(analysis);

--- a/Yafc.Model/Analysis/Analysis.cs
+++ b/Yafc.Model/Analysis/Analysis.cs
@@ -40,6 +40,12 @@ public abstract class Analysis {
             analysis.excludedObjects.Add(obj);
         }
     }
+
+    public static void ClearExclusions() {
+        foreach (Analysis analysis in analyses) {
+            analysis.excludedObjects.Clear();
+        }
+    }
 }
 
 public static class AnalysisExtensions {

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -710,7 +710,7 @@ public class EntityCrafter : EntityWithModules {
     public int itemInputs { get; internal set; }
     public int fluidInputs { get; internal set; } // fluid inputs for recipe, not including power
     public bool hasVectorToPlaceResult { get; internal set; }
-    public Goods[]? inputs { get; internal set; }
+    public Item[]? inputs { get; internal set; }
     public RecipeOrTechnology[] recipes { get; internal set; } = null!; // null-forgiving: Set in the first step of CalculateMaps
     private float _craftingSpeed = 1;
     // For rocket silos, the number of inventory slots. Launch recipes are limited by both weight and available slots.

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -44,6 +44,7 @@ public abstract class FactorioObject : IFactorioObjectWrapper, IComparable<Facto
     /// This value matches the numeric value of <c>Yafc.UI.Icon</c>
     /// and should only be interpreted in the UI layer via <c>GetIcon()</c>.
     /// </summary>
+    // Renaming iconId or id, or changing them to manual properties, requires matching changes to the Cache.fields initializer.
     public int iconId { get; internal set; }
     public FactorioId id { get; internal set; }
     internal abstract FactorioObjectSortOrder sortingOrder { get; }

--- a/Yafc.Model/Data/Database.cs
+++ b/Yafc.Model/Data/Database.cs
@@ -7,11 +7,17 @@ using System.Linq;
 namespace Yafc.Model;
 
 public static class Database {
-    // null-forgiveness for all static properties here:
+    // null-forgiveness for all not-null properties; they're initialized by LoadBuiltData.
+    // ----------------------------------------------------------------
+    // For caching, the properties in this section must match (by name and cache storage type) the corresponding parameter to LoadBuiltData.
+    public static int constantCombinatorCapacity { get; private set; }
     public static FactorioObject[] rootAccessible { get; private set; } = null!;
-    public static Item[] allSciencePacks { get; private set; } = null!;
-    public static Dictionary<string, FactorioObject> objectsByTypeName { get; private set; } = null!;
+    public static IObjectWithQuality<Special> heat { get; private set; } = null!; // Only the Special is stored in the cache.
     public static Dictionary<string, List<Fluid>> fluidVariants { get; private set; } = null!;
+    // End of the cache-dependent section. The remaining static properties are calculated based on the method parameters and known names.
+    // ----------------------------------------------------------------
+    public static Dictionary<string, FactorioObject> objectsByTypeName { get; private set; } = null!;
+    public static Item[] allSciencePacks { get; private set; } = null!;
     public static List<Special>? heatVariants { get; private set; }
     public static IObjectWithQuality<Goods> voidEnergy { get; private set; } = null!;
     public static IObjectWithQuality<Item> science { get; private set; } = null!;
@@ -19,7 +25,6 @@ public static class Database {
     public static IObjectWithQuality<Item> itemOutput { get; private set; } = null!;
     public static IObjectWithQuality<Special> electricity { get; private set; } = null!;
     public static IObjectWithQuality<Recipe> electricityGeneration { get; private set; } = null!;
-    public static IObjectWithQuality<Special> heat { get; private set; } = null!;
     public static Entity? character { get; private set; }
     public static EntityCrafter[] allCrafters { get; private set; } = null!;
     public static Module[] allModules { get; private set; } = null!;
@@ -40,7 +45,6 @@ public static class Database {
     public static FactorioIdRange<Entity> entities { get; private set; } = null!;
     public static FactorioIdRange<Quality> qualities { get; private set; } = null!;
     public static FactorioIdRange<Location> locations { get; private set; } = null!;
-    public static int constantCombinatorCapacity { get; private set; }
 
     /// <summary>
     /// Returns the set of beacons filtered to only those that can accept at least one module.
@@ -106,15 +110,20 @@ public static class Database {
     }
 
     /// <summary>
-    /// Initializes the <see cref="Database"/> class from the supplied parameters.
+    /// Initializes the <see cref="Database"/> class from the supplied parameters. For caching to work, most parameters must be stored in a readable
+    /// property with the same name and cache storage type.
     /// </summary>
     /// <param name="constantCombinatorCapacity">The number of values that can be set in a single constant combinator.</param>
     /// <param name="rootAccessible">The objects that are inherently accessible (character, nauvis, void, etc.).</param>
-    /// <param name="allObjects">The list of all objects.</param>
-    /// <param name="formerAliases">The old names of objects that were renamed by Yafc in the process of development.</param>
+    /// <param name="allObjects">The list of all objects. This does not have a matching property, and must accept a List&lt;FactorioObject>. Renaming
+    /// this parameter requires matching changes in the cache reader and writer.</param>
+    /// <param name="formerAliases">The old names of objects that were renamed by Yafc in the process of development.
+    /// This does not have a matching property, and must have the same cache storage type as a Dictionary&lt;string, FactorioObject>. Renaming this
+    /// parameter requires matching changes in the cache writer.</param>
     /// <param name="heat">The original heat object, which has probably been renamed heat@&lt;temperature>.</param>
     /// <param name="fluidVariants">The collection of all fluid variants from their original name.</param>
     // This method's parameters must be cachable objects. Notably, IObjectWithQuality is not currently cachable.
+    // Changing this method signature will invalidate existing caches. Except as noted above, the reader and writer will automatically adapt.
     internal static void LoadBuiltData(int constantCombinatorCapacity, FactorioObject[] rootAccessible, List<FactorioObject> allObjects,
         Dictionary<string, FactorioObject> formerAliases, Special heat, Dictionary<string, List<Fluid>> fluidVariants) {
 

--- a/Yafc.Model/Data/Database.cs
+++ b/Yafc.Model/Data/Database.cs
@@ -8,40 +8,39 @@ namespace Yafc.Model;
 
 public static class Database {
     // null-forgiveness for all static properties here:
-    public static FactorioObject[] rootAccessible { get; internal set; } = null!;
-    public static Item[] allSciencePacks { get; internal set; } = null!;
-    public static Dictionary<string, FactorioObject> objectsByTypeName { get; internal set; } = null!;
-    public static Dictionary<string, List<Fluid>> fluidVariants { get; internal set; } = null!;
-    public static List<Special>? heatVariants { get; internal set; }
-    public static IObjectWithQuality<Goods> voidEnergy { get; internal set; } = null!;
-    public static IObjectWithQuality<Item> science { get; internal set; } = null!;
-    public static IObjectWithQuality<Item> itemInput { get; internal set; } = null!;
-    public static IObjectWithQuality<Item> itemOutput { get; internal set; } = null!;
-    public static IObjectWithQuality<Special> electricity { get; internal set; } = null!;
-    public static IObjectWithQuality<Recipe> electricityGeneration { get; internal set; } = null!;
-    public static IObjectWithQuality<Special> heat { get; internal set; } = null!;
-    public static Entity? character { get; internal set; }
-    public static EntityCrafter[] allCrafters { get; internal set; } = null!;
-    public static Module[] allModules { get; internal set; } = null!;
-    public static EntityBeacon[] allBeacons { get; internal set; } = null!;
-    public static EntityBelt[] allBelts { get; internal set; } = null!;
-    public static EntityInserter[] allInserters { get; internal set; } = null!;
-    public static EntityAccumulator[] allAccumulators { get; internal set; } = null!;
-    public static EntityContainer[] allContainers { get; internal set; } = null!;
-    public static FactorioIdRange<FactorioObject> objects { get; internal set; } = null!;
-    public static FactorioIdRange<Goods> goods { get; internal set; } = null!;
-    public static FactorioIdRange<Special> specials { get; internal set; } = null!;
-    public static FactorioIdRange<Item> items { get; internal set; } = null!;
-    public static FactorioIdRange<Fluid> fluids { get; internal set; } = null!;
-    public static FactorioIdRange<Recipe> recipes { get; internal set; } = null!;
-    public static FactorioIdRange<Mechanics> mechanics { get; internal set; } = null!;
-    public static FactorioIdRange<RecipeOrTechnology> recipesAndTechnologies { get; internal set; } = null!;
-    public static FactorioIdRange<Technology> technologies { get; internal set; } = null!;
-    public static FactorioIdRange<Entity> entities { get; internal set; } = null!;
-    public static FactorioIdRange<Quality> qualities { get; internal set; } = null!;
-    public static FactorioIdRange<Location> locations { get; internal set; } = null!;
-    public static int constantCombinatorCapacity { get; internal set; } = 18;
-    public static int rocketCapacity { get; internal set; }
+    public static FactorioObject[] rootAccessible { get; private set; } = null!;
+    public static Item[] allSciencePacks { get; private set; } = null!;
+    public static Dictionary<string, FactorioObject> objectsByTypeName { get; private set; } = null!;
+    public static Dictionary<string, List<Fluid>> fluidVariants { get; private set; } = null!;
+    public static List<Special>? heatVariants { get; private set; }
+    public static IObjectWithQuality<Goods> voidEnergy { get; private set; } = null!;
+    public static IObjectWithQuality<Item> science { get; private set; } = null!;
+    public static IObjectWithQuality<Item> itemInput { get; private set; } = null!;
+    public static IObjectWithQuality<Item> itemOutput { get; private set; } = null!;
+    public static IObjectWithQuality<Special> electricity { get; private set; } = null!;
+    public static IObjectWithQuality<Recipe> electricityGeneration { get; private set; } = null!;
+    public static IObjectWithQuality<Special> heat { get; private set; } = null!;
+    public static Entity? character { get; private set; }
+    public static EntityCrafter[] allCrafters { get; private set; } = null!;
+    public static Module[] allModules { get; private set; } = null!;
+    public static EntityBeacon[] allBeacons { get; private set; } = null!;
+    public static EntityBelt[] allBelts { get; private set; } = null!;
+    public static EntityInserter[] allInserters { get; private set; } = null!;
+    public static EntityAccumulator[] allAccumulators { get; private set; } = null!;
+    public static EntityContainer[] allContainers { get; private set; } = null!;
+    public static FactorioIdRange<FactorioObject> objects { get; private set; } = null!;
+    public static FactorioIdRange<Goods> goods { get; private set; } = null!;
+    public static FactorioIdRange<Special> specials { get; private set; } = null!;
+    public static FactorioIdRange<Item> items { get; private set; } = null!;
+    public static FactorioIdRange<Fluid> fluids { get; private set; } = null!;
+    public static FactorioIdRange<Recipe> recipes { get; private set; } = null!;
+    public static FactorioIdRange<Mechanics> mechanics { get; private set; } = null!;
+    public static FactorioIdRange<RecipeOrTechnology> recipesAndTechnologies { get; private set; } = null!;
+    public static FactorioIdRange<Technology> technologies { get; private set; } = null!;
+    public static FactorioIdRange<Entity> entities { get; private set; } = null!;
+    public static FactorioIdRange<Quality> qualities { get; private set; } = null!;
+    public static FactorioIdRange<Location> locations { get; private set; } = null!;
+    public static int constantCombinatorCapacity { get; private set; }
 
     /// <summary>
     /// Returns the set of beacons filtered to only those that can accept at least one module.
@@ -104,6 +103,89 @@ public static class Database {
         }
 
         return null;
+    }
+
+    /// <summary>
+    /// Initializes the <see cref="Database"/> class from the supplied parameters.
+    /// </summary>
+    /// <param name="constantCombinatorCapacity">The number of values that can be set in a single constant combinator.</param>
+    /// <param name="rootAccessible">The objects that are inherently accessible (character, nauvis, void, etc.).</param>
+    /// <param name="allObjects">The list of all objects.</param>
+    /// <param name="formerAliases">The old names of objects that were renamed by Yafc in the process of development.</param>
+    /// <param name="heat">The original heat object, which has probably been renamed heat@&lt;temperature>.</param>
+    /// <param name="fluidVariants">The collection of all fluid variants from their original name.</param>
+    // This method's parameters must be cachable objects. Notably, IObjectWithQuality is not currently cachable.
+    internal static void LoadBuiltData(int constantCombinatorCapacity, FactorioObject[] rootAccessible, List<FactorioObject> allObjects,
+        Dictionary<string, FactorioObject> formerAliases, Special heat, Dictionary<string, List<Fluid>> fluidVariants) {
+
+        Database.constantCombinatorCapacity = constantCombinatorCapacity;
+        Database.rootAccessible = rootAccessible;
+        objectsByTypeName = allObjects.ToDictionary(x => x.typeDotName);
+        foreach (var alias in formerAliases) {
+            _ = objectsByTypeName.TryAdd(alias.Key, alias.Value);
+        }
+
+        // null-forgiving: inputs is always initialized for labs
+        allSciencePacks = [.. allObjects.OfType<EntityCrafter>().Where(c => c.factorioType == "lab").SelectMany(l => l.inputs!).Distinct()];
+        voidEnergy = ((Goods)objectsByTypeName["Power." + SpecialNames.Void]).With(Quality.Normal);
+        science = ((Item)objectsByTypeName["Item.science"]).With(Quality.Normal);
+        itemInput = ((Item)objectsByTypeName["Item.item-total-input"]).With(Quality.Normal);
+        itemOutput = ((Item)objectsByTypeName["Item.item-total-output"]).With(Quality.Normal);
+        electricity = ((Special)objectsByTypeName["Power." + SpecialNames.Electricity]).With(Quality.Normal);
+        electricityGeneration = ((Recipe)objectsByTypeName[$"Mechanics.{SpecialNames.GeneratorRecipe}.{SpecialNames.Electricity}"]).With(Quality.Normal);
+        Database.heat = heat.With(Quality.Normal);
+        if (objectsByTypeName.TryGetValue("Entity.character", out var ch)) {
+            character = (Entity)ch;
+        }
+
+        int firstSpecial = 0;
+        int firstItem = skip(firstSpecial, FactorioObjectSortOrder.SpecialGoods);
+        int firstFluid = skip(firstItem, FactorioObjectSortOrder.Items);
+        int firstRecipe = skip(firstFluid, FactorioObjectSortOrder.Fluids);
+        int firstMechanics = skip(firstRecipe, FactorioObjectSortOrder.Recipes);
+        int firstTechnology = skip(firstMechanics, FactorioObjectSortOrder.Mechanics);
+        int firstEntity = skip(firstTechnology, FactorioObjectSortOrder.Technologies);
+        int firstTile = skip(firstEntity, FactorioObjectSortOrder.Entities);
+        int firstQuality = skip(firstTile, FactorioObjectSortOrder.Tiles);
+        int firstLocation = skip(firstQuality, FactorioObjectSortOrder.Qualities);
+        int firstTrigger = skip(firstLocation, FactorioObjectSortOrder.Locations);
+        int last = skip(firstTrigger, FactorioObjectSortOrder.Triggers);
+        if (last != allObjects.Count) {
+            throw new Exception("Something is not right");
+        }
+
+        objects = new FactorioIdRange<FactorioObject>(0, last, allObjects);
+        specials = new FactorioIdRange<Special>(firstSpecial, firstItem, allObjects);
+        items = new FactorioIdRange<Item>(firstItem, firstFluid, allObjects);
+        fluids = new FactorioIdRange<Fluid>(firstFluid, firstRecipe, allObjects);
+        goods = new FactorioIdRange<Goods>(firstSpecial, firstRecipe, allObjects);
+        recipes = new FactorioIdRange<Recipe>(firstRecipe, firstTechnology, allObjects);
+        mechanics = new FactorioIdRange<Mechanics>(firstMechanics, firstTechnology, allObjects);
+        recipesAndTechnologies = new FactorioIdRange<RecipeOrTechnology>(firstRecipe, firstEntity, allObjects);
+        technologies = new FactorioIdRange<Technology>(firstTechnology, firstEntity, allObjects);
+        entities = new FactorioIdRange<Entity>(firstEntity, firstTile, allObjects);
+        qualities = new FactorioIdRange<Quality>(firstQuality, firstLocation, allObjects);
+        locations = new FactorioIdRange<Location>(firstLocation, firstTrigger, allObjects);
+        Database.fluidVariants = fluidVariants;
+        heatVariants = heat.variants;
+
+        allModules = [.. items.all.OfType<Module>()];
+        allBeacons = [.. entities.all.OfType<EntityBeacon>()];
+        allCrafters = [.. entities.all.OfType<EntityCrafter>()];
+        allBelts = [.. entities.all.OfType<EntityBelt>()];
+        allInserters = [.. entities.all.OfType<EntityInserter>()];
+        allAccumulators = [.. entities.all.OfType<EntityAccumulator>()];
+        allContainers = [.. entities.all.OfType<EntityContainer>()];
+
+        int skip(int from, FactorioObjectSortOrder sortOrder) {
+            for (; from < allObjects.Count; from++) {
+                if (allObjects[from].sortingOrder != sortOrder) {
+                    break;
+                }
+            }
+
+            return from;
+        }
     }
 }
 
@@ -245,4 +327,27 @@ public readonly struct Mapping<TKey1, TKey2, TValue> where TKey1 : FactorioObjec
     public ArraySegment<TValue> GetSlice(TKey1 row) => new ArraySegment<TValue>(data, ((int)row.id - offset1) * count1, count1);
 
     public FactorioId IndexToId(int index) => (FactorioId)(index + offset2);
+}
+
+public static class SpecialNames {
+    public const string BurnableFluid = "burnable-fluid.";
+    public const string Heat = "heat";
+    public const string Void = "void";
+    public const string Electricity = "electricity";
+    public const string HotFluid = "hot-fluid";
+    public const string SpecificFluid = "fluid.";
+    public const string MiningRecipe = "mining.";
+    public const string BoilerRecipe = "boiler.";
+    public const string FakeRecipe = "fake-recipe";
+    public const string FixedRecipe = "fixed-recipe.";
+    public const string GeneratorRecipe = "generator";
+    public const string PumpingRecipe = "pump.";
+    public const string Labs = "labs.";
+    public const string TechnologyTrigger = "technology-trigger";
+    public const string RocketLaunch = "launch";
+    public const string RocketCraft = "rocket.";
+    public const string ReactorRecipe = "reactor";
+    public const string SpoilRecipe = "spoil";
+    public const string PlantRecipe = "plant";
+    public const string AsteroidCapture = "asteroid-capture";
 }

--- a/Yafc.Model/Data/Database.cs
+++ b/Yafc.Model/Data/Database.cs
@@ -10,7 +10,7 @@ public static class Database {
     // null-forgiveness for all not-null properties; they're initialized by LoadBuiltData.
     // ----------------------------------------------------------------
     // For caching, the properties in this section must match (by name and cache storage type) the corresponding parameter to LoadBuiltData.
-    public static int constantCombinatorCapacity { get; private set; }
+    public static int constantCombinatorCapacity { get; private set; } = 18; // Keep this initializer for the tests.
     public static FactorioObject[] rootAccessible { get; private set; } = null!;
     public static IObjectWithQuality<Special> heat { get; private set; } = null!; // Only the Special is stored in the cache.
     public static Dictionary<string, List<Fluid>> fluidVariants { get; private set; } = null!;

--- a/Yafc.Parser/Data/DataParserUtils.cs
+++ b/Yafc.Parser/Data/DataParserUtils.cs
@@ -112,26 +112,3 @@ internal static class DataParserUtils {
         }
     }
 }
-
-public static class SpecialNames {
-    public const string BurnableFluid = "burnable-fluid.";
-    public const string Heat = "heat";
-    public const string Void = "void";
-    public const string Electricity = "electricity";
-    public const string HotFluid = "hot-fluid";
-    public const string SpecificFluid = "fluid.";
-    public const string MiningRecipe = "mining.";
-    public const string BoilerRecipe = "boiler.";
-    public const string FakeRecipe = "fake-recipe";
-    public const string FixedRecipe = "fixed-recipe.";
-    public const string GeneratorRecipe = "generator";
-    public const string PumpingRecipe = "pump.";
-    public const string Labs = "labs.";
-    public const string TechnologyTrigger = "technology-trigger";
-    public const string RocketLaunch = "launch";
-    public const string RocketCraft = "rocket.";
-    public const string ReactorRecipe = "reactor";
-    public const string SpoilRecipe = "spoil";
-    public const string PlantRecipe = "plant";
-    public const string AsteroidCapture = "asteroid-capture";
-}

--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -193,9 +193,8 @@ internal partial class FactorioDataDeserializer {
     }
 
     /// <summary>
-    /// Process the data loaded from Factorio and the mods, and load the project specified by <paramref name="projectPath"/>.
+    /// Process the data loaded from Factorio and the mods.
     /// </summary>
-    /// <param name="projectPath">The path to the project file to create or load. May be <see langword="null"/> or empty.</param>
     /// <param name="data">The Lua table data (containing data.raw) that was populated by the lua scripts.</param>
     /// <param name="prototypes">The Lua table defines.prototypes that was populated by the lua scripts.</param>
     /// <param name="netProduction">If <see langword="true"/>, recipe selection windows will only display recipes that provide net production or consumption 
@@ -205,12 +204,10 @@ internal partial class FactorioDataDeserializer {
     /// but will appear as only producing U-235 and consuming U-238 when <see langword="true"/>.</param>
     /// <param name="progress">An <see cref="IProgress{T}"/> that receives two strings describing the current loading state.</param>
     /// <param name="errorCollector">An <see cref="ErrorCollector"/> that will collect the errors and warnings encountered while loading and processing the file and data.</param>
-    /// <param name="renderIcons">If <see langword="true"/>, Yafc will render the icons necessary for UI display.</param>
-    /// <param name="useLatestSave">If <see langword="true"/>, Yafc will try to find the most recent autosave.</param>
-    /// <returns>A <see cref="Project"/> containing the information loaded from <paramref name="projectPath"/>. Also sets the <see langword="static"/> properties
-    /// in <see cref="Database"/>.</returns>
-    public Project LoadData(string projectPath, LuaTable data, LuaTable prototypes, bool netProduction,
-        IProgress<(string, string)> progress, ErrorCollector errorCollector, bool renderIcons, bool useLatestSave) {
+    /// <param name="renderIcons">If <see langword="true"/>, Yafc will start rendering the icons necessary for UI display. To wait for the rendering
+    /// to complete, call <see cref="WaitForRendering"/>.</param>
+    public void LoadLuaData(LuaTable data, LuaTable prototypes, bool netProduction, IProgress<(string, string)> progress,
+        ErrorCollector errorCollector, bool renderIcons) {
 
         progress.Report((LSs.ProgressLoading, LSs.ProgressLoadingItems));
         raw = (LuaTable?)data["raw"] ?? throw new ArgumentException("Could not load data.raw from data argument", nameof(data));
@@ -222,7 +219,6 @@ internal partial class FactorioDataDeserializer {
             DeserializePrototypes(raw, (string)prototypeName, DeserializeItem, progress, errorCollector);
         }
 
-        allModules.AddRange(allObjects.OfType<Module>());
         progress.Report((LSs.ProgressLoading, LSs.ProgressLoadingFluids));
         DeserializePrototypes(raw, "fluid", DeserializeFluid, progress, errorCollector);
         progress.Report((LSs.ProgressLoading, LSs.ProgressLoadingTiles));
@@ -266,30 +262,54 @@ internal partial class FactorioDataDeserializer {
         UpdateSplitHeats();
         UpdateRecipeIngredientFluids(errorCollector);
         CalculateMaps(netProduction);
-        var iconRenderTask = renderIcons ? Task.Run(RenderIcons) : Task.CompletedTask;
+        StartRendering(renderIcons, allObjects);
         UpdateRecipeCatalysts();
         CalculateItemWeights();
         ObjectWithQuality.LoadCache(allObjects);
-        ExportBuiltData();
+        Database.LoadBuiltData(constantCombinatorCapacity, [.. rootAccessible], allObjects, formerAliases, heat, fluidVariants);
+
         progress.Report((LSs.ProgressPostprocessing, LSs.ProgressCalculatingDependencies));
         Dependencies.Calculate();
         TechnologyLoopsFinder.FindTechnologyLoops();
+    }
+
+    public void StartRendering(bool renderIcons, ICollection<FactorioObject> objects) => iconRenderTask = renderIcons ? Task.Run(() => RenderIcons(objects)) : Task.CompletedTask;
+
+    /// <summary>
+    /// Load the project specified by <paramref name="projectPath"/>.
+    /// </summary>
+    /// <param name="projectPath">The path to the project file to create or load. May be <see langword="null"/> or empty.</param>
+    /// <param name="progress">An <see cref="IProgress{T}"/> that receives two strings describing the current loading state.</param>
+    /// <param name="errorCollector">An <see cref="ErrorCollector"/> that will collect the errors and warnings encountered while loading and processing the file and data.</param>
+    /// <param name="useLatestSave">If <see langword="true"/>, Yafc will try to find the most recent autosave.</param>
+    /// <returns>A <see cref="Project"/> containing the information loaded from <paramref name="projectPath"/>. Also sets the <see langword="static"/> properties
+    /// in <see cref="Database"/>.</returns>
+    public static Project LoadProject(string projectPath, IProgress<(string, string)> progress, ErrorCollector errorCollector, bool useLatestSave) {
         progress.Report((LSs.ProgressPostprocessing, LSs.ProgressCreatingProject));
         Project project = Project.ReadFromFile(projectPath, errorCollector, useLatestSave);
         Analysis.ProcessAnalyses(progress, project, errorCollector);
-        progress.Report((LSs.ProgressRenderingIcons, ""));
-        iconRenderedProgress = progress;
-        iconRenderTask.Wait();
-
         return project;
     }
 
-    private IProgress<(string, string)>? iconRenderedProgress;
+    /// <summary>
+    /// Block until the current rendering task is complete.
+    /// </summary>
+    /// <param name="progress">An <see cref="IProgress{T}"/> that receives two strings describing the current icon rendering state.</param>
+    public void WaitForRendering(IProgress<(string, string)> progress) {
+        if (iconRenderTask.IsCompleted) { return; }
 
-    private Icon CreateSimpleIcon(Dictionary<(string mod, string path), IntPtr> cache, string graphicsPath)
+        progress.Report((LSs.ProgressRenderingIcons, ""));
+        iconRenderedProgress = progress;
+        iconRenderTask.Wait();
+    }
+
+    private IProgress<(string, string)>? iconRenderedProgress;
+    private Task iconRenderTask = Task.CompletedTask;
+
+    private static Icon CreateSimpleIcon(Dictionary<(string mod, string path), IntPtr> cache, string graphicsPath)
         => CreateIconFromSpec(cache, new FactorioIconPart("__core__/graphics/" + graphicsPath + ".png"));
 
-    private void RenderIcons() {
+    private void RenderIcons(ICollection<FactorioObject> allObjects) {
         Dictionary<(string mod, string path), IntPtr> cache = [];
         try {
             foreach (char digit in "0123456789d") {
@@ -342,7 +362,7 @@ internal partial class FactorioDataDeserializer {
         }
     }
 
-    private unsafe Icon CreateIconFromSpec(Dictionary<(string mod, string path), IntPtr> cache, params FactorioIconPart[] spec) {
+    private static unsafe Icon CreateIconFromSpec(Dictionary<(string mod, string path), IntPtr> cache, params FactorioIconPart[] spec) {
         const int cachedIconSize = IconCollection.IconSize;
         int renderSize = MathUtils.Round(spec[0].size * spec[0].scale);
         nint targetSurface = SDL.SDL_CreateRGBSurfaceWithFormat(0, renderSize, renderSize, 0, SDL.SDL_PIXELFORMAT_RGBA8888);

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
@@ -14,30 +14,23 @@ internal partial class FactorioDataDeserializer {
     private readonly DataBucket<Entity, string> fuelUsers = new DataBucket<Entity, string>();
     private readonly DataBucket<string, RecipeOrTechnology> recipeCategories = new DataBucket<string, RecipeOrTechnology>();
     private readonly DataBucket<EntityCrafter, string> recipeCrafters = new DataBucket<EntityCrafter, string>();
-    private readonly DataBucket<Recipe, Module> recipeModules = new DataBucket<Recipe, Module>();
     private readonly Dictionary<Item, List<string>> placeResults = [];
     private readonly Dictionary<Item, string> plantResults = [];
     private readonly DataBucket<string, Entity> asteroids = new();
-    private readonly List<Module> allModules = [];
-    private readonly HashSet<Item> sciencePacks = [];
     private readonly Dictionary<string, List<Fluid>> fluidVariants = [];
     private readonly Dictionary<string, FactorioObject> formerAliases = [];
 
-    private readonly Recipe generatorProduction;
     private readonly Special voidEnergy;
     private readonly Special heat;
-    private readonly Special electricity;
     private readonly Special rocketLaunch;
     private readonly Item science;
-    // Note: These must be Items (or possibly a derived type) so belt capacity can be displayed and set.
-    private readonly Item totalItemOutput, totalItemInput;
-    private readonly EntityEnergy voidEntityEnergy;
-    private readonly EntityEnergy laborEntityEnergy;
-    private Entity? character;
+    private readonly EntityEnergy voidEntityEnergy = new EntityEnergy { type = EntityEnergyType.Void, effectivity = float.PositiveInfinity };
+    private readonly EntityEnergy laborEntityEnergy = new EntityEnergy { type = EntityEnergyType.Labor, effectivity = float.PositiveInfinity };
     private EntityCrafter? spoilageEntity;
     private readonly Version factorioVersion;
     private int rocketCapacity;
     private int defaultItemWeight;
+    private int constantCombinatorCapacity = 18;
 
     internal static readonly Version v0_18 = new Version(0, 18);
     internal static readonly Version v2_0 = new Version(2, 0);
@@ -74,7 +67,7 @@ internal partial class FactorioDataDeserializer {
             return obj;
         }
 
-        electricity = createSpecialObject(true, SpecialNames.Electricity, LSs.SpecialObjectElectricity, LSs.SpecialObjectElectricityDescription,
+        var electricity = createSpecialObject(true, SpecialNames.Electricity, LSs.SpecialObjectElectricity, LSs.SpecialObjectElectricityDescription,
             "__core__/graphics/icons/alerts/electricity-icon-unplugged.png", "signal-E");
 
         heat = createSpecialObject(true, SpecialNames.Heat, LSs.SpecialObjectHeat, LSs.SpecialObjectHeatDescription, "__core__/graphics/arrows/heat-exchange-indication.png", "signal-H");
@@ -104,17 +97,14 @@ internal partial class FactorioDataDeserializer {
         Analysis.ExcludeFromAnalysis<CostAnalysis>(science);
         formerAliases["Special.research-unit"] = science;
 
-        generatorProduction = CreateSpecialRecipe(electricity, SpecialNames.GeneratorRecipe, LSs.SpecialRecipeGenerating);
+        var generatorProduction = CreateSpecialRecipe(electricity, SpecialNames.GeneratorRecipe, LSs.SpecialRecipeGenerating);
         generatorProduction.products = [new Product(electricity, 1f)];
         generatorProduction.flags |= RecipeFlags.ScaleProductionWithPower;
         generatorProduction.ingredients = [];
 
-        voidEntityEnergy = new EntityEnergy { type = EntityEnergyType.Void, effectivity = float.PositiveInfinity };
-        laborEntityEnergy = new EntityEnergy { type = EntityEnergyType.Labor, effectivity = float.PositiveInfinity };
-
         // Note: These must be Items (or possibly a derived type) so belt capacity can be displayed and set.
-        totalItemInput = createSpecialItem("item-total-input", LSs.SpecialItemTotalConsumption, LSs.SpecialItemTotalConsumptionDescription, "__base__/graphics/icons/signal/signal_I.png");
-        totalItemOutput = createSpecialItem("item-total-output", LSs.SpecialItemTotalProduction, LSs.SpecialItemTotalProductionDescription, "__base__/graphics/icons/signal/signal_O.png");
+        Item totalItemInput = createSpecialItem("item-total-input", LSs.SpecialItemTotalConsumption, LSs.SpecialItemTotalConsumptionDescription, "__base__/graphics/icons/signal/signal_I.png");
+        Item totalItemOutput = createSpecialItem("item-total-output", LSs.SpecialItemTotalProduction, LSs.SpecialItemTotalProductionDescription, "__base__/graphics/icons/signal/signal_O.png");
         formerAliases["Special.total-item-input"] = totalItemInput;
         formerAliases["Special.total-item-output"] = totalItemOutput;
     }
@@ -259,74 +249,6 @@ internal partial class FactorioDataDeserializer {
         allObjects.Add(newObject);
         registeredObjects[key] = newObject;
         return newObject;
-    }
-
-    private int Skip(int from, FactorioObjectSortOrder sortOrder) {
-        for (; from < allObjects.Count; from++) {
-            if (allObjects[from].sortingOrder != sortOrder) {
-                break;
-            }
-        }
-
-        return from;
-    }
-
-    private void ExportBuiltData() {
-        Database.rootAccessible = [.. rootAccessible];
-        Database.objectsByTypeName = allObjects.ToDictionary(x => x.typeDotName);
-        foreach (var alias in formerAliases) {
-            _ = Database.objectsByTypeName.TryAdd(alias.Key, alias.Value);
-        }
-
-        Database.allSciencePacks = [.. sciencePacks];
-        Database.voidEnergy = voidEnergy.With(Quality.Normal);
-        Database.science = science.With(Quality.Normal);
-        Database.itemInput = totalItemInput.With(Quality.Normal);
-        Database.itemOutput = totalItemOutput.With(Quality.Normal);
-        Database.electricity = electricity.With(Quality.Normal);
-        Database.electricityGeneration = generatorProduction.With(Quality.Normal);
-        Database.heat = heat.With(Quality.Normal);
-        Database.character = character;
-        int firstSpecial = 0;
-        int firstItem = Skip(firstSpecial, FactorioObjectSortOrder.SpecialGoods);
-        int firstFluid = Skip(firstItem, FactorioObjectSortOrder.Items);
-        int firstRecipe = Skip(firstFluid, FactorioObjectSortOrder.Fluids);
-        int firstMechanics = Skip(firstRecipe, FactorioObjectSortOrder.Recipes);
-        int firstTechnology = Skip(firstMechanics, FactorioObjectSortOrder.Mechanics);
-        int firstEntity = Skip(firstTechnology, FactorioObjectSortOrder.Technologies);
-        int firstTile = Skip(firstEntity, FactorioObjectSortOrder.Entities);
-        int firstQuality = Skip(firstTile, FactorioObjectSortOrder.Tiles);
-        int firstLocation = Skip(firstQuality, FactorioObjectSortOrder.Qualities);
-        int firstTrigger = Skip(firstLocation, FactorioObjectSortOrder.Locations);
-        int last = Skip(firstTrigger, FactorioObjectSortOrder.Triggers);
-        if (last != allObjects.Count) {
-            throw new Exception("Something is not right");
-        }
-
-        Database.objects = new FactorioIdRange<FactorioObject>(0, last, allObjects);
-        Database.specials = new FactorioIdRange<Special>(firstSpecial, firstItem, allObjects);
-        Database.items = new FactorioIdRange<Item>(firstItem, firstFluid, allObjects);
-        Database.fluids = new FactorioIdRange<Fluid>(firstFluid, firstRecipe, allObjects);
-        Database.goods = new FactorioIdRange<Goods>(firstSpecial, firstRecipe, allObjects);
-        Database.recipes = new FactorioIdRange<Recipe>(firstRecipe, firstTechnology, allObjects);
-        Database.mechanics = new FactorioIdRange<Mechanics>(firstMechanics, firstTechnology, allObjects);
-        Database.recipesAndTechnologies = new FactorioIdRange<RecipeOrTechnology>(firstRecipe, firstEntity, allObjects);
-        Database.technologies = new FactorioIdRange<Technology>(firstTechnology, firstEntity, allObjects);
-        Database.entities = new FactorioIdRange<Entity>(firstEntity, firstTile, allObjects);
-        Database.qualities = new FactorioIdRange<Quality>(firstQuality, firstLocation, allObjects);
-        Database.locations = new FactorioIdRange<Location>(firstLocation, firstTrigger, allObjects);
-        Database.fluidVariants = fluidVariants;
-        Database.heatVariants = heat.variants;
-
-        Database.allModules = [.. allModules];
-        Database.allBeacons = [.. Database.entities.all.OfType<EntityBeacon>()];
-        Database.allCrafters = [.. Database.entities.all.OfType<EntityCrafter>()];
-        Database.allBelts = [.. Database.entities.all.OfType<EntityBelt>()];
-        Database.allInserters = [.. Database.entities.all.OfType<EntityInserter>()];
-        Database.allAccumulators = [.. Database.entities.all.OfType<EntityAccumulator>()];
-        Database.allContainers = [.. Database.entities.all.OfType<EntityContainer>()];
-
-        Database.rocketCapacity = rocketCapacity;
     }
 
     private static bool AreInverseRecipes(Recipe packing, Recipe unpacking) {

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
@@ -36,6 +36,7 @@ internal partial class FactorioDataDeserializer {
     internal static readonly Version v2_0 = new Version(2, 0);
 
     public FactorioDataDeserializer(Version factorioVersion) {
+        Analysis.ClearExclusions();
         this.factorioVersion = factorioVersion;
 
         Special createSpecialObject(bool isPower, string name, string locName, string locDescr, string icon, string signal) {

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
@@ -328,14 +328,13 @@ internal partial class FactorioDataDeserializer {
 
                 character.energy = laborEntityEnergy;
                 if (character.name == "character") {
-                    this.character = character;
                     character.mapGenerated = true;
                     rootAccessible.Insert(0, character);
                 }
                 break;
             case "constant-combinator":
                 if (name == "constant-combinator") {
-                    Database.constantCombinatorCapacity = table.Get("item_slot_count", 18);
+                    constantCombinatorCapacity = table.Get("item_slot_count", 18);
                 }
                 break;
             case "container":
@@ -435,7 +434,6 @@ internal partial class FactorioDataDeserializer {
                 recipeCrafters.Add(lab, SpecialNames.Labs);
                 _ = table.Get("inputs", out LuaTable? inputs);
                 lab.inputs = [.. inputs.ArrayElements<string>().Select(GetObject<Item>)];
-                sciencePacks.UnionWith(lab.inputs.Select(x => (Item)x));
                 lab.itemInputs = lab.inputs.Length;
                 break;
             case "logistic-container":

--- a/Yafc.Parser/FactorioDataSource.Cache.cs
+++ b/Yafc.Parser/FactorioDataSource.Cache.cs
@@ -1,0 +1,539 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
+using System.IO.Hashing;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+using System.Text;
+using SharpCompress.Compressors;
+using SharpCompress.Compressors.LZMA;
+using Yafc.I18n;
+using Yafc.Model;
+
+namespace Yafc.Parser;
+
+public static partial class FactorioDataSource {
+    private static class Cache {
+        // The cache file contains the data version and last access time, uncompressed, and a compressed stream of:
+        // A 1-byte index into Cache.types for each object, indicating its concrete type, terminated by the byte FF.
+        // The value of each field in each object, in the order fields[objectType], fields[objectType.BaseType], fields[objectType.BT.BT], ...:
+        //     00 indicates null if it's possible for the value to be null.
+        //     ints and enums use .NET's 7-bit integer encoding.
+        //     FactorioObjects are serialized as their id plus one
+        //     Lazy<>s are never null and are serialized as their Value. (i.e. 00 indicates a Lazy that returns null or zero, not a null Lazy.)
+        //     LocalizableStrings are serialized as their key.
+        //     Collections and strings are (length+1)-prefixed, followed by <length> objects or bytes.
+        //     Other nested types are 01-prefixed (if needed to indicate not null), then written one field at a time.
+        // After the objects are written, the additional data necessary for Database.LoadBuiltData and Analysis.excludedObjects is written in the
+        // same format.
+        // For probably-paranoia reasons, the CRC is written at the end of the compressed stream and also after the compressed stream. If either CRC
+        //     is missing, the cached data will not be used.
+
+        // -----------------------------------------------------------
+
+        // Increment this to forcibly invalidate all existing cached data. This should happen when a change to FactorioDataDeserializer changes
+        //     "Lua is loaded successfully but incorrectly" to "Lua is loaded successfully and correctly", and the change is not accompanied by a
+        //     change to the Mod-fixes folder or the types, fields, or loadDataParameters static fields.
+        // If the Lua previously didn't load at all, this should not be updated.
+        // Also increment this if the compressed data format changes, for example if strings are deduplicated.
+        private const uint CACHE_DATA_VERSION = 0;
+
+        // The number of cache files that are allowed to exist before YAFC starts deleting old ones.
+        private const int MAX_CACHE_COUNT = 20;
+
+        private static readonly List<Type> types = [.. typeof(FactorioObject).Assembly.GetTypes()
+            .Where(t => t.IsAssignableTo(typeof(FactorioObject))).OrderBy(t => t.IsAbstract).ThenBy(t => t.Name),
+            typeof(FactorioIconPart), typeof(ModuleSpecification), typeof(Ingredient), typeof(Product), typeof(EntityEnergy), typeof(EffectReceiver),
+            typeof(Effect), typeof(TemperatureRange)];
+        private static readonly Dictionary<Type, int> typeDictionary = new(types.Select((x, i) => KeyValuePair.Create(x, i)));
+
+        private static readonly Dictionary<Type, List<FieldInfo>> fields = types
+            .Select(t => KeyValuePair.Create(t, t.GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)
+                .Where(f => f.DeclaringType == t && !f.Name.Contains("<iconId>") && !f.Name.Contains("<id>")).OrderBy(f => f.Name)
+                .ToList()))
+            .ToDictionary();
+
+        private static readonly MethodInfo loadBuiltData = typeof(Database)
+            .GetMethod(nameof(Database.LoadBuiltData), BindingFlags.Static | BindingFlags.NonPublic)!;
+        private static readonly ParameterInfo[] loadDataParameters = loadBuiltData.GetParameters();
+
+        /// <summary>
+        /// Takes the partially-computed hash, and appends data that depends on the capabilities of the current version of Yafc.
+        /// </summary>
+        /// <returns>The fully-computed hash to be used for file lookup and cache coherency checks.</returns>
+        private static uint GetHash(Crc32 hash) {
+            hash = hash.Clone();
+            foreach (var type in types) {
+                hash.Append(Encoding.UTF8.GetBytes(type.Name));
+                foreach (var field in fields[type]) {
+                    hash.Append(Encoding.UTF8.GetBytes(field.Name));
+                }
+            }
+            foreach (var param in loadDataParameters) {
+                hash.Append(Encoding.UTF8.GetBytes(param.Name!));
+            }
+
+            return hash.GetCurrentHashAsUInt32();
+        }
+
+        /// <summary>
+        /// Gets the full path to the platform-dependent folder where cache files should be stored, and creates that folder if necessary.
+        /// </summary>
+        private static string GetCacheDirectory() {
+            string path;
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+                path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData), "YAFC/cache");
+            }
+            else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX)) {
+                path = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), "Library/Caches/yafc");
+            }
+            else { // Anything else, including Linux, *BSD, Solaris, etc.
+                path = Environment.GetEnvironmentVariable("XDG_CACHE_HOME") ??
+                    Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".cache");
+                path = Path.Combine(path, "yafc");
+            }
+            Directory.CreateDirectory(path);
+            return path;
+        }
+
+        /// <summary>
+        /// Gets the full path to the cache file for C# data.
+        /// </summary>
+        /// <param name="hash">The hash used for file lookup and cache coherency checks.</param>
+        /// <returns></returns>
+        private static string GetCSharpCacheFile(uint hash) => Path.Combine(GetCacheDirectory(), $"{hash:X8}.csharpcache");
+
+        /// <summary>
+        /// Writes data into the appropriate cache file from the storage maintained by <see cref="Database"/> and <see cref="Analysis"/>.
+        /// (<see cref="ObjectWithQuality"/> must be initialized by the cache reader, but that only requires the data in <see cref="Database"/>.)
+        /// </summary>
+        /// <param name="modData">A <see cref="Crc32"/> that has been initialized with data dependent on the active mods, mod versions, and mod
+        /// settings. To load this file, a <see cref="Crc32"/> initialized with the same data must be passed to <see cref="ReadCSharp"/>.</param>
+        /// <returns>An <see cref="Action"/> that should be executed asynchronously to write the cache file.</returns>
+        public static Action WriteCSharp(Crc32 modData) => () => {
+            try {
+                uint hash = GetHash(modData);
+
+                // This will throw if the cache is open in any other process, either in ReadCSharp or WriteCSharp.
+                using Stream stream = File.Open(GetCSharpCacheFile(hash), FileMode.Create, FileAccess.Write, FileShare.Read);
+                stream.Write(BitConverter.GetBytes(CACHE_DATA_VERSION));
+                stream.Write(BitConverter.GetBytes(DateTime.UtcNow.ToBinary()));
+
+                using (BinaryWriter writer = new(LZipStream.Create(stream, CompressionMode.Compress, true))) {
+                    // Write the type of each object.
+                    foreach (FactorioObject obj in Database.objects.all) {
+                        int index = typeDictionary[obj.GetType()];
+                        // If this fires, we have at least 256 concrete types derived from FactorioObject. Should some of them be abstract or removed?
+                        // If not, read and write ushorts instead of bytes. The hash will change, so CACHE_DATA_VERSION does not need to be updated.
+                        Debug.Assert(index < 0xFF);
+                        writer.Write((byte)index);
+                    }
+                    writer.Write((byte)0xFF);
+
+                    // Write the field data for each object.
+                    foreach (FactorioObject obj in Database.objects.all) {
+                        Type currentType = obj.GetType();
+                        while (currentType != typeof(object)) {
+                            foreach (var field in fields[currentType]) {
+                                writeValue(writer, field.FieldType, field.GetValue(obj));
+                            }
+                            currentType = currentType.BaseType!;
+                        }
+                    }
+
+                    // Write the additional data needed by Database.LoadBuiltData
+                    foreach (ParameterInfo parameter in loadDataParameters) {
+                        if (parameter.Name == "formerAliases") {
+                            // Recalculate the names that were included in formerAliases
+                            var aliases = Database.objectsByTypeName.Where(kvp => kvp.Key != kvp.Value.typeDotName).ToDictionary();
+                            writeValue(writer, aliases.GetType(), aliases);
+                        }
+                        else if (parameter.Name != "allObjects") { // Skip allObjects; it's everything we already wrote for Database.objects.all
+                            object? value = typeof(Database).GetProperty(parameter.Name!)!.GetValue(null);
+                            if (value is IObjectWithQuality<FactorioObject> objectWithQuality) {
+                                value = objectWithQuality.target;
+                            }
+                            // Write the value stored in the property with the same name.
+                            writeValue(writer, parameter.ParameterType, value);
+                        }
+                    }
+
+                    // Write the additional data stored in Analysis.excludedObjects.
+                    var excludedObjects = typeof(Analysis).GetField("excludedObjects", BindingFlags.Instance | BindingFlags.NonPublic)!;
+                    foreach (var analysis in (IEnumerable<Analysis>)typeof(Analysis)
+                        .GetField("analyses", BindingFlags.Static | BindingFlags.NonPublic)!.GetValue(null)!) {
+
+                        writeValue(writer, excludedObjects.FieldType, excludedObjects.GetValue(analysis));
+                    }
+                    writer.Write(hash);
+                } // End compressed stream
+
+                stream.Write(BitConverter.GetBytes(hash));
+
+                // We might have created a new file. Check to see if we need to delete any old ones.
+                DeleteOldFiles();
+            }
+            catch (Exception ex) {
+                logger.Warning(ex, "Could not write data cache.");
+            }
+
+            // Write one value of the type fieldType, recursing as necessary for complex values.
+            static void writeValue(BinaryWriter writer, Type fieldType, object? value) {
+                if (value == null) {
+                    writer.Write((byte)0);
+                }
+                // Simple values (bool, float, nullable, string)
+                else if (fieldType.IsGenericType && fieldType.GetGenericTypeDefinition() == typeof(Nullable<>)) {
+                    // Nullable must appear before the value is <type> tests, since (float?)5 matches the type pattern float.
+                    writer.Write((byte)1);
+                    writeValue(writer, fieldType.GenericTypeArguments[0], value);
+                }
+                else if (value is bool b) {
+                    writer.Write(b);
+                }
+                else if (fieldType == typeof(int) || (fieldType.IsEnum && fieldType.GetEnumUnderlyingType() == typeof(int))
+                    || fieldType == typeof(uint) || (fieldType.IsEnum && fieldType.GetEnumUnderlyingType() == typeof(uint))) {
+
+                    writer.Write7BitEncodedInt((int)value);
+                }
+                else if (value is float f) {
+                    writer.Write(f);
+                }
+                else if (value is string or LocalizableString) {
+                    if (value is not string str) {
+                        str = (string)typeof(LocalizableString).GetField("key", BindingFlags.Instance | BindingFlags.NonPublic)!.GetValue(value)!;
+                    }
+
+                    byte[] bytes = Encoding.UTF8.GetBytes(str);
+                    writer.Write7BitEncodedInt(bytes.Length + 1);
+                    writer.Write(bytes);
+                }
+
+                // Yafc types (FactorioObject, Ingredient, Effect, etc.)
+                else if (value is FactorioObject o) {
+                    writer.Write7BitEncodedInt((int)o.id + 1);
+                }
+                else if (fields.TryGetValue(fieldType, out var nestedFields)) {
+                    writer.Write((byte)1);
+                    foreach (var field in nestedFields) {
+                        object? nested = field.GetValue(value);
+                        writeValue(writer, field.FieldType, nested);
+                    }
+                }
+
+                // Collections
+                // IDictionary must be before IEnumerable, since all IDictionaries are also IEnumerables
+                else if (fieldType.IsGenericType && value is IDictionary dictionary) {
+                    Type keyType = fieldType.GenericTypeArguments[0];
+                    Type valueType = fieldType.GenericTypeArguments[1];
+                    writer.Write7BitEncodedInt(dictionary.Count + 1);
+                    foreach (DictionaryEntry entry in dictionary) {
+                        writeValue(writer, keyType, entry.Key);
+                        writeValue(writer, valueType, entry.Value);
+                    }
+                }
+                else if ((fieldType.IsSZArray || fieldType.IsGenericType) && value is IEnumerable list && getCount(fieldType) is { } countProp) {
+                    // HashSet<> doesn't have a non-generic Count property, so we have to call its Count property through reflection.
+                    // We might as well do it for everything else too.
+                    writer.Write7BitEncodedInt((int)countProp.GetValue(value)! + 1);
+                    Type type = fieldType.GetElementType() /* Arrays */ ?? fieldType.GenericTypeArguments[0] /* everything else */;
+                    foreach (object? item in list) {
+                        writeValue(writer, type, item);
+                    }
+                }
+
+                // Other weird types
+                else if (fieldType.IsGenericType && fieldType.GetGenericTypeDefinition() == typeof(Lazy<>)) {
+                    writeValue(writer, fieldType.GenericTypeArguments[0], value.GetType().GetProperty("Value")!.GetValue(value));
+                }
+                else if (fieldType.FullName!.StartsWith("System.ValueTuple`") && value is ITuple { Length: < 8 } tuple) {
+                    // Restricted to System.ValueTuple of up to seven elements.
+                    // Lengths of eight or more and System.Tuple values require reader updates (writing Rest and m_Item#)
+                    for (int i = 0; i < tuple.Length; i++) {
+                        object? nestedValue = tuple[i];
+                        writeValue(writer, nestedValue?.GetType()!, nestedValue); // null-forgiving: If value is null, the type is not used.
+                    }
+                }
+
+                else {
+                    throw new Exception($"Don't know how to serialize {fieldType} into the cache. Does it need to be added to '{nameof(types)}'?");
+                }
+            }
+
+            // Get a .Count property for this type, if at least one exists.
+            static PropertyInfo? getCount(Type type) {
+                var count = type.GetInterfaces().SelectMany(i => i.GetProperties()).FirstOrDefault(p => p.Name == "Count");
+                if (count != null) {
+                    return count;
+                }
+
+                while (type != null) {
+                    count = type.GetProperty("Count");
+                    if (count != null) {
+                        return count;
+                    }
+                    type = type.BaseType!;
+                }
+
+                return null;
+            }
+        };
+
+        /// <summary>
+        /// Tries to load data from the appropriate cache file into the storage maintained by <see cref="ObjectWithQuality"/>, <see cref="Database"/>,
+        /// and <see cref="Analysis"/>.
+        /// </summary>
+        /// <param name="progress">An <see cref="IProgress{T}"/> that receives two strings describing the current loading state.</param>
+        /// <param name="modData">A <see cref="Crc32"/> that has been initialized with data dependent on the active mods, mod versions, and mod
+        /// settings. This must match the <see cref="Crc32"/> passed to <see cref="WriteCSharp"/> when this file was written.</param>
+        /// <returns><see langword="true"/> if the data was successfully loaded from the cache file, or <see langword="false"/> if the CRC did not
+        /// match or an error occurred.</returns>
+        public static bool ReadCSharp(IProgress<(string, string)> progress, Crc32 modData) {
+            try {
+                uint hash = GetHash(modData);
+
+                // This will throw if the file doesn't exist, or if WriteCSharp has the file open in any process.
+                using Stream stream = File.Open(GetCSharpCacheFile(hash), FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+
+                byte[] bytes = new byte[4];
+                if (stream.Read(bytes) != 4 || BitConverter.ToUInt32(bytes) != CACHE_DATA_VERSION) {
+                    logger.Information($"Cache file has unrecognized data version {BitConverter.ToUInt32(bytes)}.");
+                    return false;
+                }
+
+                stream.Seek(-4, SeekOrigin.End);
+                if (stream.Read(bytes) != 4 || BitConverter.ToUInt32(bytes) != hash) {
+                    logger.Information($"Cache file is missing its terminating uncompressed CRC.");
+                    return false;
+                }
+
+                stream.Position = 4;
+                stream.Write(BitConverter.GetBytes(DateTime.UtcNow.ToBinary())); // Update the atime
+
+                using BinaryReader reader = new(LZipStream.Create(stream, CompressionMode.Decompress));
+                byte typeId;
+                // Read the type of each FactorioObject, and construct empty storage.
+                List<FactorioObject> objects = [];
+                while ((typeId = reader.ReadByte()) != 0xFF) {
+                    FactorioObject obj = (FactorioObject)Activator.CreateInstance(types[typeId])!;
+                    obj.id = (FactorioId)objects.Count;
+                    objects.Add(obj);
+                }
+
+                // Read the field data for each object
+                foreach (FactorioObject obj in objects) {
+                    if ((int)obj.id % 1000 == 0) {
+                        progress.Report((LSs.ProgressLoadingCache, LSs.ProgressRenderingXOfY.L((int)obj.id, objects.Count)));
+                    }
+                    Type currentType = obj.GetType();
+                    while (currentType != typeof(object)) {
+                        foreach (var field in fields[currentType]) {
+                            field.SetValue(obj, readValue(reader, field.FieldType, objects));
+                        }
+                        currentType = currentType.BaseType!;
+                    }
+                }
+
+                Quality.Normal = objects.OfType<Quality>().Single(q => q.name == "normal");
+                ObjectWithQuality.LoadCache(objects);
+                List<object?> parameters = [];
+
+                // Read the additional data needed by Database.LoadBuiltData
+                foreach (ParameterInfo parameter in loadDataParameters) {
+                    if (parameter.Name == "allObjects") {
+                        parameters.Add(objects);
+                    }
+                    else {
+                        // No special case for formerAliases here; just read the Dictionary from the cache
+                        parameters.Add(readValue(reader, parameter.ParameterType, objects));
+                    }
+                }
+                // and call Database.LoadBuiltData
+                loadBuiltData.Invoke(null, [.. parameters]);
+
+                // Load and store the additional data for Analysis.excludedObjects.
+                var excludedObjects = typeof(Analysis).GetField("excludedObjects", BindingFlags.Instance | BindingFlags.NonPublic)!;
+                foreach (var analysis in (IEnumerable<Analysis>)typeof(Analysis)
+                    .GetField("analyses", BindingFlags.Static | BindingFlags.NonPublic)!.GetValue(null)!) {
+
+                    excludedObjects.SetValue(analysis, readValue(reader, excludedObjects.FieldType, objects));
+                }
+
+                // Validate the end-of-compression CRC.
+                if (reader.ReadUInt32() != hash) {
+                    logger.Information("Compressed cache data did not end with with the expected CRC.");
+                    return false;
+                }
+            }
+            catch (Exception ex) {
+                logger.Information(ex, "Could not load data cache.");
+                return false;
+            }
+
+            return true;
+
+            // Read and return one value of the type fieldType, recursing as necessary for complex values.
+            // Index into objects when loading a FactorioObject.
+            static object? readValue(BinaryReader reader, Type fieldType, List<FactorioObject> objects) {
+                // We can't preemptively convert 0 to null here, at least without checking for quite a few special cases.
+                // Simple values (bool, float, nullable, string)
+                if (fieldType.IsGenericType && fieldType.GetGenericTypeDefinition() == typeof(Nullable<>)) {
+                    if (reader.ReadByte() == 0) {
+                        return null;
+                    }
+                    return readValue(reader, fieldType.GenericTypeArguments[0], objects);
+                }
+                else if (fieldType == typeof(bool)) {
+                    return reader.ReadBoolean();
+                }
+                else if (fieldType == typeof(int) || (fieldType.IsEnum && fieldType.GetEnumUnderlyingType() == typeof(int))
+                    || fieldType == typeof(uint) || (fieldType.IsEnum && fieldType.GetEnumUnderlyingType() == typeof(uint))) {
+
+                    return reader.Read7BitEncodedInt();
+                }
+                else if (fieldType == typeof(float)) {
+                    return reader.ReadSingle();
+                }
+                else if (fieldType == typeof(string) || fieldType.IsAssignableTo(typeof(LocalizableString))) {
+                    int length = reader.Read7BitEncodedInt() - 1;
+                    if (length == -1) { return null; }
+                    if (length == 0 && fieldType == typeof(string)) { return ""; }
+
+                    string value = Encoding.UTF8.GetString(reader.ReadBytes(length));
+                    if (fieldType == typeof(string)) {
+                        return value;
+                    }
+
+                    if (fieldType == typeof(LocalizableString)) {
+                        // We can't create an abstract LocalizableString. Use LS0 as a backup. In the absence of dynamic (its presence is unlikely),
+                        // the consumers will never take advantage of the implicit conversion or the .L() method.
+                        fieldType = typeof(LocalizableString0);
+                    }
+
+                    return Activator.CreateInstance(fieldType, BindingFlags.Instance | BindingFlags.NonPublic, null, [value], null);
+                }
+
+                // Yafc types (FactorioObject, Ingredient, Effect, etc.)
+                else if (fieldType.IsAssignableTo(typeof(FactorioObject))) {
+                    int idx = reader.Read7BitEncodedInt();
+                    if (idx == 0) { return null; }
+                    return objects[idx - 1];
+                }
+                else if (fields.TryGetValue(fieldType, out var nestedFields)) {
+                    if (reader.ReadByte() == 0) {
+                        return null;
+                    }
+
+                    // Get an empty object we can populate
+                    object resultObject = RuntimeHelpers.GetUninitializedObject(fieldType);
+
+                    foreach (var field in nestedFields) {
+                        field.SetValue(resultObject, readValue(reader, field.FieldType, objects));
+                    }
+                    return resultObject;
+                }
+
+                // Collections
+                // IDictionary must be before IEnumerable, since all IDictionaries are also IEnumerables
+                else if (fieldType.IsGenericType && fieldType.IsAssignableTo(typeof(IDictionary))) {
+                    int count = reader.Read7BitEncodedInt() - 1;
+                    if (count == -1) { return null; }
+
+                    IDictionary resultObject = (IDictionary)Activator.CreateInstance(fieldType, [count])!;
+                    Type keyType = fieldType.GenericTypeArguments[0];
+                    Type valueType = fieldType.GenericTypeArguments[1];
+
+                    for (int i = 0; i < count; i++) {
+                        object key = readValue(reader, keyType, objects) ?? throw new($"Read a null key for a field of type {fieldType}.");
+                        resultObject[key] = readValue(reader, valueType, objects);
+                    }
+                    return resultObject;
+                }
+                else if (fieldType.IsSZArray || (fieldType.IsGenericType && fieldType.IsAssignableTo(typeof(IEnumerable)))) {
+                    int count = reader.Read7BitEncodedInt() - 1;
+                    if (count == -1) { return null; }
+
+                    if (fieldType.IsSZArray) {
+                        Type elementType = fieldType.GetElementType()!;
+                        IList array = Array.CreateInstance(elementType, count)!;
+                        for (int i = 0; i < count; i++) {
+                            array[i] = readValue(reader, elementType, objects);
+                        }
+                        return array;
+                    }
+                    else {
+                        Type elementType = fieldType.GenericTypeArguments[0];
+                        Type listType = typeof(List<>).MakeGenericType(elementType);
+                        IList list = (IList)Activator.CreateInstance(listType, [count])!;
+                        for (int i = 0; i < count; i++) {
+                            list.Add(readValue(reader, elementType, objects));
+                        }
+                        if (listType.IsAssignableTo(fieldType)) {
+                            return list;
+                        }
+                        // HashSet<> doesn't have a non-generic Add method, so construct a List<> first and rebuild it as a HashSet.
+                        return Activator.CreateInstance(fieldType, [list])!;
+                    }
+                }
+
+                // Other weird types
+                else if (fieldType.IsGenericType && fieldType.GetGenericTypeDefinition() == typeof(Lazy<>)) {
+                    Type valueType = fieldType.GenericTypeArguments[0];
+                    var constructor = fieldType.GetConstructor([valueType])!;
+                    return constructor.Invoke([readValue(reader, valueType, objects)]);
+                }
+                else if (fieldType.IsGenericType && fieldType.FullName!.StartsWith("System.ValueTuple`")) {
+                    object? tuple = Activator.CreateInstance(fieldType);
+                    var valueTypes = fieldType.GenericTypeArguments;
+                    for (int i = 0; i < valueTypes.Length; i++) {
+                        fieldType.GetField("Item" + (i + 1))!.SetValue(tuple, readValue(reader, valueTypes[i], objects));
+                    }
+                    return tuple;
+                }
+
+                else {
+                    throw new Exception($"Don't know how to deserialize {fieldType} from the cache. Does it need to be added to '{nameof(types)}'?");
+                }
+            }
+        }
+
+        /// <summary>
+        /// Delete old files matching <paramref name="pattern"/> in the <see cref="GetCachePath">cache path</see>. Files are 'old' if there are at
+        /// least <see cref="MAX_CACHE_COUNT"/> files with newer last-accessed times.
+        /// </summary>
+        private static void DeleteOldFiles() {
+            PriorityQueue<string, ulong> queue = new();
+            foreach (string file in Directory.EnumerateFiles(GetCacheDirectory(), "*.csharpcache")) {
+                try {
+                    using BinaryReader reader = new(File.Open(file, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete));
+
+                    if (reader.ReadInt32() != CACHE_DATA_VERSION) {
+                        // Delete files with an invalid version; they won't be useful unless you roll back to an older version of YAFC.
+                        // The delete works even though we still have the file open; FileShare.Delete allows deletion before we close the file.
+                        // It'll fail in the unlikely case that another process has the file open in ReadCSharp or WriteCSharp.
+                        tryDelete(file);
+                    }
+                    else if (queue.Count == MAX_CACHE_COUNT) {
+                        // We found a twenty-first file with valid version; delete the oldest.
+                        tryDelete(queue.EnqueueDequeue(file, reader.ReadUInt64()));
+                    }
+                    else {
+                        queue.Enqueue(file, reader.ReadUInt64());
+                    }
+                }
+                catch { /* Can't check this file for expiry; ignore it. */ }
+            }
+
+            static void tryDelete(string path) {
+                try {
+                    File.Delete(path);
+                }
+                catch { /* Can't delete this file; ignore it. */ }
+            }
+        }
+    }
+}

--- a/Yafc.Parser/FactorioDataSource.cs
+++ b/Yafc.Parser/FactorioDataSource.cs
@@ -2,9 +2,12 @@
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
+using System.IO.Hashing;
 using System.Linq;
+using System.Text;
 using System.Text.Json;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using Serilog;
 using Yafc.I18n;
 using Yafc.Model;
@@ -132,14 +135,39 @@ public static partial class FactorioDataSource {
         catch (DirectoryNotFoundException) { /* No Yafc translation for this locale */ }
     }
 
-    private static void FindMods(string directory, IProgress<(string, string)> progress, List<ModInfo> mods) {
+    /// <summary>
+    /// Version-sensitively loads metadata for the mods found in <paramref name="directory"/>, and appends them to <paramref name="mods"/>.
+    /// </summary>
+    /// <param name="directory">The path to search for mods.</param>
+    /// <param name="isBuiltIn">If <see langword="true"/>, <paramref name="directory"/> contains core and base, and possibly the SA mods.</param>
+    /// <param name="progress">An <see cref="IProgress{T}"/> that receives two strings describing the current loading state.</param>
+    /// <param name="mods">The <see cref="List{T}"/> that will receive the newly-discovered mods.</param>
+    private static void FindMods(string directory, bool isBuiltIn, IProgress<(string, string)> progress, List<ModInfo> mods) {
+        Crc32 modHash = new();
         foreach (string entry in Directory.EnumerateDirectories(directory)) {
             string infoFile = Path.Combine(entry, "info.json");
 
             if (File.Exists(infoFile)) {
                 progress.Report((LSs.ProgressInitializing, entry));
-                ModInfo info = new(entry, File.ReadAllBytes(infoFile));
+                byte[] infoBytes = File.ReadAllBytes(infoFile);
+
+                if (isBuiltIn) {
+                    // The official mods only load the info.json, since loading and hashing multiple megabytes takes longer than I'd like.
+                    modHash.Append(infoBytes);
+                }
+                else {
+                    // Other mods (and all zipped mods, below) load all lua and language data.
+                    foreach (string file in Directory.GetFiles(entry, "*.lua", SearchOption.AllDirectories).Order()
+                        .Concat(Directory.GetFiles(entry, "*.cfg", SearchOption.AllDirectories).Order())) {
+
+                        byte[] bytes = File.ReadAllBytes(file);
+                        appendEntry(modHash, Path.GetRelativePath(entry, file), bytes.Length, Crc32.HashToUInt32(bytes));
+                    }
+                }
+
+                ModInfo info = new(entry, infoBytes, modHash.GetCurrentHashAsUInt32());
                 mods.Add(info);
+                modHash.Reset();
             }
         }
 
@@ -152,12 +180,28 @@ public static partial class FactorioDataSource {
                     x.FullName.IndexOf('/') == x.FullName.Length - "info.json".Length - 1);
 
                 if (infoEntry != null) {
-                    ModInfo info = new(infoEntry.FullName[..^"info.json".Length], infoEntry.Open().ReadAllBytes((int)infoEntry.Length)) {
-                        zipArchive = zipArchive
-                    };
+                    string folder = infoEntry.FullName[..^"info.json".Length];
+
+                    // built-in mods are never zipped
+                    foreach (var fileEntry in zipArchive.Entries.Where(e => e.FullName.EndsWith(".lua")).OrderBy(e => e.FullName)
+                        .Concat(zipArchive.Entries.Where(e => e.FullName.EndsWith(".cfg")).OrderBy(e => e.FullName))) {
+
+                        // GetRelativePath converts zip's always-/-delimited paths to the OS's native delimiters, matching unzipped relative paths.
+                        appendEntry(modHash, Path.GetRelativePath(folder, fileEntry.FullName), fileEntry.Length, fileEntry.Crc32);
+                    }
+
+                    ModInfo info = new(folder, infoEntry.Open().ReadAllBytes((int)infoEntry.Length), modHash.GetCurrentHashAsUInt32(), zipArchive);
                     mods.Add(info);
+                    modHash.Reset();
                 }
             }
+        }
+
+        // Append a filesystem entry or zip entry to the mod's running hash.
+        static void appendEntry(Crc32 modHash, string relativePath, long size, uint fileCrc) {
+            modHash.Append(Encoding.UTF8.GetBytes(relativePath));
+            modHash.Append(BitConverter.GetBytes(size));
+            modHash.Append(BitConverter.GetBytes(fileCrc));
         }
     }
 
@@ -212,10 +256,10 @@ public static partial class FactorioDataSource {
             logger.Information("Mod list parsed");
 
             List<ModInfo> allFoundMods = [];
-            FindMods(factorioPath, progress, allFoundMods);
+            FindMods(factorioPath, true, progress, allFoundMods);
 
             if (modPath != factorioPath && modPath != "") {
-                FindMods(modPath, progress, allFoundMods);
+                FindMods(modPath, false, progress, allFoundMods);
             }
 
             if (!hasModList) {
@@ -348,11 +392,10 @@ public static partial class FactorioDataSource {
                     LoadModLocale(mod, "en");
                 }
             }
-            if (locale != null) {
-                foreach (string mod in modLoadOrder) {
-                    CurrentLoadingMod = mod;
-                    LoadModLocale(mod, locale);
-                }
+
+            foreach (string mod in modLoadOrder) {
+                CurrentLoadingMod = mod;
+                LoadModLocale(mod, locale);
             }
 
             byte[] preProcess = File.ReadAllBytes("Data/Sandbox.lua");
@@ -366,33 +409,64 @@ public static partial class FactorioDataSource {
             dataContext = new LuaContext(factorioVersion);
             object? settings = null;
 
+            Crc32 modData = new();
             if (File.Exists(modSettingsPath)) {
                 using (FileStream fs = new FileStream(Path.Combine(modPath, "mod-settings.dat"), FileMode.Open, FileAccess.Read)) {
                     settings = FactorioPropertyTree.ReadModSettings(new BinaryReader(fs), dataContext);
                 }
 
                 logger.Information("Mod settings parsed");
+                modData.Append(File.ReadAllBytes(Path.Combine(modPath, "mod-settings.dat")));
             }
             settings ??= dataContext.NewTable();
 
             // TODO default mod settings
             dataContext.SetGlobal("settings", settings);
 
-            _ = dataContext.Exec(preProcess, "*", "pre", dataContext.Exec(defines, "*", "defines"));
-            dataContext.DoModFiles(modLoadOrder, "data.lua", progress);
-            dataContext.DoModFiles(modLoadOrder, "data-updates.lua", progress);
-            dataContext.DoModFiles(modLoadOrder, "data-final-fixes.lua", progress);
-            CurrentLoadingMod = null;
-            byte[] postProcess;
-            if (factorioVersion < FactorioDataDeserializer.v2_0) {
-                postProcess = File.ReadAllBytes($"Data/Postprocess1.1.lua");
-                _ = dataContext.Exec(postProcess, "*", "post");
+            foreach (string mod in modLoadOrder) {
+                modData.Append(BitConverter.GetBytes(allMods[mod].crc));
             }
-            postProcess = File.ReadAllBytes($"Data/Postprocess.lua");
-            _ = dataContext.Exec(postProcess, "*", "post");
+
+            foreach (string modFix in Directory.EnumerateFiles("Data/Mod-fixes", "*.lua")) {
+                modData.Append(File.ReadAllBytes(modFix));
+            }
+            foreach (string localeFile in Directory.EnumerateFiles("Data/locale/en", "*.cfg")) {
+                modData.Append(File.ReadAllBytes(localeFile));
+            }
+            if (Directory.Exists(Path.Combine("Data/locale", locale))) {
+                foreach (string localeFile in Directory.EnumerateFiles(Path.Combine("Data/locale", locale), "*.cfg")) {
+                    modData.Append(File.ReadAllBytes(localeFile));
+                }
+            }
+            modData.Append(Encoding.UTF8.GetBytes(locale));
 
             FactorioDataDeserializer deserializer = new FactorioDataDeserializer(factorioVersion ?? defaultFactorioVersion);
-            deserializer.LoadLuaData(dataContext.data, (LuaTable)dataContext.defines["prototypes"]!, netProduction, progress, errorCollector, renderIcons);
+            if (Cache.ReadCSharp(progress, modData)) {
+                deserializer.StartRendering(renderIcons, Database.objects.all);
+
+                progress.Report((LSs.ProgressPostprocessing, LSs.ProgressCalculatingDependencies));
+                Dependencies.Calculate();
+                TechnologyLoopsFinder.FindTechnologyLoops();
+            }
+            else {
+                _ = dataContext.Exec(preProcess, "*", "pre", dataContext.Exec(defines, "*", "defines"));
+                dataContext.DoModFiles(modLoadOrder, "data.lua", progress);
+                dataContext.DoModFiles(modLoadOrder, "data-updates.lua", progress);
+                dataContext.DoModFiles(modLoadOrder, "data-final-fixes.lua", progress);
+                CurrentLoadingMod = null;
+                byte[] postProcess;
+                if (factorioVersion < FactorioDataDeserializer.v2_0) {
+                    postProcess = File.ReadAllBytes($"Data/Postprocess1.1.lua");
+                    _ = dataContext.Exec(postProcess, "*", "post");
+                }
+                postProcess = File.ReadAllBytes($"Data/Postprocess.lua");
+                _ = dataContext.Exec(postProcess, "*", "post");
+
+                deserializer.LoadLuaData(dataContext.data, (LuaTable)dataContext.defines["prototypes"]!, netProduction, progress, errorCollector, renderIcons);
+
+                Task.Run(Cache.WriteCSharp(modData));
+            }
+
             var project = FactorioDataDeserializer.LoadProject(projectPath, progress, errorCollector, useLatestSave);
             deserializer.WaitForRendering(progress);
             logger.Information("Completed!");
@@ -448,8 +522,9 @@ public static partial class FactorioDataSource {
 
         public ZipArchive? zipArchive;
         public string folder;
+        public uint crc;
 
-        public ModInfo(string folder, byte[] json, ZipArchive? zipArchive = null) {
+        public ModInfo(string folder, byte[] json, uint crc, ZipArchive? zipArchive = null) {
             this.folder = folder;
             this.zipArchive = zipArchive;
             Newtonsoft.Json.JsonSerializer.Create().Populate(new StreamReader(new MemoryStream(json)), this);
@@ -457,6 +532,7 @@ public static partial class FactorioDataSource {
             parsedVersion = parsedV ?? new Version();
             _ = Version.TryParse(factorio_version, out parsedV);
             parsedFactorioVersion = parsedV ?? defaultFactorioVersion;
+            this.crc = crc;
         }
 
         public void ParseDependencies() {

--- a/Yafc.Parser/FactorioDataSource.cs
+++ b/Yafc.Parser/FactorioDataSource.cs
@@ -392,7 +392,9 @@ public static partial class FactorioDataSource {
             _ = dataContext.Exec(postProcess, "*", "post");
 
             FactorioDataDeserializer deserializer = new FactorioDataDeserializer(factorioVersion ?? defaultFactorioVersion);
-            var project = deserializer.LoadData(projectPath, dataContext.data, (LuaTable)dataContext.defines["prototypes"]!, netProduction, progress, errorCollector, renderIcons, useLatestSave);
+            deserializer.LoadLuaData(dataContext.data, (LuaTable)dataContext.defines["prototypes"]!, netProduction, progress, errorCollector, renderIcons);
+            var project = FactorioDataDeserializer.LoadProject(projectPath, progress, errorCollector, useLatestSave);
+            deserializer.WaitForRendering(progress);
             logger.Information("Completed!");
             progress.Report((LSs.ProgressCompleted, ""));
 

--- a/Yafc.Parser/Yafc.Parser.csproj
+++ b/Yafc.Parser/Yafc.Parser.csproj
@@ -18,6 +18,8 @@
     <ItemGroup>
       <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="5.3.0" />
       <PackageReference Include="Newtonsoft.Json" Version="13.0.4" />
+      <PackageReference Include="SharpCompress" Version="0.49.1" />
+      <PackageReference Include="System.IO.Hashing" Version="10.0.8" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Yafc/Data/locale/en/yafc.cfg
+++ b/Yafc/Data/locale/en/yafc.cfg
@@ -14,6 +14,7 @@ circular-mod-dependencies=Mods dependencies are circular. Unable to load mods: _
 ; In most languages, this should have a trailing space:
 list-separator=, 
 progress-completed=Completed!
+progress-loading-cache=Loading cached mod data
 
 ; LuaContext.cs
 progress-executing-mod-at-data-stage=Executing mods __1__


### PR DESCRIPTION
I spent too much time on this, mostly because I got tired of watching pypost spend 15 seconds thinking for no obvious reason.
This definitely fails to make Yafc simpler; it adds a cache that stores the data in all the C# objects Yafc uses, and attempts to load that data instead of executing the Lua. If loading the cache fails for any reason, it logs the error and reverts to Lua execution.

In exchange for the complexity, and a small amount of storage, it makes Yafc faster in many cases. Some rough timings on my computer (from clicking Load to main screen display) are:
|Mod pack|First load|Cached load|Cache size|
|-|-|-|-|
|PyHM|27 sec|3 sec|568 KB|
|kry-all-planets|35 sec|11 sec|1.6 MB|
|SE|3 sec|1.4 sec|147 KB|
|AngelBob|10 sec|8 sec|287 KB|

kry-all-planets takes about 5 seconds after the main screen appears to finish writing the cache file. If you exit Yafc before then, it leaves behind a ~~corrupt (invalid CRC, but also~~ truncated cache file, and ~~you'll have to~~ the missing CRC will make YAFC execute the lua again.

It appears AngelBob would benefit from an icon cache, but I don't want to make this cache depend on SDL. A second cache file named icondata.yafccache could be added for that purpose.

### Discussion points/concerns
1. There is no feedback on when the cache writing completes. Is this a problem?
1. The cache uses file dates (of the active zip files and active unzipped lua files) to determine cache validity, along with the fields in the stored object types. Are there other things that should be considered?
1. I spend [some effort](https://github.com/DaleStan/yafc/blob/c19018b3dfbc55242371cde3b7056b66423ee563/Yafc.Parser/FactorioDataSource.Cache.cs#L354-L365) tricking types without default constructors into letting me construct them anyway. This is somewhat fragile, since it relies on the constructors not enforcing is-not-null requirements. A `[CacheHandlers(nameof(ReadMethod), nameof(WriteMethod))]` attribute could be used instead. Is that desirable? Is it a reverse dependency?
1. I also have code that caches the data and defines tables. This creates larger cache files and provides less speed benefit. (Only Py sees a significant benefit.) On the other hand, the read/write code is smaller and the cache doesn't need to be invalidated when we fix bugs in the Lua->C# conversion. Is this desirable for review/addition/replacement?
1. The cache file is stored in the mod folder. This keeps it out of the user's immediate view, but means users who frequently change their modpacks don't see as much benefit, unless they maintain multiple mod folders. Is there a better place to store it?