### PR TITLE
fix: Do not log an exception when the cache is missing

### DIFF
--- a/Yafc.Parser/FactorioDataSource.Cache.cs
+++ b/Yafc.Parser/FactorioDataSource.Cache.cs
@@ -211,8 +211,14 @@ public static partial class FactorioDataSource {
         /// of this stream, it will <b>throw when closed</b>.</returns>
         private DecompressAndVerifyStream? OpenReadCache(Crc32 partialHash, out uint? hash) {
             hash = FinishHash(partialHash.Clone());
+            string cacheFile = GetCacheFile(hash.Value);
+            if (!File.Exists(cacheFile)) {
+                // A missing cache file is an ordinary cache miss (e.g. first run, or the hash changed); not an error worth logging.
+                return null;
+            }
+
             // This will throw if the cache is open in any other process for write.
-            FileStream? file = File.Open(GetCacheFile(hash.Value), FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
+            FileStream? file = File.Open(cacheFile, FileMode.Open, FileAccess.ReadWrite, FileShare.ReadWrite);
 
             try { // conditional using block; dispose file if something fails before we transfer ownership
                 Span<byte> bytes = stackalloc byte[4];

--- a/changelog.txt
+++ b/changelog.txt
@@ -26,6 +26,7 @@ Date:
     Fixes:
         - Several improvements loading Exotic Space Industries:Remembrance and its dependencies.
         - Ensure technology levels can always be specified, even with super-long technology names.
+        - Don't log an exception when a cache file is simply absent.
     Internal changes:
         - Upgrade to .NET 10.
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
I noticed exceptions in my logs, so I assumed something was wrong. But it turned out the cache file was missing.

With this small PR, missing cache files are not logged, reducing noise.