### PR TITLE
fix: hide "always fresh" for non-spoilable products

### DIFF
--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -374,11 +374,14 @@ public class Product : IFactorioObjectWrapper {
                 }
             }
 
-            if (percentSpoiled == 0) {
-                text = LSs.ProductAlwaysFresh.L(text);
-            }
-            else if (percentSpoiled != null) {
-                text = LSs.ProductFixedSpoilage.L(text, DataUtils.FormatAmount(percentSpoiled.Value, UnitOfMeasure.Percent));
+            // Spoilage only makes sense for perishable products; non-spoilable items have no freshness to report.
+            if (goods is Item { spoilResult: not null }) {
+                if (percentSpoiled == 0) {
+                    text = LSs.ProductAlwaysFresh.L(text);
+                }
+                else if (percentSpoiled != null) {
+                    text = LSs.ProductFixedSpoilage.L(text, DataUtils.FormatAmount(percentSpoiled.Value, UnitOfMeasure.Percent));
+                }
             }
 
             return text;

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -704,7 +704,11 @@ goodsHaveNoProduction:;
             else if (recipe.recipe != null) {
                 foreach (var (goods, amount, link, percentSpoiled) in recipe.Products) {
                     grid.Next();
-                    if (recipe.recipe.target is Recipe { preserveProducts: true }) {
+                    // Spoilage only makes sense for perishable products; non-spoilable items have no freshness to report.
+                    if (goods?.target is not Item { spoilResult: not null }) {
+                        view.BuildGoodsIcon(gui, goods, link, amount, ProductDropdownType.Product, recipe, recipe.linkRoot, HintLocations.OnConsumingRecipes);
+                    }
+                    else if (recipe.recipe.target is Recipe { preserveProducts: true }) {
                         view.BuildGoodsIcon(gui, goods, link, amount, ProductDropdownType.Product, recipe, recipe.linkRoot, new() {
                             HintLocations = HintLocations.OnConsumingRecipes,
                             ExtraSpoilInformation = gui => gui.BuildText(LSs.ProductionTableOutputPreservedInMachine, TextBlockDisplayStyle.WrappedText)

--- a/changelog.txt
+++ b/changelog.txt
@@ -25,6 +25,7 @@ Date:
         - Yafc will cache rendered icons to improve mod load times.
         - Support Factorio 2.1.
     Fixes:
+        - Don't show spoilage information (e.g. "always fresh") for non-spoilable recipe products.
         - Several improvements loading Exotic Space Industries:Remembrance and its dependencies.
         - Ensure technology levels can always be specified, even with super-long technology names.
         - Don't log an exception when a cache file is simply absent.


### PR DESCRIPTION
While playing pyanodons (with spoilage enabled), I noticed that all recipe products are showing "always fresh".
I assume that this indicates that the product won't spoil, but then I noticed that it also showed this on products that _do_ spoil, so I got confused...

After checking I saw it is mentioning this if the product is fresh when produced, independent of its ingredients. (The clock icon indicates the product is spoilable).

So I figured that showing this "always fresh" does not make sense for non-spoilable products. As they are (ofc) always fresh...! Which is what this PR does.

Note that I used the `spoilResult != 0` to check if an item is spoilable, as it made more sense in my mind, while the 'clock icon' uses `baseSpoilTime > 0`... If you'd prefer I can also use the latter...?

*Before:*
<img width="339" height="121" alt="image" src="https://github.com/user-attachments/assets/57fe6608-d3dd-4250-acc1-6389a8c595ec" />

*With this PR:*
<img width="339" height="121" alt="image" src="https://github.com/user-attachments/assets/9ec830df-8f5a-4764-9b5b-152f3e8f182c" />
