### PR TITLE
fix(#626): Allow a missing type for known-to-be-item products.

### DIFF
--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -583,10 +583,10 @@ internal partial class FactorioDataDeserializer {
             || factorioVersion < v2_0) {
 
             if (table.Get("rocket_launch_product", out LuaTable? product)) {
-                launchProducts = [LoadProduct("rocket_launch_product", item.stackSize)(product)];
+                launchProducts = [LoadProduct("rocket_launch_product", item.stackSize, isAlwaysItem: true)(product)];
             }
             else if (table.Get("rocket_launch_products", out LuaTable? products)) {
-                launchProducts = [.. products.ArrayElements<LuaTable>().Select(LoadProduct(item.typeDotName, item.stackSize))];
+                launchProducts = [.. products.ArrayElements<LuaTable>().Select(LoadProduct(item.typeDotName, item.stackSize, isAlwaysItem: true))];
             }
             else if (factorioVersion >= v2_0) {
                 launchProducts = [];
@@ -816,10 +816,11 @@ nextWeightCalculation:;
         fluid.temperatureRange = new TemperatureRange(table.Get("default_temperature", 0), table.Get("max_temperature", 0));
     }
 
-    private Goods? LoadItemOrFluid(LuaTable table, bool useTemperature) {
-        if (table.Get("type", out string? type)) {
+    private Goods? LoadItemOrFluid(LuaTable table, bool useTemperature, bool isAlwaysItem) {
+        string? type = null;
+        if (isAlwaysItem || table.Get("type", out type)) {
             if (table.Get("name", out string? name)) {
-                if (type == "item") {
+                if (isAlwaysItem || type == "item") {
                     return GetObject<Item>(table);
                 }
                 else if (type == "fluid") {

--- a/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
@@ -213,8 +213,8 @@ internal partial class FactorioDataDeserializer {
         }
     }
 
-    private Func<LuaTable, Product> LoadProduct(string typeDotName, int multiplier = 1, float? percentSpoiled = null) => table => {
-        Goods? goods = LoadItemOrFluid(table, true);
+    private Func<LuaTable, Product> LoadProduct(string recipeName, int multiplier = 1, float? percentSpoiled = null, bool isAlwaysItem = false) => table => {
+        Goods? goods = LoadItemOrFluid(table, useTemperature: true, isAlwaysItem);
 
         float min, max, catalyst;
         if (goods is Item) {
@@ -226,7 +226,7 @@ internal partial class FactorioDataDeserializer {
                 max = effectiveMax;
             }
             else {
-                throw new NotSupportedException($"Could not load amount for one of the products for {typeDotName}, possibly named '{table.Get("name", "")}'.");
+                throw new NotSupportedException($"Could not load amount for one of the products for {recipeName}, possibly named '{table.Get("name", "")}'.");
             }
 
             percentSpoiled ??= table.Get<float?>("percent_spoiled");
@@ -247,7 +247,7 @@ internal partial class FactorioDataDeserializer {
                 // nothing to do
             }
             else {
-                throw new NotSupportedException($"Could not load amount for one of the products for {typeDotName}, possibly named '{table.Get("name", "")}'.");
+                throw new NotSupportedException($"Could not load amount for one of the products for {recipeName}, possibly named '{table.Get("name", "")}'.");
             }
 
             // ignored_by_productivity (default is the value of ignored_by_stats) in 2.0; catalyst_amount in 1.1.
@@ -255,7 +255,7 @@ internal partial class FactorioDataDeserializer {
             catalyst = table.Get("ignored_by_productivity", table.Get("ignored_by_stats", table.Get("catalyst_amount", 0f)));
         }
         else {
-            throw new NotSupportedException($"Could not load one of the products for {typeDotName}, possibly named '{table.Get("name", "")}'.");
+            throw new NotSupportedException($"Could not load one of the products for {recipeName}, possibly named '{table.Get("name", "")}'.");
         }
 
         Product product = new Product(goods, min * multiplier, max * multiplier, table.Get("probability", 1f)) { percentSpoiled = percentSpoiled };
@@ -287,7 +287,7 @@ internal partial class FactorioDataDeserializer {
         _ = table.Get("ingredients", out LuaTable? ingredientsList);
 
         return ingredientsList?.ArrayElements<LuaTable>().Select(table => {
-            Goods? goods = LoadItemOrFluid(table, false);
+            Goods? goods = LoadItemOrFluid(table, useTemperature: false, isAlwaysItem: false);
 
             if (goods is null) {
                 errorCollector.Error($"Failed to load at least one ingredient for {typeDotName}.", ErrorSeverity.AnalysisWarning);

--- a/changelog.txt
+++ b/changelog.txt
@@ -27,6 +27,7 @@ Date:
         - Extended main window title - append current project name (with * indicator for unsaved changes).
         - Main dropdown - disable Save/Undo when there is nothing to do.
     Fixes:
+        - Fix loading Tricky Old Nick and other mods that forget to declare that rocket launch products are items.
     Internal changes:
         - Rename SettingsDropdown to MainDropdown.
         - Rename LoadProjectHeavy to ReturnToWelcomeScreen.


### PR DESCRIPTION
This fixes #626, based on the [response](https://forums.factorio.com/viewtopic.php?t=133511) from boskid.