### PR TITLE
fix: Make deserialization flag thread-static

### DIFF
--- a/Yafc.Model/Serialization/SerializationMap.cs
+++ b/Yafc.Model/Serialization/SerializationMap.cs
@@ -58,7 +58,10 @@ internal abstract class SerializationMap {
     public abstract void ReadUndo(object? target, UndoSnapshotReader reader);
 
     private static readonly Dictionary<Type, SerializationMap> undoBuilders = [];
-    protected static int deserializingCount;
+    // Deserialization is a synchronous, single-threaded operation, but the test suite runs multiple
+    // collections in parallel. A process-global counter would let one thread's deserialization make
+    // IsDeserializing observable on unrelated threads, so this is per-thread.
+    [ThreadStatic] protected static int deserializingCount;
     public static bool IsDeserializing => deserializingCount > 0;
 
     public static SerializationMap GetSerializationMap(Type type) {


### PR DESCRIPTION
`SerializationMap.deserializingCount` was a process-global `static int`, but deserialization is a synchronous, single-threaded operation — the counter is only ever incremented/decremented inside a `try/finally` on the same thread.

Because xUnit runs test classes in parallel and `UndoSystemTests` isn't part of the serialized `LuaDependentTests` collection, a Lua-dependent test deserializing a project on one thread made `IsDeserializing` true *globally*. A parallel
`RecordUndo()` would then trip the `UndoSystem` guard:

> Do not record an undo event while deserializing.

This showed up as a [flaky, single-test CI failure](https://github.com/veger/yafc-ce/actions/runs/28316885361/job/83891721010). Marking the counter `[ThreadStatic]` gives each thread its own depth, matching the actual semantics. No effect on the single-threaded production load path.