### PR TITLE
SummaryView: make the page-name column sticky when scrolling horizontally

### DIFF
--- a/Yafc.UI/ImGui/ScrollArea.cs
+++ b/Yafc.UI/ImGui/ScrollArea.cs
@@ -309,6 +309,50 @@ public class ScrollArea(float height, GuiBuilder builder, Padding padding = defa
     public void Rebuild() => RebuildContents();
 }
 
+/// <summary>A vertical-scrolling area whose vertical scroll position is mirrored to a linked partner, so two
+/// side-by-side scroll areas stay aligned. Call <see cref="Link"/> on either side to pair them.</summary>
+/// <param name="height">See <see cref="ScrollAreaBase"/>.</param>
+/// <param name="builder">See <see cref="ScrollArea"/>.</param>
+/// <param name="horizontal">See <see cref="Scrollable"/>.</param>
+/// <param name="drawVerticalScrollbar">See <see cref="Scrollable"/>.</param>
+public class LinkedScrollArea(float height, GuiBuilder builder, bool horizontal, bool drawVerticalScrollbar)
+    : ScrollArea(height, builder, default, collapsible: false, vertical: true, horizontal: horizontal, drawVerticalScrollbar: drawVerticalScrollbar) {
+
+    private LinkedScrollArea? partner;
+    private bool syncing;
+
+    /// <summary>Pair this scroll area with <paramref name="other"/> so their vertical scroll positions stay in sync.
+    /// Mouse-wheel, keyboard, or programmatic scrolling on either side updates both.</summary>
+    public void Link(LinkedScrollArea other) {
+        partner = other;
+        other.partner = this;
+    }
+
+    public override Vector2 scroll {
+        get => base.scroll;
+        set {
+            base.scroll = value;
+            if (partner != null && !syncing) {
+                partner.MirrorScrollY(base.scroll.Y);
+            }
+        }
+    }
+
+    private void MirrorScrollY(float y) {
+        // The flag breaks the otherwise-infinite mirror cycle (A → B → A → …); try/finally guarantees it's cleared
+        // even if the assignment ever throws, so a failure can't permanently desync the pair.
+        syncing = true;
+        try {
+            scrollY = y;
+        }
+        finally {
+            syncing = false;
+        }
+    }
+
+    public void Build(ImGui gui, float availableHeight) => Build(gui, availableHeight, useBottomPadding: false);
+}
+
 public class VirtualScrollList<TData>(float height, Vector2 elementSize, VirtualScrollList<TData>.Drawer drawer, Padding padding = default,
     Action<int, int>? reorder = null, bool collapsible = false) : ScrollAreaBase(height, padding, collapsible) {
 

--- a/Yafc.UI/ImGui/ScrollArea.cs
+++ b/Yafc.UI/ImGui/ScrollArea.cs
@@ -7,8 +7,17 @@ using Yafc.Core;
 namespace Yafc.UI;
 
 /// <summary> Provide scrolling support for any component.</summary>
+/// <param name="vertical">Whether vertical scrolling is enabled (mouse wheel, keyboard, programmatic <see cref="scrollY"/>).</param>
+/// <param name="horizontal">Whether horizontal scrolling is enabled (Ctrl+wheel, keyboard, programmatic <see cref="scrollX"/>).</param>
+/// <param name="collapsible">If <see langword="true"/>, the rendered area shrinks to fit the content when the content is smaller
+/// than the available height. If <see langword="false"/>, the area always uses the full available height.</param>
+/// <param name="drawVerticalScrollbar">When <see langword="false"/> and <paramref name="vertical"/> is <see langword="true"/>,
+/// vertical scrolling still works (mouse wheel, keyboard, programmatic <see cref="scrollY"/>) but no scrollbar is drawn and no
+/// width is reserved for it. Useful for one half of a pair of side-by-side, vertically-synced scroll areas where only one
+/// visible scrollbar is desired.</param>
 /// <remarks> The component should use the <see cref="scroll"/> property to get the offset of rendering the contents. </remarks>
-public abstract class Scrollable(bool vertical, bool horizontal, bool collapsible) : IKeyboardFocus {
+public abstract class Scrollable(bool vertical, bool horizontal, bool collapsible, bool drawVerticalScrollbar = true) : IKeyboardFocus {
+    private readonly bool drawVerticalScrollbar = drawVerticalScrollbar;
     /// <summary>Required size to fit Scrollable (child) contents</summary>
     private Vector2 requiredContentSize;
     /// <summary>This rectangle contains the available size (and position) of the scrollable content</summary>
@@ -35,7 +44,7 @@ public abstract class Scrollable(bool vertical, bool horizontal, bool collapsibl
         var rect = gui.statePosition;
         float width = rect.Width;
 
-        if (vertical) {
+        if (vertical && drawVerticalScrollbar) {
             width -= ScrollbarSize;
         }
 
@@ -94,7 +103,7 @@ public abstract class Scrollable(bool vertical, bool horizontal, bool collapsibl
                 BuildScrollBar(gui, 0, in scrollbarRect, in scrollerRect);
             }
 
-            if (vertical && maxScroll.Y > 0f) {
+            if (vertical && drawVerticalScrollbar && maxScroll.Y > 0f) {
                 Rect scrollbarRect = new Rect(rect.Right - ScrollbarSize, rect.Y, ScrollbarSize, rect.Height);
                 Rect scrollerRect = new Rect(scrollbarRect.X, rect.Y + scrollerStart.Y, ScrollbarSize, scrollerSize.Y);
                 BuildScrollBar(gui, 1, in scrollbarRect, in scrollerRect);
@@ -254,7 +263,14 @@ public abstract class ScrollAreaBase : Scrollable {
     private ImGui.OverlappingAllocations? controller;
     public float height { get; }
 
-    public ScrollAreaBase(float height, Padding padding, bool collapsible = false, bool vertical = true, bool horizontal = false) : base(vertical, horizontal, collapsible) {
+    /// <param name="height">Default available height passed to <see cref="Scrollable.Build(ImGui, float, bool)"/> when no explicit
+    /// height is provided.</param>
+    /// <param name="padding">Padding applied to the inner contents <see cref="ImGui"/>.</param>
+    /// <param name="collapsible">See <see cref="Scrollable"/>.</param>
+    /// <param name="vertical">See <see cref="Scrollable"/>.</param>
+    /// <param name="horizontal">See <see cref="Scrollable"/>.</param>
+    /// <param name="drawVerticalScrollbar">See <see cref="Scrollable"/>.</param>
+    public ScrollAreaBase(float height, Padding padding, bool collapsible = false, bool vertical = true, bool horizontal = false, bool drawVerticalScrollbar = true) : base(vertical, horizontal, collapsible, drawVerticalScrollbar) {
         contents = new ImGui(BuildContents, padding, clip: true);
         this.height = height;
     }
@@ -280,7 +296,14 @@ public abstract class ScrollAreaBase : Scrollable {
 }
 
 ///<summary>Area with scrollbars, which will be visible if it does not fit in the parent area in order to let the user fully view the content of the area.</summary>
-public class ScrollArea(float height, GuiBuilder builder, Padding padding = default, bool collapsible = false, bool vertical = true, bool horizontal = false) : ScrollAreaBase(height, padding, collapsible, vertical, horizontal) {
+/// <param name="height">See <see cref="ScrollAreaBase"/>.</param>
+/// <param name="builder">Callback that draws the scroll area's contents into the inner <see cref="ImGui"/>.</param>
+/// <param name="padding">See <see cref="ScrollAreaBase"/>.</param>
+/// <param name="collapsible">See <see cref="Scrollable"/>.</param>
+/// <param name="vertical">See <see cref="Scrollable"/>.</param>
+/// <param name="horizontal">See <see cref="Scrollable"/>.</param>
+/// <param name="drawVerticalScrollbar">See <see cref="Scrollable"/>.</param>
+public class ScrollArea(float height, GuiBuilder builder, Padding padding = default, bool collapsible = false, bool vertical = true, bool horizontal = false, bool drawVerticalScrollbar = true) : ScrollAreaBase(height, padding, collapsible, vertical, horizontal, drawVerticalScrollbar) {
     protected override void BuildContents(ImGui gui) => builder(gui);
 
     public void Rebuild() => RebuildContents();

--- a/Yafc/Widgets/DataGrid.cs
+++ b/Yafc/Widgets/DataGrid.cs
@@ -163,7 +163,16 @@ public class DataGrid<TData>(params DataColumn<TData>[] columns) where TData : c
         }
     }
 
-    public Rect BuildRow(ImGui gui, TData element, float startX = 0f) {
+    /// <summary>Builds a single grid row for the given <paramref name="element"/>, allocating each column's cell at its configured
+    /// width and drawing a separator line at the bottom of the row.</summary>
+    /// <param name="gui">The <see cref="ImGui"/> to draw the row into.</param>
+    /// <param name="element">The data element passed to each column's <see cref="DataColumn{TData}.BuildElement"/>.</param>
+    /// <param name="startX">X coordinate at which the row's bottom separator starts. Cells to the left of this X have no separator drawn.</param>
+    /// <param name="minRowHeight">Minimum height (in YAFC units) to allocate for each column's cell. The <see cref="RectAllocator.LeftRow"/>
+    /// allocator inside each column will widen its content rect to at least this height, which is useful when rendering rows of
+    /// multiple grids in parallel (e.g. side-by-side scroll areas) that must keep their per-row heights aligned.</param>
+    /// <returns>The rectangle that the row occupies in the parent <paramref name="gui"/>.</returns>
+    public Rect BuildRow(ImGui gui, TData element, float startX = 0f, float minRowHeight = 0f) {
         contentGui = gui;
         float x = innerPadding.left;
         var rowColor = SchemeColor.None;
@@ -176,7 +185,7 @@ public class DataGrid<TData>(params DataColumn<TData>[] columns) where TData : c
                         column.width = column.minWidth;
                     }
 
-                    @group.SetManualRect(new Rect(x, 0, column.width, 0f), RectAllocator.LeftRow);
+                    @group.SetManualRect(new Rect(x, 0, column.width, minRowHeight), RectAllocator.LeftRow);
                     column.BuildElement(gui, element);
                     x += column.width + spacing;
                 }

--- a/Yafc/Workspace/ProjectPageView.cs
+++ b/Yafc/Workspace/ProjectPageView.cs
@@ -14,7 +14,11 @@ public abstract class ProjectPageView : Scrollable {
 
     public readonly ImGui headerContent;
     public readonly ImGui bodyContent;
-    private float contentWidth, headerHeight, contentHeight;
+    private float contentWidth, contentHeight;
+    /// <summary>The header's measured height. Available to subclasses so they can size body-area widgets to the actual viewport.</summary>
+    protected float headerHeight { get; private set; }
+    /// <summary>The visible size most recently passed to <see cref="Build(ImGui, Vector2)"/>. Body viewport height equals <c>visibleSize.Y - headerHeight</c>.</summary>
+    protected Vector2 visibleSize { get; private set; }
     private SearchQuery searchQuery;
     protected abstract void BuildHeader(ImGui gui);
     protected abstract void BuildContent(ImGui gui);
@@ -40,6 +44,7 @@ public abstract class ProjectPageView : Scrollable {
     public ProjectPageView CreateSecondaryView() => (ProjectPageView)Activator.CreateInstance(GetType())!;
 
     public void Build(ImGui gui, Vector2 visibleSize) {
+        this.visibleSize = visibleSize;
         if (gui.isBuilding) {
             gui.spacing = 0f;
             var position = gui.AllocateRect(0f, 0f, 0f).Position;

--- a/Yafc/Workspace/SummaryView.cs
+++ b/Yafc/Workspace/SummaryView.cs
@@ -17,14 +17,7 @@ public class SummaryView : ProjectPageView<Summary> {
     /// <summary>Some padding to have the contents of the first column not 'stick' to the rest of the UI</summary>
     private readonly Padding FirstColumnPadding = new Padding(1f, 1.5f, 0, 0);
     private static float firstColumnWidth;
-
-    private class SummaryScrollArea(GuiBuilder builder) : ScrollArea(DefaultHeight, builder, horizontal: true) {
-        private static readonly float DefaultHeight = 10;
-
-        public new void Build(ImGui gui) =>
-            // Maximize scroll area to fit parent area (minus header and 'show issues' heights, and some (3) padding probably)
-            Build(gui, gui.valid && gui.parent is not null ? gui.parent.contentSize.Y - Font.header.size - Font.text.size - 3 : DefaultHeight);
-    }
+    private const float DefaultScrollHeight = 10f;
 
     private class SummaryTabColumn : TextDataColumn<ProjectPage> {
         public SummaryTabColumn() : base(LSs.Page, firstColumnWidth) {
@@ -86,7 +79,6 @@ public class SummaryView : ProjectPageView<Summary> {
                     // Reserve empty space to prevent 'compressing' empty rows
                     _ = gui.AllocateRect(0f, view.rowHeight);
                 }
-
             }
         }
 
@@ -161,9 +153,12 @@ public class SummaryView : ProjectPageView<Summary> {
     private Project project;
     private SearchQuery searchQuery;
 
-    private readonly SummaryScrollArea scrollArea;
+    private readonly LinkedScrollArea leftScrollArea;
+    private readonly LinkedScrollArea rightScrollArea;
+    private readonly SummaryTabColumn tabColumn;
     private readonly SummaryDataColumn goodsColumn;
-    private readonly DataGrid<ProjectPage> mainGrid;
+    private readonly DataGrid<ProjectPage> leftGrid;
+    private readonly DataGrid<ProjectPage> rightGrid;
 
     private Dictionary<string, GoodDetails> allGoods = [];
 
@@ -200,10 +195,15 @@ public class SummaryView : ProjectPageView<Summary> {
     }
 
     public SummaryView(Project project) {
+        tabColumn = new SummaryTabColumn();
         goodsColumn = new SummaryDataColumn(this);
-        TextDataColumn<ProjectPage>[] columns = [new SummaryTabColumn(), goodsColumn];
-        scrollArea = new SummaryScrollArea(BuildScrollArea);
-        mainGrid = new DataGrid<ProjectPage>(columns);
+        leftGrid = new DataGrid<ProjectPage>(tabColumn);
+        rightGrid = new DataGrid<ProjectPage>(goodsColumn);
+        // Only the right side draws the visible vertical scrollbar; the left's vertical scrolling is mirrored from
+        // the right via Link() so both sides stay aligned without a second visible scrollbar.
+        leftScrollArea = new LinkedScrollArea(DefaultScrollHeight, BuildLeftScrollArea, horizontal: false, drawVerticalScrollbar: false);
+        rightScrollArea = new LinkedScrollArea(DefaultScrollHeight, BuildRightScrollArea, horizontal: true, drawVerticalScrollbar: true);
+        leftScrollArea.Link(rightScrollArea);
 
         SetProject(project);
     }
@@ -278,7 +278,24 @@ public class SummaryView : ProjectPageView<Summary> {
             rowHeight = ButtonDisplayStyle.ProductionTableUnscaled.Size + gui.PixelsToUnits(gui.GetFontSize().lineSize);
         }
 
-        scrollArea.Build(gui);
+        // Lay out left (sticky) and right (horizontally scrollable) side-by-side. The left side's scrollbar is
+        // hidden, so it doesn't reserve scrollbar width. DataGrid.BuildRow shifts the column by `innerPadding.left`
+        // twice (once via the row's starting x, once via the manual-rect padding) before reserving `innerPadding.right`
+        // at the right edge — so account for both inner-padding halves here.
+        using (gui.EnterRow(spacing: 0, allocator: RectAllocator.LeftRow)) {
+            // Compute availableHeight *inside* the row so EnterRow's implicit spacing is already accounted for in
+            // gui.statePosition.Y. visibleSize.Y - headerHeight is the body's viewport; subtracting the current top
+            // gives the exact remaining height. Fall back to DefaultScrollHeight on the first build, before
+            // ProjectPageView.Build has populated visibleSize.
+            float availableHeight = MathF.Max(DefaultScrollHeight, visibleSize.Y - headerHeight - gui.statePosition.Y);
+            float leftWidth = firstColumnWidth + (2 * DataGrid<ProjectPage>.innerPadding.left) + DataGrid<ProjectPage>.innerPadding.right;
+            using (gui.EnterFixedPositioning(leftWidth, 0, default)) {
+                leftScrollArea.Build(gui, availableHeight);
+            }
+            using (gui.EnterFixedPositioning(gui.width, 0, default)) {
+                rightScrollArea.Build(gui, availableHeight);
+            }
+        }
     }
 
     private async Task AutoBalance() {
@@ -347,10 +364,22 @@ public class SummaryView : ProjectPageView<Summary> {
     private IEnumerable<ProductionTable> DisplayTables => project.displayPages.Select(p => project.FindPage(p)?.content as ProductionTable).WhereNotNull();
     private IEnumerable<ProjectPage> DisplayPages => DisplayTables.Select(t => (ProjectPage)t.owner);
 
-    private void BuildScrollArea(ImGui gui) {
+    private void BuildLeftScrollArea(ImGui gui) {
         foreach (ProjectPage page in DisplayPages) {
-            _ = mainGrid.BuildRow(gui, page);
+            _ = leftGrid.BuildRow(gui, page, minRowHeight: rowHeight);
         }
+        // Match the right side's reserved-for-H-scrollbar space so the synced vertical scroll positions align
+        // perfectly between the two sides.
+        _ = gui.AllocateRect(0, ScrollArea.ScrollbarSize);
+    }
+
+    private void BuildRightScrollArea(ImGui gui) {
+        foreach (ProjectPage page in DisplayPages) {
+            _ = rightGrid.BuildRow(gui, page, minRowHeight: rowHeight);
+        }
+        // Reserve space below the last row so it can be scrolled clear of the horizontal scrollbar that sits at
+        // the bottom of this scroll area.
+        _ = gui.AllocateRect(0, ScrollArea.ScrollbarSize);
     }
 
     private void Recalculate() => Recalculate(false);
@@ -404,12 +433,15 @@ public class SummaryView : ProjectPageView<Summary> {
             count++;
         }
 
-        goodsColumn.width = count * (ElementWidth + ElementSpacing);
+        // Width of the goods column: N cells of (ElementWidth + ElementSpacing), minus the trailing inter-cell
+        // spacing after the last cell, which doesn't visually exist.
+        goodsColumn.width = (count * (ElementWidth + ElementSpacing)) - ElementSpacing;
 
         allGoods = newGoods;
 
         Rebuild(visualOnly);
-        scrollArea.RebuildContents();
+        leftScrollArea.RebuildContents();
+        rightScrollArea.RebuildContents();
     }
 
     // Convert/truncate value as shown in UI to prevent slight mismatches
@@ -421,6 +453,7 @@ public class SummaryView : ProjectPageView<Summary> {
     public override void SetSearchQuery(SearchQuery query) {
         searchQuery = query;
         bodyContent.Rebuild();
-        scrollArea.Rebuild();
+        leftScrollArea.Rebuild();
+        rightScrollArea.Rebuild();
     }
 }


### PR DESCRIPTION
The Summary view in YAFC has a single horizontal scroll area covering both the page-name column on the left and the goods grid on the right. For projects with lots of distinct goods scrolling right to see the rightmost goods drags the page-name column out of view along with everything else. Once it is gone you cannot tell which row matches which page without scrolling all the way back left to check.

This has bothered me for years, but finally I managed to make an acceptable solution, am I happy with. (I am using a variety of hackish solutions for years locally, and kept them rebased on the master branch...)

This PR keeps that left column in place. You can scroll the goods horizontally as much as you want, and the row labels ("pow", "stone", "lab", and so on) stay where they are. Vertical scrolling moves both sides together.

## How

The body of `SummaryView` is split into two scroll areas placed side by side. The left one holds the page-name column and only scrolls vertically. The right one holds the goods grid and scrolls both ways. The two are paired with a new `LinkedScrollArea` type so their vertical scroll positions stay in sync. Only the right side actually draws the vertical scrollbar; the left side's vertical scroll still works (mouse wheel, keyboard, drag the right side) via the link, but you do not get a second scrollbar in the middle of the screen.

## Commits

Five small commits, each builds cleanly on its own:

1. **DataGrid: add optional minRowHeight to BuildRow** lets a caller force a minimum row height. Default zero, so no existing caller is affected.
2. **ProjectPageView: expose visibleSize and headerHeight to subclasses** makes both values available to subclasses so they can size things against the real body viewport.
3. **Scrollable: add drawVerticalScrollbar parameter** lets a Scrollable suppress drawing its vertical scrollbar without disabling vertical scroll. Defaults to true.
4. **ScrollArea: add LinkedScrollArea utility for synced vertical scroll** is the new type itself. It sits in `ScrollArea.cs` next to `ScrollArea` and `VirtualScrollList`.
5. **SummaryView: sticky page-name column with synced vertical scroll** is the actual feature, built on top of the previous four.

The first four are infrastructure additions and do not change behavior anywhere else in YAFC. The visible behavior change is fully contained in the fifth commit.

## Testing

I tested this on a project with around enough goods (~25) to need scrollbars on minimal window width and none of maximum width. So both scenarios (and transitioning between them) could be visually tested.  YAFC does not have UI-layer tests so this is not covered by automated tests, but the four infrastructure commits are no-ops for everything outside SummaryView. To be sure, I checked all (think) other places with scrollbars to see that these were indeed not impacted.