### PR TITLE
refactor(yafc-ce): Make WelcomeScreen Project Parsing Boundary Explicit

### DIFF
--- a/Yafc/Windows/WelcomeScreen.cs
+++ b/Yafc/Windows/WelcomeScreen.cs
@@ -8,6 +8,7 @@ using System.Linq;
 using System.Net.Http;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using SDL2;
 using Serilog;
@@ -562,12 +563,18 @@ public class WelcomeScreen : WindowUtility, IProgress<(string, string)>, IKeyboa
             loading = true;
             rootGui.Rebuild();
 
-            await Ui.ExitMainThread();
-
             ErrorCollector collector = new ErrorCollector();
-            var project = FactorioDataSource.Parse(dataPath, modsPath, projectPath, expensive, netProduction, this, collector, Preferences.Instance.language, Preferences.Instance.useMostRecentSave);
+            var project = await Task.Run(() => FactorioDataSource.Parse(
+                dataPath,
+                modsPath,
+                projectPath,
+                expensive,
+                netProduction,
+                this,
+                collector,
+                Preferences.Instance.language,
+                Preferences.Instance.useMostRecentSave));
 
-            await Ui.EnterMainThread();
             logger.Information("Opening main screen");
             _ = new MainScreen(displayIndex, project);
 
@@ -580,11 +587,9 @@ public class WelcomeScreen : WindowUtility, IProgress<(string, string)>, IKeyboa
             logger.Information("GC: {TotalMemory}", GC.GetTotalMemory(false));
         }
         catch (InvalidOperationException ex) when (FactorioDataSource.CurrentLoadingMod == null && (ex.StackTrace?.Contains("MoveNext") ?? false)) {
-            await Ui.EnterMainThread();
             definesUpdateState = DefinesUpdateState.WaitingForCopy;
         }
         catch (Exception ex) {
-            await Ui.EnterMainThread();
             while (ex.InnerException != null) {
                 ex = ex.InnerException;
             }


### PR DESCRIPTION
## Summary

This PR clarifies the threading boundary in `WelcomeScreen.LoadProject()` by wrapping `FactorioDataSource.Parse(...)` in an explicit `Task.Run(...)` call instead of manually switching away from and back to the UI thread around the parse operation.

The expensive parse/load work remains off the UI thread, while the continuation continues to rely on the existing UI `SynchronizationContext` for subsequent UI updates. The existing success path, error handling, and loading-state behavior are preserved.

Closes #643.

## Validation

- `dotnet format --verify-no-changes --diagnostics IDE0055 --severity info --verbosity normal`
- `dotnet build .\FactorioCalc.sln --no-restore --verbosity minimal`
- `dotnet test .\Yafc.Model.Tests\Yafc.Model.Tests.csproj --no-restore --nologo --verbosity minimal` (423 tests passed)
