### PR TITLE
fix(#536): Shopping lists with spoiling include prices again.

### DIFF
--- a/Yafc/Windows/ShoppingListScreen.cs
+++ b/Yafc/Windows/ShoppingListScreen.cs
@@ -92,7 +92,12 @@ public class ShoppingListScreen : PseudoScreen {
             else if (obj.target is Entity or Item) {
                 buildings += count;
             }
-            cost += obj.target.Cost() * count;
+
+            if (obj.target is not EntityCrafter { name: "spoilage" }) {
+                // The spoilage entity doesn't have a meaningful cost.
+                // TODO: Consider chests? If so, which ones? also, include heating cost for them?
+                cost += obj.target.Cost() * count;
+            }
         }
         shoppingCost = cost;
         totalBuildings = buildings;

--- a/changelog.txt
+++ b/changelog.txt
@@ -29,6 +29,7 @@ Date:
     Fixes:
         - Fix loading Tricky Old Nick and other mods that forget to declare that rocket launch products are items.
         - Fix loading mods that set some properties to "" (the 'default' value) instead of nil.
+        - Restore price display when the shopping list includes item spoiling.
     Internal changes:
         - Rename SettingsDropdown to MainDropdown.
         - Rename LoadProjectHeavy to ReturnToWelcomeScreen.


### PR DESCRIPTION
This fixes #536 by assuming the spoiling entity is zero-cost.