### PR TITLE
refactor(model): Bridge ProjectPage Thread Switching

### DIFF
--- a/Yafc.Model.Tests/Model/ProjectPageTests.cs
+++ b/Yafc.Model.Tests/Model/ProjectPageTests.cs
@@ -1,0 +1,92 @@
+﻿using System;
+using System.Threading.Tasks;
+using Xunit;
+
+namespace Yafc.Model.Tests;
+
+public class ProjectPageTests {
+    [Fact]
+    public async Task ExternalSolve_DefaultThreadSwitcher_CompletesWithoutUiInitialization() {
+        ProjectPage page = new(new Project(), typeof(Summary));
+
+        var error = await page.ExternalSolve();
+
+        Assert.Null(error);
+        Assert.False(page.IsSolutionStale());
+    }
+
+    [Fact]
+    public async Task ExternalSolve_UsesProjectThreadSwitcher() {
+        Project project = new();
+        CountingModelThreadSwitcher switcher = new();
+        project.modelThreadSwitcher = switcher;
+        ProjectPage page = new(project, typeof(Summary));
+
+        _ = await page.ExternalSolve();
+
+        Assert.Equal(0, switcher.backgroundSwitches);
+        Assert.Equal(2, switcher.modelThreadSwitches);
+    }
+
+    [Fact]
+    public async Task ExternalSolve_ModelThreadContinuationRunsInsideSwitcherDispatch() {
+        Project project = new();
+        GuardedModelThreadSwitcher switcher = new();
+        project.modelThreadSwitcher = switcher;
+        ProjectPage page = new(project, typeof(Summary));
+
+        _ = await page.ExternalSolve();
+
+        Assert.Equal(2, switcher.modelThreadSwitches);
+        Assert.False(page.IsSolutionStale());
+    }
+
+    private sealed class CountingModelThreadSwitcher : IModelThreadSwitcher {
+        public int backgroundSwitches { get; private set; }
+        public int modelThreadSwitches { get; private set; }
+
+        public ModelThreadSwitch SwitchToBackground() {
+            backgroundSwitches++;
+            return default;
+        }
+
+        public ModelThreadSwitch SwitchToModelThread() {
+            modelThreadSwitches++;
+            return default;
+        }
+    }
+
+    private sealed class GuardedModelThreadSwitcher : IModelThreadSwitcher {
+        private bool inModelThreadDispatch;
+
+        public int modelThreadSwitches { get; private set; }
+
+        public ModelThreadSwitch SwitchToBackground() => default;
+
+        public ModelThreadSwitch SwitchToModelThread() {
+            modelThreadSwitches++;
+            return new ModelThreadSwitch(new GuardedAwaitable(this));
+        }
+
+        private sealed class GuardedAwaitable(GuardedModelThreadSwitcher owner) : IModelThreadSwitchAwaitable, IModelThreadSwitchAwaiter {
+            public IModelThreadSwitchAwaiter GetAwaiter() => this;
+            public bool IsCompleted => false;
+
+            public void GetResult() {
+                if (!owner.inModelThreadDispatch) {
+                    throw new InvalidOperationException("Continuation did not run inside the model thread dispatch.");
+                }
+            }
+
+            public void OnCompleted(Action continuation) {
+                owner.inModelThreadDispatch = true;
+                try {
+                    continuation();
+                }
+                finally {
+                    owner.inModelThreadDispatch = false;
+                }
+            }
+        }
+    }
+}

--- a/Yafc.Model.Tests/Model/ProjectPageTests.cs
+++ b/Yafc.Model.Tests/Model/ProjectPageTests.cs
@@ -25,11 +25,11 @@ public class ProjectPageTests {
         _ = await page.ExternalSolve();
 
         Assert.Equal(0, switcher.backgroundSwitches);
-        Assert.Equal(2, switcher.modelThreadSwitches);
+        Assert.Equal(2, switcher.foregroundSwitches);
     }
 
     [Fact]
-    public async Task ExternalSolve_ModelThreadContinuationRunsInsideSwitcherDispatch() {
+    public async Task ExternalSolve_ForegroundContinuationRunsInsideSwitcherDispatch() {
         Project project = new();
         GuardedModelThreadSwitcher switcher = new();
         project.modelThreadSwitcher = switcher;
@@ -37,34 +37,34 @@ public class ProjectPageTests {
 
         _ = await page.ExternalSolve();
 
-        Assert.Equal(2, switcher.modelThreadSwitches);
+        Assert.Equal(2, switcher.foregroundSwitches);
         Assert.False(page.IsSolutionStale());
     }
 
     private sealed class CountingModelThreadSwitcher : IModelThreadSwitcher {
         public int backgroundSwitches { get; private set; }
-        public int modelThreadSwitches { get; private set; }
+        public int foregroundSwitches { get; private set; }
 
         public ModelThreadSwitch SwitchToBackground() {
             backgroundSwitches++;
             return default;
         }
 
-        public ModelThreadSwitch SwitchToModelThread() {
-            modelThreadSwitches++;
+        public ModelThreadSwitch SwitchToForeground() {
+            foregroundSwitches++;
             return default;
         }
     }
 
     private sealed class GuardedModelThreadSwitcher : IModelThreadSwitcher {
-        private bool inModelThreadDispatch;
+        private bool inForegroundDispatch;
 
-        public int modelThreadSwitches { get; private set; }
+        public int foregroundSwitches { get; private set; }
 
         public ModelThreadSwitch SwitchToBackground() => default;
 
-        public ModelThreadSwitch SwitchToModelThread() {
-            modelThreadSwitches++;
+        public ModelThreadSwitch SwitchToForeground() {
+            foregroundSwitches++;
             return new ModelThreadSwitch(new GuardedAwaitable(this));
         }
 
@@ -73,18 +73,18 @@ public class ProjectPageTests {
             public bool IsCompleted => false;
 
             public void GetResult() {
-                if (!owner.inModelThreadDispatch) {
-                    throw new InvalidOperationException("Continuation did not run inside the model thread dispatch.");
+                if (!owner.inForegroundDispatch) {
+                    throw new InvalidOperationException("Continuation did not run inside the foreground dispatch.");
                 }
             }
 
             public void OnCompleted(Action continuation) {
-                owner.inModelThreadDispatch = true;
+                owner.inForegroundDispatch = true;
                 try {
                     continuation();
                 }
                 finally {
-                    owner.inModelThreadDispatch = false;
+                    owner.inForegroundDispatch = false;
                 }
             }
         }

--- a/Yafc.Model/Model/IModelThreadSwitcher.cs
+++ b/Yafc.Model/Model/IModelThreadSwitcher.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace Yafc.Model;
+
+public interface IModelThreadSwitcher {
+    ModelThreadSwitch SwitchToBackground();
+    ModelThreadSwitch SwitchToModelThread();
+}
+
+public readonly struct ModelThreadSwitch {
+    private readonly IModelThreadSwitchAwaitable? awaitable;
+
+    public ModelThreadSwitch(IModelThreadSwitchAwaitable awaitable) => this.awaitable = awaitable ?? throw new ArgumentNullException(nameof(awaitable));
+
+    public ModelThreadSwitchAwaiter GetAwaiter() => new(awaitable?.GetAwaiter());
+}
+
+public readonly struct ModelThreadSwitchAwaiter : INotifyCompletion {
+    private readonly IModelThreadSwitchAwaiter? awaiter;
+
+    internal ModelThreadSwitchAwaiter(IModelThreadSwitchAwaiter? awaiter) => this.awaiter = awaiter;
+
+    public bool IsCompleted => awaiter?.IsCompleted ?? true;
+    public void GetResult() => awaiter?.GetResult();
+    public void OnCompleted(Action continuation) {
+        if (awaiter == null) {
+            continuation();
+            return;
+        }
+
+        awaiter.OnCompleted(continuation);
+    }
+}
+
+public interface IModelThreadSwitchAwaitable {
+    IModelThreadSwitchAwaiter GetAwaiter();
+}
+
+public interface IModelThreadSwitchAwaiter : INotifyCompletion {
+    bool IsCompleted { get; }
+    void GetResult();
+}
+
+public sealed class NoOpModelThreadSwitcher : IModelThreadSwitcher {
+    public static NoOpModelThreadSwitcher Instance { get; } = new();
+
+    private NoOpModelThreadSwitcher() { }
+
+    public ModelThreadSwitch SwitchToBackground() => default;
+
+    public ModelThreadSwitch SwitchToModelThread() => default;
+}

--- a/Yafc.Model/Model/IModelThreadSwitcher.cs
+++ b/Yafc.Model/Model/IModelThreadSwitcher.cs
@@ -1,6 +1,16 @@
 ﻿namespace Yafc.Model;
 
+/// <summary>
+/// Provides awaitable switches between the model's foreground and background execution contexts.
+/// </summary>
 public interface IModelThreadSwitcher {
+    /// <summary>
+    /// Returns an awaitable switch from the foreground context to the background context.
+    /// </summary>
     ModelThreadSwitch SwitchToBackground();
-    ModelThreadSwitch SwitchToModelThread();
+
+    /// <summary>
+    /// Returns an awaitable switch from the background context to the foreground context.
+    /// </summary>
+    ModelThreadSwitch SwitchToForeground();
 }

--- a/Yafc.Model/Model/IModelThreadSwitcher.cs
+++ b/Yafc.Model/Model/IModelThreadSwitcher.cs
@@ -1,53 +1,6 @@
-﻿using System;
-using System.Runtime.CompilerServices;
-
-namespace Yafc.Model;
+﻿namespace Yafc.Model;
 
 public interface IModelThreadSwitcher {
     ModelThreadSwitch SwitchToBackground();
     ModelThreadSwitch SwitchToModelThread();
-}
-
-public readonly struct ModelThreadSwitch {
-    private readonly IModelThreadSwitchAwaitable? awaitable;
-
-    public ModelThreadSwitch(IModelThreadSwitchAwaitable awaitable) => this.awaitable = awaitable ?? throw new ArgumentNullException(nameof(awaitable));
-
-    public ModelThreadSwitchAwaiter GetAwaiter() => new(awaitable?.GetAwaiter());
-}
-
-public readonly struct ModelThreadSwitchAwaiter : INotifyCompletion {
-    private readonly IModelThreadSwitchAwaiter? awaiter;
-
-    internal ModelThreadSwitchAwaiter(IModelThreadSwitchAwaiter? awaiter) => this.awaiter = awaiter;
-
-    public bool IsCompleted => awaiter?.IsCompleted ?? true;
-    public void GetResult() => awaiter?.GetResult();
-    public void OnCompleted(Action continuation) {
-        if (awaiter == null) {
-            continuation();
-            return;
-        }
-
-        awaiter.OnCompleted(continuation);
-    }
-}
-
-public interface IModelThreadSwitchAwaitable {
-    IModelThreadSwitchAwaiter GetAwaiter();
-}
-
-public interface IModelThreadSwitchAwaiter : INotifyCompletion {
-    bool IsCompleted { get; }
-    void GetResult();
-}
-
-public sealed class NoOpModelThreadSwitcher : IModelThreadSwitcher {
-    public static NoOpModelThreadSwitcher Instance { get; } = new();
-
-    private NoOpModelThreadSwitcher() { }
-
-    public ModelThreadSwitch SwitchToBackground() => default;
-
-    public ModelThreadSwitch SwitchToModelThread() => default;
 }

--- a/Yafc.Model/Model/ModelThreadSwitch.cs
+++ b/Yafc.Model/Model/ModelThreadSwitch.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using System.Runtime.CompilerServices;
+
+namespace Yafc.Model;
+
+public readonly struct ModelThreadSwitch {
+    private readonly IModelThreadSwitchAwaitable? awaitable;
+
+    public ModelThreadSwitch(IModelThreadSwitchAwaitable awaitable) => this.awaitable = awaitable ?? throw new ArgumentNullException(nameof(awaitable));
+
+    public ModelThreadSwitchAwaiter GetAwaiter() => new(awaitable?.GetAwaiter());
+}
+
+public readonly struct ModelThreadSwitchAwaiter : INotifyCompletion {
+    private readonly IModelThreadSwitchAwaiter? awaiter;
+
+    internal ModelThreadSwitchAwaiter(IModelThreadSwitchAwaiter? awaiter) => this.awaiter = awaiter;
+
+    public bool IsCompleted => awaiter?.IsCompleted ?? true;
+    public void GetResult() => awaiter?.GetResult();
+    public void OnCompleted(Action continuation) {
+        if (awaiter == null) {
+            continuation();
+            return;
+        }
+
+        awaiter.OnCompleted(continuation);
+    }
+}
+
+public interface IModelThreadSwitchAwaitable {
+    IModelThreadSwitchAwaiter GetAwaiter();
+}
+
+public interface IModelThreadSwitchAwaiter : INotifyCompletion {
+    bool IsCompleted { get; }
+    void GetResult();
+}

--- a/Yafc.Model/Model/ModelThreadSwitch.cs
+++ b/Yafc.Model/Model/ModelThreadSwitch.cs
@@ -3,21 +3,44 @@ using System.Runtime.CompilerServices;
 
 namespace Yafc.Model;
 
+/// <summary>
+/// Represents an awaitable switch between model execution contexts.
+/// </summary>
 public readonly struct ModelThreadSwitch {
     private readonly IModelThreadSwitchAwaitable? awaitable;
 
-    public ModelThreadSwitch(IModelThreadSwitchAwaitable awaitable) => this.awaitable = awaitable ?? throw new ArgumentNullException(nameof(awaitable));
+    /// <summary>
+    /// Initializes a new switch that delegates to <paramref name="awaitable"/>.
+    /// </summary>
+    /// <param name="awaitable">The awaitable that performs the context switch, or <see langword="null" /> to complete synchronously.</param>
+    public ModelThreadSwitch(IModelThreadSwitchAwaitable? awaitable) => this.awaitable = awaitable;
 
+    /// <summary>
+    /// Gets the awaiter used by the C# await pattern.
+    /// </summary>
+    /// <returns>The awaiter for this switch.</returns>
     public ModelThreadSwitchAwaiter GetAwaiter() => new(awaitable?.GetAwaiter());
 }
 
+/// <summary>
+/// Provides completion notifications for a <see cref="ModelThreadSwitch"/>.
+/// </summary>
 public readonly struct ModelThreadSwitchAwaiter : INotifyCompletion {
     private readonly IModelThreadSwitchAwaiter? awaiter;
 
     internal ModelThreadSwitchAwaiter(IModelThreadSwitchAwaiter? awaiter) => this.awaiter = awaiter;
 
+    /// <summary>
+    /// Gets a value indicating whether the switch has already completed.
+    /// </summary>
     public bool IsCompleted => awaiter?.IsCompleted ?? true;
+
+    /// <summary>
+    /// Completes the switch and propagates any exception from the underlying awaiter.
+    /// </summary>
     public void GetResult() => awaiter?.GetResult();
+
+    /// <inheritdoc />
     public void OnCompleted(Action continuation) {
         if (awaiter == null) {
             continuation();
@@ -28,11 +51,28 @@ public readonly struct ModelThreadSwitchAwaiter : INotifyCompletion {
     }
 }
 
+/// <summary>
+/// Supplies an awaiter for a model thread switch operation.
+/// </summary>
 public interface IModelThreadSwitchAwaitable {
+    /// <summary>
+    /// Gets the awaiter that performs the switch.
+    /// </summary>
+    /// <returns>The awaiter for the switch operation.</returns>
     IModelThreadSwitchAwaiter GetAwaiter();
 }
 
+/// <summary>
+/// Defines the awaiter contract used by model thread switch implementations.
+/// </summary>
 public interface IModelThreadSwitchAwaiter : INotifyCompletion {
+    /// <summary>
+    /// Gets a value indicating whether the switch has already completed.
+    /// </summary>
     bool IsCompleted { get; }
+
+    /// <summary>
+    /// Completes the switch and propagates any exception from the implementation.
+    /// </summary>
     void GetResult();
 }

--- a/Yafc.Model/Model/NoOpModelThreadSwitcher.cs
+++ b/Yafc.Model/Model/NoOpModelThreadSwitcher.cs
@@ -1,0 +1,11 @@
+﻿namespace Yafc.Model;
+
+public sealed class NoOpModelThreadSwitcher : IModelThreadSwitcher {
+    public static NoOpModelThreadSwitcher Instance { get; } = new();
+
+    private NoOpModelThreadSwitcher() { }
+
+    public ModelThreadSwitch SwitchToBackground() => default;
+
+    public ModelThreadSwitch SwitchToModelThread() => default;
+}

--- a/Yafc.Model/Model/NoOpModelThreadSwitcher.cs
+++ b/Yafc.Model/Model/NoOpModelThreadSwitcher.cs
@@ -1,11 +1,19 @@
 ﻿namespace Yafc.Model;
 
+/// <summary>
+/// Completes all model thread switches synchronously for hosts that do not need thread switching.
+/// </summary>
 public sealed class NoOpModelThreadSwitcher : IModelThreadSwitcher {
+    /// <summary>
+    /// Gets the shared no-op switcher instance.
+    /// </summary>
     public static NoOpModelThreadSwitcher Instance { get; } = new();
 
     private NoOpModelThreadSwitcher() { }
 
+    /// <inheritdoc />
     public ModelThreadSwitch SwitchToBackground() => default;
 
-    public ModelThreadSwitch SwitchToModelThread() => default;
+    /// <inheritdoc />
+    public ModelThreadSwitch SwitchToForeground() => default;
 }

--- a/Yafc.Model/Model/Project.cs
+++ b/Yafc.Model/Model/Project.cs
@@ -17,6 +17,7 @@ public partial class Project : ModelObject {
     public bool justCreated { get; private set; } = true;
     public ProjectSettings settings { get; }
     public ProjectPreferences preferences { get; }
+    [SkipSerialization] public IModelThreadSwitcher modelThreadSwitcher { get; set; } = NoOpModelThreadSwitcher.Instance;
 
     public List<ProjectModuleTemplate> sharedModuleTemplates { get; } = [];
     public string? yafcVersion { get; set; }

--- a/Yafc.Model/Model/ProjectPage.cs
+++ b/Yafc.Model/Model/ProjectPage.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Threading.Tasks;
 using Yafc.I18n;
-using Yafc.UI;
 
 namespace Yafc.Model;
 
@@ -96,11 +95,11 @@ public class ProjectPage : ModelObject<Project> {
         currentSolvingVersion = actualVersion;
         try {
             string? error = await content.Solve(this);
-            await Ui.EnterMainThread();
+            await owner.modelThreadSwitcher.SwitchToModelThread();
             return error;
         }
         finally {
-            await Ui.EnterMainThread();
+            await owner.modelThreadSwitcher.SwitchToModelThread();
             lastSolvedVersion = currentSolvingVersion;
             currentSolvingVersion = 0;
         }

--- a/Yafc.Model/Model/ProjectPage.cs
+++ b/Yafc.Model/Model/ProjectPage.cs
@@ -95,11 +95,11 @@ public class ProjectPage : ModelObject<Project> {
         currentSolvingVersion = actualVersion;
         try {
             string? error = await content.Solve(this);
-            await owner.modelThreadSwitcher.SwitchToModelThread();
+            await owner.modelThreadSwitcher.SwitchToForeground();
             return error;
         }
         finally {
-            await owner.modelThreadSwitcher.SwitchToModelThread();
+            await owner.modelThreadSwitcher.SwitchToForeground();
             lastSolvedVersion = currentSolvingVersion;
             currentSolvingVersion = 0;
         }

--- a/Yafc/UiModelThreadSwitcher.cs
+++ b/Yafc/UiModelThreadSwitcher.cs
@@ -4,14 +4,22 @@ using Yafc.UI;
 
 namespace Yafc;
 
+/// <summary>
+/// Switches model execution between the UI foreground thread and the background thread pool.
+/// </summary>
 public sealed class UiModelThreadSwitcher : IModelThreadSwitcher {
+    /// <summary>
+    /// Gets the shared UI switcher instance.
+    /// </summary>
     public static UiModelThreadSwitcher Instance { get; } = new();
 
     private UiModelThreadSwitcher() { }
 
+    /// <inheritdoc />
     public ModelThreadSwitch SwitchToBackground() => new(ExitMainThreadSwitch.Instance);
 
-    public ModelThreadSwitch SwitchToModelThread() => new(EnterMainThreadSwitch.Instance);
+    /// <inheritdoc />
+    public ModelThreadSwitch SwitchToForeground() => new(EnterMainThreadSwitch.Instance);
 
     private sealed class ExitMainThreadSwitch : IModelThreadSwitchAwaitable, IModelThreadSwitchAwaiter {
         public static ExitMainThreadSwitch Instance { get; } = new();

--- a/Yafc/UiModelThreadSwitcher.cs
+++ b/Yafc/UiModelThreadSwitcher.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using Yafc.Model;
+using Yafc.UI;
+
+namespace Yafc;
+
+public sealed class UiModelThreadSwitcher : IModelThreadSwitcher {
+    public static UiModelThreadSwitcher Instance { get; } = new();
+
+    private UiModelThreadSwitcher() { }
+
+    public ModelThreadSwitch SwitchToBackground() => new(ExitMainThreadSwitch.Instance);
+
+    public ModelThreadSwitch SwitchToModelThread() => new(EnterMainThreadSwitch.Instance);
+
+    private sealed class ExitMainThreadSwitch : IModelThreadSwitchAwaitable, IModelThreadSwitchAwaiter {
+        public static ExitMainThreadSwitch Instance { get; } = new();
+
+        public IModelThreadSwitchAwaiter GetAwaiter() => this;
+        public bool IsCompleted => Ui.ExitMainThread().GetAwaiter().IsCompleted;
+        public void GetResult() => Ui.ExitMainThread().GetAwaiter().GetResult();
+        public void OnCompleted(Action continuation) => Ui.ExitMainThread().GetAwaiter().OnCompleted(continuation);
+    }
+
+    private sealed class EnterMainThreadSwitch : IModelThreadSwitchAwaitable, IModelThreadSwitchAwaiter {
+        public static EnterMainThreadSwitch Instance { get; } = new();
+
+        public IModelThreadSwitchAwaiter GetAwaiter() => this;
+        public bool IsCompleted => Ui.EnterMainThread().GetAwaiter().IsCompleted;
+        public void GetResult() => Ui.EnterMainThread().GetAwaiter().GetResult();
+        public void OnCompleted(Action continuation) => Ui.EnterMainThread().GetAwaiter().OnCompleted(continuation);
+    }
+}

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -76,6 +76,7 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
             this.project.settings.changed -= ProjectSettingsChanged;
         }
         Project.current = project;
+        project.modelThreadSwitcher = UiModelThreadSwitcher.Instance;
         DataUtils.SetupForProject(project);
         this.project = project;
         if (project.justCreated) {


### PR DESCRIPTION
## Summary
- Introduce a model-owned `IModelThreadSwitcher` abstraction for ProjectPage solve lifecycle thread switching.
- Attach the switcher to the `Project` lifecycle with a safe default for headless model usage.
- Register the UI implementation from `MainScreen` so existing UI dispatcher behavior is preserved without `ProjectPage` directly depending on `Yafc.UI.Ui`.

Closes #640
Refs #590

## Validation
- Built the solution before launch: `dotnet build .\FactorioCalc.sln --no-restore --verbosity minimal`
- Pre-push formatting verification completed successfully.
- Manual testing performed:
  - Loaded an existing project.
  - Modified input and output quantities and verified normal solving.
  - Performed continuous edits and page switching.
  - Saved the project successfully.