### PR TITLE
fix: Show the per-cycle amount for every science pack when 3+ science packs are required

### DIFF
--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -475,7 +475,23 @@ doneDrawing:;
 
         using (gui.EnterGroup(contentPadding)) {
             if (recipe is Technology) {
-                BuildIconRow(gui, recipe.ingredients, 2, DataUtils.DefaultSciencePackOrdering);
+                var sortedPacks = recipe.ingredients.OrderBy(x => (IFactorioObjectWrapper)x, DataUtils.DefaultSciencePackOrdering);
+                if (recipe.ingredients.Length > 2) {
+                    // Many science packs: show each pack's per-cycle amount as a compact badge. (Spelling out every
+                    // "Nx <name>" on its own line would make the tooltip too tall, and collapsing all but the first into
+                    // amount-less icons hides the per-pack amounts, which can differ between packs.)
+                    using var grid = gui.EnterInlineGrid(2f);
+                    foreach (Ingredient ingredient in sortedPacks) {
+                        grid.Next();
+                        _ = gui.BuildFactorioObjectWithAmount(ingredient.goods, ingredient.amount, ButtonDisplayStyle.Default);
+                    }
+                }
+                else {
+                    // One or two packs: spell out "Nx <name>" so new players can learn the layout meaning.
+                    foreach (Ingredient ingredient in sortedPacks) {
+                        BuildItem(gui, ingredient);
+                    }
+                }
             }
             else {
                 foreach (Ingredient ingredient in recipe.ingredients) {

--- a/changelog.txt
+++ b/changelog.txt
@@ -28,6 +28,7 @@ Date:
         - Several improvements loading Exotic Space Industries:Remembrance and its dependencies.
         - Ensure technology levels can always be specified, even with super-long technology names.
         - Don't log an exception when a cache file is simply absent.
+        - Show the per-cycle amount for every science pack in a technology tooltip, instead of only the first.
     Internal changes:
         - Upgrade to .NET 10.
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
The per-cycle amount for science packs is dropped in the milestone tooltip when there are more than 2 (or 3?) science packs:
<img width="346" height="193" alt="old" src="https://github.com/user-attachments/assets/c1ab66b9-28c2-45f5-a5e7-24dd46c35f5c" />

With more than 3 packs required, it now renders as:
<img width="346" height="174" alt="new1" src="https://github.com/user-attachments/assets/4bb3c53b-6cf1-4d54-8615-25fc8fa3e05b" />
