### PR TITLE
refactor(production-table): Route ProductionTable Through the Thread-Switching Bridge

### DIFF
--- a/Yafc.Model.Tests/Model/ProductionTableTests.Solve_UsesProjectThreadSwitcher_ForInfeasibleLink.lua
+++ b/Yafc.Model.Tests/Model/ProductionTableTests.Solve_UsesProjectThreadSwitcher_ForInfeasibleLink.lua
@@ -1,0 +1,345 @@
+data = {
+  raw = {
+    item = {
+      wood = {
+        type = "item",
+        name = "wood",
+        fuel_category = "chemical",
+        fuel_value = "2MJ",
+        burnt_result = "ash"
+      },
+      coal = {
+        type = "item",
+        name = "coal",
+        fuel_category = "chemical",
+        fuel_value = "4MJ",
+        burnt_result = "ash"
+      },
+      fuel = {
+        type = "item",
+        name = "fuel",
+        fuel_category = "chemical",
+        fuel_value = "15MJ",
+      },
+      ash = {
+        type = "item",
+        name = "ash",
+      },
+      dummy_1 = {
+        type = "item",
+        name = "dummy_1",
+      },
+      dummy_2 = {
+        type = "item",
+        name = "dummy_2",
+      },
+      dummy_3 = {
+        type = "item",
+        name = "dummy_3",
+      }
+    },
+    ["assembling-machine"] = {
+      ["assembling-machine-f1"] = {
+        type = "assembling-machine",
+        name = "assembling-machine-f1",
+        crafting_speed = 0.5,
+        energy_source = {
+          type = "burner",
+          fuel_categories = { "chemical" },
+          burnt_result_inventory = 1,
+        },
+        energy_usage = "75kW",
+        crafting_categories = { "crafting" },
+        allowed_effects = {
+          "consumption",
+          "speed",
+          "pollution",
+          "productivity",
+        },
+      },
+      ["assembling-machine-f2"] = {
+        type = "assembling-machine",
+        name = "assembling-machine-f2",
+        crafting_speed = 0.75,
+        energy_source = {
+          type = "burner",
+          fuel_categories = { "chemical" },
+          burnt_result_inventory = 1,
+        },
+        energy_usage = "150kW",
+        module_specification = {
+          module_slots = 1,
+        },
+        crafting_categories = { "crafting" },
+        allowed_effects = {
+          "consumption",
+          "speed",
+          "pollution",
+          "productivity",
+        },
+      },
+      ["assembling-machine-f3"] = {
+        type = "assembling-machine",
+        name = "assembling-machine-f3",
+        crafting_speed = 1.25,
+        energy_source = {
+          type = "burner",
+          fuel_categories = { "chemical" },
+          burnt_result_inventory = 0, -- Test with burnt-result deletion too
+        },
+        energy_usage = "250kW",
+        module_specification = {
+          module_slots = 2,
+        },
+        crafting_categories = { "crafting" },
+        allowed_effects = {
+          "consumption",
+          "speed",
+          "pollution",
+          "productivity",
+        },
+      },
+      ["assembling-machine-e1"] = {
+        type = "assembling-machine",
+        name = "assembling-machine-e1",
+        crafting_speed = 0.75,
+        energy_source = {
+          type = "electric",
+        },
+        energy_usage = "150kW",
+        crafting_categories = { "crafting" },
+        allowed_effects = {
+          "consumption",
+          "speed",
+          "pollution",
+          "productivity",
+        },
+      },
+      ["assembling-machine-e2"] = {
+        type = "assembling-machine",
+        name = "assembling-machine-e2",
+        crafting_speed = 1,
+        energy_source = {
+          type = "electric",
+        },
+        energy_usage = "250kW",
+        module_specification = {
+          module_slots = 2,
+        },
+        crafting_categories = { "crafting" },
+        allowed_effects = {
+          "consumption",
+          "speed",
+          "pollution",
+          "productivity",
+        },
+      },
+      ["assembling-machine-e3"] = {
+        type = "assembling-machine",
+        name = "assembling-machine-e3",
+        crafting_speed = 1.75,
+        energy_source = {
+          type = "electric",
+        },
+        energy_usage = "375kW",
+        module_specification = {
+          module_slots = 4,
+        },
+        crafting_categories = { "crafting" },
+        allowed_effects = {
+          "consumption",
+          "speed",
+          "pollution",
+          "productivity",
+        },
+      },
+    },
+    beacon = {
+      beacon = {
+        type = "beacon",
+        name = "beacon",
+        allowed_effects = {
+          "consumption",
+          "speed",
+          "pollution",
+        },
+        energy_source = {
+          type = "electric",
+        },
+        energy_usage = "480kW",
+        distribution_effectivity = 0.5,
+        module_specification = {
+          module_slots = 2,
+        },
+      },
+    },
+    module = {
+      ["speed-module"] = {
+        type = "module",
+        name = "speed-module",
+        effect = {
+          speed = {
+            bonus = 0.2,
+          },
+          consumption = {
+            bonus = 0.5,
+          },
+        },
+      },
+      ["speed-module-2"] = {
+        type = "module",
+        name = "speed-module-2",
+        effect = {
+          speed = {
+            bonus = 0.3,
+          },
+          consumption = {
+            bonus = 0.6,
+          },
+        },
+      },
+      ["speed-module-3"] = {
+        type = "module",
+        name = "speed-module-3",
+        effect = {
+          speed = {
+            bonus = 0.5,
+          },
+          consumption = {
+            bonus = 0.7,
+          },
+        },
+      },
+      ["effectivity-module"] = {
+        type = "module",
+        name = "effectivity-module",
+        effect = {
+          consumption = {
+            bonus = -0.3,
+          },
+        },
+      },
+      ["effectivity-module-2"] = {
+        type = "module",
+        name = "effectivity-module-2",
+        effect = {
+          consumption = {
+            bonus = -0.4,
+          },
+        },
+      },
+      ["effectivity-module-3"] = {
+        type = "module",
+        name = "effectivity-module-3",
+        effect = {
+          consumption = {
+            bonus = -0.5,
+          },
+        },
+      },
+      ["productivity-module"] = {
+        type = "module",
+        name = "productivity-module",
+        effect = {
+          productivity = {
+            bonus = 0.04,
+          },
+          consumption = {
+            bonus = 0.4,
+          },
+          pollution = {
+            bonus = 0.05,
+          },
+          speed = {
+            bonus = -0.05,
+          },
+        },
+      },
+      ["productivity-module-2"] = {
+        type = "module",
+        name = "productivity-module-2",
+        effect = {
+          productivity = {
+            bonus = 0.06,
+          },
+          consumption = {
+            bonus = 0.6,
+          },
+          pollution = {
+            bonus = 0.07,
+          },
+          speed = {
+            bonus = -0.1,
+          },
+        },
+      },
+      ["productivity-module-3"] = {
+        type = "module",
+        name = "productivity-module-3",
+        effect = {
+          productivity = {
+            bonus = 0.1,
+          },
+          consumption = {
+            bonus = 0.8,
+          },
+          pollution = {
+            bonus = 0.1,
+          },
+          speed = {
+            bonus = -0.15,
+          },
+        },
+      },
+    },
+    recipe = {
+      recipe = {
+        type = "recipe",
+        name = "recipe",
+        ingredients = {
+          { type = "item", name = "dummy_1", amount = 5 },
+          { type = "item", name = "dummy_2", amount = 10 },
+        },
+        energy_required = 5,
+        results = {
+          { type = "item", name = "dummy_3", amount = 5 },
+          { type = "item", name = "ash", amount = 3 },
+        },
+      },
+      recipe2 = {
+        type = "recipe",
+        name = "recipe2",
+        ingredients = {
+          { type = "item", name = "dummy_3", amount = 5 },
+          { type = "item", name = "ash", amount = 10 },
+        },
+        energy_required = 5,
+        results = {
+          { type = "item", name = "dummy_3", amount = 5 },
+        },
+      },
+    },
+    quality = {
+      normal = {
+        name = "normal",
+        type = "quality",
+        level = 0,
+      },
+      uncommon = {
+        name = "uncommon",
+        type = "quality",
+        level = 1,
+      },
+    },
+  },
+}
+defines.prototypes = {
+  entity = {
+    ["assembling-machine"] = 0,
+    beacon = 0,
+  },
+  item = {
+    item = 0,
+    module = 0,
+  },
+}

--- a/Yafc.Model.Tests/Model/ProductionTableTests.cs
+++ b/Yafc.Model.Tests/Model/ProductionTableTests.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
@@ -50,93 +49,55 @@ public class ProductionTableTests {
 
     [Fact]
     public async Task Solve_UsesProjectThreadSwitcher_ForInfeasibleLink() {
-        Project project = LuaDependentTestHelper.GetProjectForLua("Yafc.Model.Tests.Model.ProductionTableContentTests.lua");
-        Project originalProject = Project.current;
-        project.modelThreadSwitcher = new CountingModelThreadSwitcher();
-        Project.current = project;
+        Project project = LuaDependentTestHelper.GetProjectForLua();
+        CountingModelThreadSwitcher switcher = new();
+        project.modelThreadSwitcher = switcher;
 
-        PropertyInfo ingredientsProperty = typeof(RecipeOrTechnology).GetProperty(nameof(RecipeOrTechnology.ingredients),
-            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!;
-        RecipeOrTechnology producerRecipe = Database.recipes.all.Single(r => r.name == "recipe").With(Quality.Normal).target;
-        RecipeOrTechnology consumerRecipe = Database.recipes.all.Single(r => r.name == "recipe2").With(Quality.Normal).target;
-        Ingredient[] originalIngredients = consumerRecipe.ingredients;
+        RecipeOrTechnology producerRecipe = Database.recipes.all.Single(r => r.name == "recipe");
+        RecipeOrTechnology consumerRecipe = Database.recipes.all.Single(r => r.name == "recipe2");
         Goods dummy3 = Database.items.all.Single(g => g.name == "dummy_3");
         Goods ash = Database.items.all.Single(g => g.name == "ash");
         IObjectWithQuality<Goods> dummy3Link = dummy3.With(Quality.Normal);
         IObjectWithQuality<Goods> ashLink = ash.With(Quality.Normal);
-        Dictionary<FactorioObject, float> originalCosts = [];
+        CostAnalysis.Instance.cost[dummy3] = 1f;
+        CostAnalysis.Instance.cost[ash] = 1f;
 
-        void OverrideCost(FactorioObject obj, float cost) {
-            if (!originalCosts.ContainsKey(obj)) {
-                originalCosts[obj] = CostAnalysis.Instance.cost[obj];
-            }
-            CostAnalysis.Instance.cost[obj] = cost;
-        }
+        ProjectPage page = new(project, typeof(ProductionTable));
+        project.pages.Add(page);
+        ProductionTable table = (ProductionTable)page.content;
 
-        try {
-            ingredientsProperty.SetValue(consumerRecipe, new Ingredient[] {
-                new Ingredient(dummy3, originalIngredients[0].amount),
-                new Ingredient(ash, originalIngredients[1].amount),
-            });
+        table.AddRecipe(producerRecipe.With(Quality.Normal), DataUtils.DeterministicComparer);
+        table.AddRecipe(consumerRecipe.With(Quality.Normal), DataUtils.DeterministicComparer);
+        RecipeRow producer = table.recipes[0];
+        RecipeRow consumer = table.recipes[1];
 
-            ProjectPage page = new(project, typeof(ProductionTable));
-            project.pages.Add(page);
-            ProductionTable table = (ProductionTable)page.content;
+        producer.fixedBuildings = 1f;
+        consumer.fixedBuildings = 1f;
+        Assert.True(table.CreateLink(dummy3Link));
+        Assert.True(table.CreateLink(ashLink));
+        ProductionLink dummy3LinkRecord = Assert.Single(table.links, link => link.goods == dummy3Link);
+        ProductionLink ashLinkRecord = Assert.Single(table.links, link => link.goods == ashLink);
+        dummy3LinkRecord.amount = 1f;
+        ashLinkRecord.amount = 1f;
 
-            table.AddRecipe(producerRecipe.With(Quality.Normal), DataUtils.DeterministicComparer);
-            table.AddRecipe(consumerRecipe.With(Quality.Normal), DataUtils.DeterministicComparer);
-            RecipeRow producer = table.GetAllRecipes().Single(r => r.recipe?.target.name == "recipe");
-            RecipeRow consumer = table.GetAllRecipes().Single(r => r.recipe?.target.name == "recipe2");
+        Recipe recoveryRecipe = Assert.IsType<Recipe>(producerRecipe);
+        table.AddRecipe(recoveryRecipe.With(Quality.Normal), DataUtils.DeterministicComparer);
+        RecipeRow recoveryRow = table.recipes[2];
+        recoveryRow.fixedBuildings = 1f;
+        IObjectWithQuality<Goods> recoveryGoods = Database.goods.all.Single(g => g.name == "dummy_1").With(Quality.Normal);
+        Assert.True(table.CreateLink(recoveryGoods));
+        ProductionLink recoveryLink = Assert.Single(table.links, link => link.goods == recoveryGoods);
+        recoveryLink.amount = 1f;
 
-            producer.fixedBuildings = 1f;
-            consumer.fixedBuildings = 1f;
-            Assert.True(table.CreateLink(dummy3Link));
-            Assert.True(table.CreateLink(ashLink));
-            ProductionLink dummy3LinkRecord = Assert.Single(table.links, link => link.goods == dummy3Link);
-            ProductionLink ashLinkRecord = Assert.Single(table.links, link => link.goods == ashLink);
-            dummy3LinkRecord.amount = 1f;
-            ashLinkRecord.amount = 1f;
-            OverrideCost(dummy3, 1f);
-            OverrideCost(ash, 1f);
+        var error = await table.Solve(page);
 
-            Recipe recoveryRecipe = Database.recipes.all.OfType<Recipe>().First(r => r.products.Length > 1 || r.ingredients.Length > 1);
-            foreach (var product in recoveryRecipe.products) {
-                OverrideCost(product.goods, 1f);
-            }
-            foreach (var ingredient in recoveryRecipe.ingredients) {
-                OverrideCost(ingredient.goods, 1f);
-            }
-
-            table.AddRecipe(recoveryRecipe.With(Quality.Normal), DataUtils.DeterministicComparer);
-            RecipeRow recoveryRow = table.GetAllRecipes().Last(r => r.recipe?.target == recoveryRecipe);
-            recoveryRow.fixedBuildings = 1f;
-            Product? recoveryProduct = recoveryRecipe.products.FirstOrDefault(p => p.goods.isLinkable && !table.linkMap.ContainsKey(p.goods.With(Quality.Normal)));
-            Ingredient? recoveryIngredient = recoveryProduct is null
-                ? recoveryRecipe.ingredients.FirstOrDefault(i => i.goods.isLinkable && !table.linkMap.ContainsKey(i.goods.With(Quality.Normal)))
-                : null;
-            IObjectWithQuality<Goods> recoveryGoods = (recoveryProduct?.goods ?? recoveryIngredient!.goods).With(Quality.Normal);
-            Assert.True(table.CreateLink(recoveryGoods));
-            ProductionLink recoveryLink = Assert.Single(table.links, link => link.goods == recoveryGoods);
-            recoveryLink.amount = 1f;
-
-            string? error = await table.Solve(page);
-            CountingModelThreadSwitcher switcher = (CountingModelThreadSwitcher)project.modelThreadSwitcher;
-
-            Assert.NotNull(error);
-            Assert.Equal(1, switcher.backgroundSwitches);
-            // ProductionTable.Solve is called directly here, so ProjectPage.ExternalSolve's
-            // foreground re-entry is not counted. Today Solve switches back to foreground
-            // only inside the infeasibility diagnostics branch exercised by this test.
-            Assert.Equal(1, switcher.foregroundSwitches);
-            Assert.Equal([CountingModelThreadSwitcher.SwitchEvent.Background, CountingModelThreadSwitcher.SwitchEvent.Foreground], switcher.events);
-        }
-        finally {
-            ingredientsProperty.SetValue(consumerRecipe, originalIngredients);
-            foreach (var (obj, cost) in originalCosts) {
-                CostAnalysis.Instance.cost[obj] = cost;
-            }
-            Project.current = originalProject;
-        }
+        Assert.NotNull(error);
+        Assert.Equal(1, switcher.backgroundSwitches);
+        // ProductionTable.Solve is called directly here, so ProjectPage.ExternalSolve's
+        // foreground re-entry is not counted. Today Solve switches back to foreground
+        // only inside the infeasibility diagnostics branch exercised by this test.
+        Assert.Equal(1, switcher.foregroundSwitches);
+        Assert.Equal([CountingModelThreadSwitcher.SwitchEvent.Background, CountingModelThreadSwitcher.SwitchEvent.Foreground], switcher.events);
     }
 
     [Fact]

--- a/Yafc.Model.Tests/Model/ProductionTableTests.cs
+++ b/Yafc.Model.Tests/Model/ProductionTableTests.cs
@@ -1,7 +1,9 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Reflection;
+using System.Threading.Tasks;
 using Xunit;
 
 namespace Yafc.Model.Tests.Model;
@@ -44,6 +46,98 @@ public class ProductionTableTests {
         Assert.False(table.linkMap.ContainsKey(goods));
         Assert.True(table.CreateLink(goods));
         Assert.Single(table.links);
+    }
+
+    [Fact]
+    public async Task Solve_UsesProjectThreadSwitcher_ForInfeasibleLink() {
+        Project project = LuaDependentTestHelper.GetProjectForLua("Yafc.Model.Tests.Model.ProductionTableContentTests.lua");
+        Project originalProject = Project.current;
+        project.modelThreadSwitcher = new CountingModelThreadSwitcher();
+        Project.current = project;
+
+        PropertyInfo ingredientsProperty = typeof(RecipeOrTechnology).GetProperty(nameof(RecipeOrTechnology.ingredients),
+            BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic)!;
+        RecipeOrTechnology producerRecipe = Database.recipes.all.Single(r => r.name == "recipe").With(Quality.Normal).target;
+        RecipeOrTechnology consumerRecipe = Database.recipes.all.Single(r => r.name == "recipe2").With(Quality.Normal).target;
+        Ingredient[] originalIngredients = consumerRecipe.ingredients;
+        Goods dummy3 = Database.items.all.Single(g => g.name == "dummy_3");
+        Goods ash = Database.items.all.Single(g => g.name == "ash");
+        IObjectWithQuality<Goods> dummy3Link = dummy3.With(Quality.Normal);
+        IObjectWithQuality<Goods> ashLink = ash.With(Quality.Normal);
+        Dictionary<FactorioObject, float> originalCosts = [];
+
+        void OverrideCost(FactorioObject obj, float cost) {
+            if (!originalCosts.ContainsKey(obj)) {
+                originalCosts[obj] = CostAnalysis.Instance.cost[obj];
+            }
+            CostAnalysis.Instance.cost[obj] = cost;
+        }
+
+        try {
+            ingredientsProperty.SetValue(consumerRecipe, new Ingredient[] {
+                new Ingredient(dummy3, originalIngredients[0].amount),
+                new Ingredient(ash, originalIngredients[1].amount),
+            });
+
+            ProjectPage page = new(project, typeof(ProductionTable));
+            project.pages.Add(page);
+            ProductionTable table = (ProductionTable)page.content;
+
+            table.AddRecipe(producerRecipe.With(Quality.Normal), DataUtils.DeterministicComparer);
+            table.AddRecipe(consumerRecipe.With(Quality.Normal), DataUtils.DeterministicComparer);
+            RecipeRow producer = table.GetAllRecipes().Single(r => r.recipe?.target.name == "recipe");
+            RecipeRow consumer = table.GetAllRecipes().Single(r => r.recipe?.target.name == "recipe2");
+
+            producer.fixedBuildings = 1f;
+            consumer.fixedBuildings = 1f;
+            Assert.True(table.CreateLink(dummy3Link));
+            Assert.True(table.CreateLink(ashLink));
+            ProductionLink dummy3LinkRecord = Assert.Single(table.links, link => link.goods == dummy3Link);
+            ProductionLink ashLinkRecord = Assert.Single(table.links, link => link.goods == ashLink);
+            dummy3LinkRecord.amount = 1f;
+            ashLinkRecord.amount = 1f;
+            OverrideCost(dummy3, 1f);
+            OverrideCost(ash, 1f);
+
+            Recipe recoveryRecipe = Database.recipes.all.OfType<Recipe>().First(r => r.products.Length > 1 || r.ingredients.Length > 1);
+            foreach (var product in recoveryRecipe.products) {
+                OverrideCost(product.goods, 1f);
+            }
+            foreach (var ingredient in recoveryRecipe.ingredients) {
+                OverrideCost(ingredient.goods, 1f);
+            }
+
+            table.AddRecipe(recoveryRecipe.With(Quality.Normal), DataUtils.DeterministicComparer);
+            RecipeRow recoveryRow = table.GetAllRecipes().Last(r => r.recipe?.target == recoveryRecipe);
+            recoveryRow.fixedBuildings = 1f;
+            Product? recoveryProduct = recoveryRecipe.products.FirstOrDefault(p => p.goods.isLinkable && !table.linkMap.ContainsKey(p.goods.With(Quality.Normal)));
+            Ingredient? recoveryIngredient = recoveryProduct is null
+                ? recoveryRecipe.ingredients.FirstOrDefault(i => i.goods.isLinkable && !table.linkMap.ContainsKey(i.goods.With(Quality.Normal)))
+                : null;
+            IObjectWithQuality<Goods> recoveryGoods = (recoveryProduct?.goods ?? recoveryIngredient!.goods).With(Quality.Normal);
+            Assert.True(table.CreateLink(recoveryGoods));
+            ProductionLink recoveryLink = Assert.Single(table.links, link => link.goods == recoveryGoods);
+            recoveryLink.amount = 1f;
+
+            string? error = await table.Solve(page);
+            CountingModelThreadSwitcher switcher = (CountingModelThreadSwitcher)project.modelThreadSwitcher;
+
+            Assert.NotNull(error);
+            Assert.Equal(1, switcher.backgroundSwitches);
+            Assert.Equal(1, switcher.foregroundSwitches);
+            Assert.Equal([CountingModelThreadSwitcher.SwitchEvent.Background, CountingModelThreadSwitcher.SwitchEvent.Foreground], switcher.events);
+            Assert.True(table.links.Any(link => link.notMatchedFlow != 0f || link.flags.HasFlags(ProductionLink.Flags.LinkNotMatched) || link.flags.HasFlags(ProductionLink.Flags.LinkRecursiveNotMatched))
+                || (producer.warningFlags | consumer.warningFlags | recoveryRow.warningFlags) != 0,
+                $"links={string.Join(", ", table.links.Select(link => $"{link.goods.target.name}:{link.notMatchedFlow}:{link.flags}"))}; " +
+                $"warnings={producer.warningFlags}|{consumer.warningFlags}|{recoveryRow.warningFlags}; error={error}");
+        }
+        finally {
+            ingredientsProperty.SetValue(consumerRecipe, originalIngredients);
+            foreach (var (obj, cost) in originalCosts) {
+                CostAnalysis.Instance.cost[obj] = cost;
+            }
+            Project.current = originalProject;
+        }
     }
 
     [Fact]
@@ -149,6 +243,29 @@ public class ProductionTableTests {
 
     public static TheoryData<Type> ProjectPageContentTypes => [.. AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.GetTypes())
         .Where(t => typeof(ProjectPageContents).IsAssignableFrom(t) && !t.IsAbstract)];
+
+    private sealed class CountingModelThreadSwitcher : IModelThreadSwitcher {
+        public enum SwitchEvent {
+            Background,
+            Foreground,
+        }
+
+        public int backgroundSwitches { get; private set; }
+        public int foregroundSwitches { get; private set; }
+        public List<SwitchEvent> events { get; } = [];
+
+        public ModelThreadSwitch SwitchToBackground() {
+            backgroundSwitches++;
+            events.Add(SwitchEvent.Background);
+            return default;
+        }
+
+        public ModelThreadSwitch SwitchToForeground() {
+            foregroundSwitches++;
+            events.Add(SwitchEvent.Foreground);
+            return default;
+        }
+    }
 
     [Fact]
     public void ProductionTableTest_CanLoadWithNullRecipe() {

--- a/Yafc.Model.Tests/Model/ProductionTableTests.cs
+++ b/Yafc.Model.Tests/Model/ProductionTableTests.cs
@@ -124,12 +124,11 @@ public class ProductionTableTests {
 
             Assert.NotNull(error);
             Assert.Equal(1, switcher.backgroundSwitches);
+            // ProductionTable.Solve is called directly here, so ProjectPage.ExternalSolve's
+            // foreground re-entry is not counted. Today Solve switches back to foreground
+            // only inside the infeasibility diagnostics branch exercised by this test.
             Assert.Equal(1, switcher.foregroundSwitches);
             Assert.Equal([CountingModelThreadSwitcher.SwitchEvent.Background, CountingModelThreadSwitcher.SwitchEvent.Foreground], switcher.events);
-            Assert.True(table.links.Any(link => link.notMatchedFlow != 0f || link.flags.HasFlags(ProductionLink.Flags.LinkNotMatched) || link.flags.HasFlags(ProductionLink.Flags.LinkRecursiveNotMatched))
-                || (producer.warningFlags | consumer.warningFlags | recoveryRow.warningFlags) != 0,
-                $"links={string.Join(", ", table.links.Select(link => $"{link.goods.target.name}:{link.notMatchedFlow}:{link.flags}"))}; " +
-                $"warnings={producer.warningFlags}|{consumer.warningFlags}|{recoveryRow.warningFlags}; error={error}");
         }
         finally {
             ingredientsProperty.SetValue(consumerRecipe, originalIngredients);
@@ -243,29 +242,6 @@ public class ProductionTableTests {
 
     public static TheoryData<Type> ProjectPageContentTypes => [.. AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.GetTypes())
         .Where(t => typeof(ProjectPageContents).IsAssignableFrom(t) && !t.IsAbstract)];
-
-    private sealed class CountingModelThreadSwitcher : IModelThreadSwitcher {
-        public enum SwitchEvent {
-            Background,
-            Foreground,
-        }
-
-        public int backgroundSwitches { get; private set; }
-        public int foregroundSwitches { get; private set; }
-        public List<SwitchEvent> events { get; } = [];
-
-        public ModelThreadSwitch SwitchToBackground() {
-            backgroundSwitches++;
-            events.Add(SwitchEvent.Background);
-            return default;
-        }
-
-        public ModelThreadSwitch SwitchToForeground() {
-            foregroundSwitches++;
-            events.Add(SwitchEvent.Foreground);
-            return default;
-        }
-    }
 
     [Fact]
     public void ProductionTableTest_CanLoadWithNullRecipe() {

--- a/Yafc.Model.Tests/Model/ProjectPageTests.cs
+++ b/Yafc.Model.Tests/Model/ProjectPageTests.cs
@@ -41,21 +41,6 @@ public class ProjectPageTests {
         Assert.False(page.IsSolutionStale());
     }
 
-    private sealed class CountingModelThreadSwitcher : IModelThreadSwitcher {
-        public int backgroundSwitches { get; private set; }
-        public int foregroundSwitches { get; private set; }
-
-        public ModelThreadSwitch SwitchToBackground() {
-            backgroundSwitches++;
-            return default;
-        }
-
-        public ModelThreadSwitch SwitchToForeground() {
-            foregroundSwitches++;
-            return default;
-        }
-    }
-
     private sealed class GuardedModelThreadSwitcher : IModelThreadSwitcher {
         private bool inForegroundDispatch;
 

--- a/Yafc.Model.Tests/TestHelpers.cs
+++ b/Yafc.Model.Tests/TestHelpers.cs
@@ -13,3 +13,26 @@ internal static class TestHelpers {
     public static IEnumerable<IObjectWithQuality<T>> WithAllQualities<T>(this IEnumerable<T> values) where T : FactorioObject
         => values.SelectMany(c => Database.qualities.all.Select(q => c.With(q))).Distinct();
 }
+
+internal sealed class CountingModelThreadSwitcher : IModelThreadSwitcher {
+    public enum SwitchEvent {
+        Background,
+        Foreground,
+    }
+
+    public int backgroundSwitches { get; private set; }
+    public int foregroundSwitches { get; private set; }
+    public List<SwitchEvent> events { get; } = [];
+
+    public ModelThreadSwitch SwitchToBackground() {
+        backgroundSwitches++;
+        events.Add(SwitchEvent.Background);
+        return default;
+    }
+
+    public ModelThreadSwitch SwitchToForeground() {
+        foregroundSwitches++;
+        events.Add(SwitchEvent.Foreground);
+        return default;
+    }
+}

--- a/Yafc.Model.Tests/Yafc.Model.Tests.csproj
+++ b/Yafc.Model.Tests/Yafc.Model.Tests.csproj
@@ -42,6 +42,7 @@
   <ItemGroup>
     <EmbeddedResource Include="BareMinimumLuaData.lua" />
     <EmbeddedResource Include="Model\ProductionTableContentTests.lua" />
+    <EmbeddedResource Include="Model\ProductionTableTests.Solve_UsesProjectThreadSwitcher_ForInfeasibleLink.lua" />
     <EmbeddedResource Include="Model\RecipeParametersTests.FluidBoilingRecipes_HaveCorrectConsumption.lua" />
     <EmbeddedResource Include="Model\SelectableVariantsTests.lua" />
   </ItemGroup>

--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -540,7 +540,7 @@ match:
             }
         }
 
-        await Ui.ExitMainThread();
+        await page.owner.modelThreadSwitcher.SwitchToBackground();
 
         for (int i = 0; i < allRecipes.Count; i++) {
             objective.SetCoefficient(vars[i], allRecipes[i].BaseCost);
@@ -577,7 +577,7 @@ match:
             result = productionTableSolver.Solve();
 
             logger.Information("Solver finished with result {result}", result);
-            await Ui.EnterMainThread();
+            await page.owner.modelThreadSwitcher.SwitchToForeground();
 
             if (result is Solver.ResultStatus.OPTIMAL or Solver.ResultStatus.FEASIBLE) {
                 List<IProductionLink> linkList = [];


### PR DESCRIPTION
Dear maintainers,

This PR routes `ProductionTable.Solve()` through the model thread-switching bridge so the OR-Tools solve runs on the background thread and result handling returns to the foreground thread before post-processing.

It also adds regression coverage for:
- link-map updates after create/destroy link mutations
- bridge invocation during an infeasible solve path

close #641