### PR TITLE
Load and display location dependencies, part 1

### DIFF
--- a/Yafc.Model.Tests/BareMinimumLuaData.lua
+++ b/Yafc.Model.Tests/BareMinimumLuaData.lua
@@ -1,5 +1,11 @@
-data = { raw = {} }
+data = { raw = {
+    planet = { nauvis = {
+        name = "nauvis",
+        type = "planet",
+    } },
+} }
 defines.prototypes = { 
     item = {},
     entity = {},
+    ["space-location"] = { planet = 0 },
 }

--- a/Yafc.Model.Tests/Model/ProductionTableContentTests.lua
+++ b/Yafc.Model.Tests/Model/ProductionTableContentTests.lua
@@ -292,6 +292,12 @@ data = {
         },
       },
     },
+    planet = {
+      nauvis = {
+        name = "nauvis",
+        type = "planet",
+      },
+    },
     recipe = {
       recipe = {
         type = "recipe",
@@ -341,5 +347,8 @@ defines.prototypes = {
   item = {
     item = 0,
     module = 0,
+  },
+  ["space-location"] = {
+    planet = 0
   },
 }

--- a/Yafc.Model.Tests/Model/ProductionTableTests.Solve_UsesProjectThreadSwitcher_ForInfeasibleLink.lua
+++ b/Yafc.Model.Tests/Model/ProductionTableTests.Solve_UsesProjectThreadSwitcher_ForInfeasibleLink.lua
@@ -292,6 +292,12 @@ data = {
         },
       },
     },
+    planet = {
+      nauvis = {
+        name = "nauvis",
+        type = "planet",
+      },
+    },
     recipe = {
       recipe = {
         type = "recipe",
@@ -341,5 +347,8 @@ defines.prototypes = {
   item = {
     item = 0,
     module = 0,
+  },
+  ["space-location"] = {
+    planet = 0
   },
 }

--- a/Yafc.Model.Tests/Model/RecipeParametersTests.FluidBoilingRecipes_HaveCorrectConsumption.lua
+++ b/Yafc.Model.Tests/Model/RecipeParametersTests.FluidBoilingRecipes_HaveCorrectConsumption.lua
@@ -1,5 +1,11 @@
 data = {
   raw = {
+    planet = {
+      nauvis = {
+        name = "nauvis",
+        type = "planet",
+      },
+    },
     recipe = {
       -- Recipes so Yafc will split water into the required temperatures
       cold_water = {
@@ -121,5 +127,8 @@ defines.prototypes = {
   },
   fluid = {
     fluid = 0,
+  },
+  ["space-location"] = {
+    planet = 0
   },
 }

--- a/Yafc.Model.Tests/Model/SelectableVariantsTests.lua
+++ b/Yafc.Model.Tests/Model/SelectableVariantsTests.lua
@@ -1,5 +1,11 @@
 data = {
   raw = {
+    planet = {
+      nauvis = {
+        name = "nauvis",
+        type = "planet",
+      },
+    },
     recipe = {
       steam_void = {
         type = "recipe",
@@ -96,5 +102,8 @@ defines.prototypes = {
   item = {},
   fluid = {
     fluid = 0,
+  },
+  ["space-location"] = {
+    planet = 0
   },
 }

--- a/Yafc.Model.Tests/Serialization/SerializationTreeChangeDetection.cs
+++ b/Yafc.Model.Tests/Serialization/SerializationTreeChangeDetection.cs
@@ -41,6 +41,7 @@ public class SerializationTreeChangeDetection {
             [nameof(ProductionTable.links)] = typeof(List<ProductionLink>),
             [nameof(ProductionTable.recipes)] = typeof(List<RecipeRow>),
             [nameof(ProductionTable.modules)] = typeof(ModuleFillerParameters),
+            [nameof(ProductionTable.selectedSurface)] = typeof(SelectedSurface),
         },
         [typeof(RecipeRowCustomModule)] = new() {
             [nameof(RecipeRowCustomModule.module)] = typeof(IObjectWithQuality<Module>),
@@ -131,6 +132,10 @@ public class SerializationTreeChangeDetection {
             [nameof(BeaconOverrideConfiguration.beacon)] = typeof(IObjectWithQuality<EntityBeacon>),
             [nameof(BeaconOverrideConfiguration.beaconCount)] = typeof(int),
             [nameof(BeaconOverrideConfiguration.beaconModule)] = typeof(IObjectWithQuality<Module>),
+        },
+        [typeof(SelectedSurface)] = new() {
+            [nameof(SelectedSurface.planet)] = typeof(Location),
+            [nameof(SelectedSurface.platform)] = typeof(Surface),
         },
     };
 

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -103,7 +103,7 @@ public abstract class FactorioObject : IFactorioObjectWrapper, IComparable<Facto
     public static bool operator !=(IObjectWithQuality<FactorioObject>? left, FactorioObject? right) => right != left;
 }
 
-public class FactorioIconPart(string path) {
+public sealed record FactorioIconPart(string path) {
     public string path = path;
     public int size = 32;
     public float x, y, r = 1, g = 1, b = 1, a = 1;

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -175,9 +175,6 @@ public abstract class RecipeOrTechnology : FactorioObject {
         if (sourceEntity != null) {
             collector.Add(([sourceEntity], DependencyNode.Flags.SourceEntity));
         }
-        if (sourceTiles.Count > 0) {
-            collector.Add((sourceTiles.SelectMany(t => t.locations).Distinct(), DependencyNode.Flags.Location));
-        }
 
         return collector;
     }
@@ -221,6 +218,16 @@ public class Recipe : RecipeOrTechnology {
     public bool hidden { get; internal set; }
     public float? maximumProductivity { get; internal set; }
 
+    /// <summary>
+    /// If not <see langword="null"/>, the list of surfaces where this recipe can be crafted. If <see langword="null"/>, this recipe can be crafted on
+    /// all surfaces.
+    /// </summary>
+    public IReadOnlyList<Location>? craftingSurfaces => lazyCraftingSurfaces?.Value;
+    /// <summary>
+    /// The lazy backing store for <see cref="craftingSurfaces"/>, allowing it to be calculated after its prerequsites.
+    /// </summary>
+    internal Lazy<IReadOnlyList<Location>?>? lazyCraftingSurfaces;
+
     public bool HasIngredientVariants() {
         foreach (var ingredient in ingredients) {
             if (ingredient.variants != null) {
@@ -237,6 +244,11 @@ public class Recipe : RecipeOrTechnology {
         if (!enabled) {
             nodes.Add((technologyUnlock, DependencyNode.Flags.TechnologyUnlock));
         }
+
+        if (craftingSurfaces != null) {
+            nodes.Add((craftingSurfaces, DependencyNode.Flags.Location));
+        }
+
         return nodes;
     }
 
@@ -457,6 +469,11 @@ public class Item : Goods {
     /// but it can be overridden for items that spoil into Entities.
     /// </summary>
     internal Lazy<float> getBaseSpoilTime;
+    /// <summary>
+    /// If not <see langword="null"/>, this item is a <c>space-platform-starter-pack</c> that creates the named <see cref="Location">surface</see>
+    /// when launched.
+    /// </summary>
+    internal string? launchCreatesSurface { get; set; }
 
     public override bool HasSpentFuel([NotNullWhen(true)] out Item? spent) {
         spent = fuelResult;
@@ -501,16 +518,40 @@ public class Fluid : Goods {
     }
 }
 
+/// <summary>
+/// The runtime type for space-location prototypes.
+/// </summary>
 public class Location : FactorioObject {
     public override string type => "Location";
 
     public Technology[] technologyUnlock { get; internal set; } = [];
-    internal List<string> entitySpawns { get; set; } = [];
+    internal List<string> entitySpawns { get; } = [];
     internal IReadOnlyList<string>? placementControls { get; set; }
 
     internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.Locations;
 
     public override DependencyNode GetDependencies() => (technologyUnlock, DependencyNode.Flags.TechnologyUnlock);
+}
+
+/// <summary>
+/// The runtime type for "surface" (space platform) and planet prototypes.
+/// </summary>
+public class Surface : Location {
+    /// <summary>
+    /// The names and values of this surface's properties, with defaults applied.
+    /// </summary>
+    internal Dictionary<string, float> properties { get; } = [];
+    public override DependencyNode GetDependencies() {
+        if (factorioType is "surface") {
+            // space platforms depend on the launch recipies, not a technology unlock.
+            var launches = Database.mechanics.all.Where(m => m.name.StartsWith(SpecialNames.RocketLaunch)
+                && m.ingredients is [{ goods: Item item }, _] && item.launchCreatesSurface == name);
+            return (launches, DependencyNode.Flags.Source);
+        }
+        return base.GetDependencies();
+    }
+
+    internal bool hasLightning { get; set; }
 }
 
 public class Special : Goods {
@@ -585,6 +626,11 @@ public class Entity : FactorioObject {
     public int width { get; internal set; }
     public int height { get; internal set; }
     public int size { get; internal set; }
+    /// <summary>
+    /// If not <see langword="null"/>, the list of surfaces where this entity can be built. If <see langword="null"/> and this entity can be
+    /// player-built, it can be built on all surfaces.
+    /// </summary>
+    public IReadOnlyList<Surface>? buildSurfaces { get; internal set; }
     internal override FactorioObjectSortOrder sortingOrder => FactorioObjectSortOrder.Entities;
     public override string type => "Entity";
     /// <summary>
@@ -661,12 +707,17 @@ public class Entity : FactorioObject {
             sources.Add(([], DependencyNode.Flags.ItemToPlace));
         }
 
+        List<DependencyNode> requirements = [DependencyNode.RequireAny(sources)];
+
+        if (!mapGenerated && buildSurfaces != null) {
+            requirements.Add((buildSurfaces, DependencyNode.Flags.Location));
+        }
+
         if (energy != null) {
-            return DependencyNode.RequireAll((energy.fuels, DependencyNode.Flags.Fuel), DependencyNode.RequireAny(sources));
+            requirements.Add((energy.fuels, DependencyNode.Flags.Fuel));
         }
-        else { // Doesn't require fuel
-            return DependencyNode.RequireAny(sources);
-        }
+
+        return DependencyNode.RequireAll(requirements);
     }
 
     private sealed class ListComparer : IEqualityComparer<List<EntitySpawner>> {

--- a/Yafc.Model/Data/Database.cs
+++ b/Yafc.Model/Data/Database.cs
@@ -26,6 +26,7 @@ public static class Database {
     public static IObjectWithQuality<Special> electricity { get; private set; } = null!;
     public static IObjectWithQuality<Recipe> electricityGeneration { get; private set; } = null!;
     public static Entity? character { get; private set; }
+    public static Special planetSurface { get; private set; } = null!;
     public static EntityCrafter[] allCrafters { get; private set; } = null!;
     public static Module[] allModules { get; private set; } = null!;
     public static EntityBeacon[] allBeacons { get; private set; } = null!;
@@ -146,6 +147,7 @@ public static class Database {
         if (objectsByTypeName.TryGetValue("Entity.character", out var ch)) {
             character = (Entity)ch;
         }
+        planetSurface = (Special)objectsByTypeName[$"Special.{SpecialNames.PlanetSurface}"];
 
         int firstSpecial = 0;
         int firstItem = skip(firstSpecial, FactorioObjectSortOrder.SpecialGoods);
@@ -359,4 +361,5 @@ public static class SpecialNames {
     public const string SpoilRecipe = "spoil";
     public const string PlantRecipe = "plant";
     public const string AsteroidCapture = "asteroid-capture";
+    public const string PlanetSurface = "planet-surface";
 }

--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -45,6 +45,15 @@ public sealed partial class ProductionTable : ProjectPageContents, IComparer<Pro
     public ModuleFillerParameters? modules { get; } // If you add a setter for this, ensure it calls RecipeRow.ModuleFillerParametersChanging().
     public bool containsDesiredProducts { get; private set; }
 
+    /// <summary>
+    /// Gets or sets the surface explicitly selected by this table, if any.
+    /// </summary>
+    public SelectedSurface selectedSurface { get; set; } = new();
+    /// <summary>
+    /// Gets the effective surface for this table, considering the ancestors' <see cref="selectedSurface"/>s if the current table doesn't have one.
+    /// </summary>
+    public SelectedSurface effectiveSurface => selectedSurface.planet == null && owner is RecipeRow row ? row.owner.effectiveSurface : selectedSurface;
+
     // For deserialization
     private ProductionTable(ModelObject owner) : base(owner) {
         if (owner is RecipeRow row) {

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -992,6 +992,12 @@ public class ProductionLink(ProductionTable group, IObjectWithQuality<Goods> goo
     }
 }
 
+[Serializable]
+public sealed record SelectedSurface {
+    public Location? planet { get; set; }
+    public Surface? platform { get; set; }
+}
+
 /// <summary>
 /// An ingredient for a recipe row, as reported to the UI.
 /// </summary>

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -996,6 +996,10 @@ public class ProductionLink(ProductionTable group, IObjectWithQuality<Goods> goo
 public sealed record SelectedSurface {
     public Location? planet { get; set; }
     public Surface? platform { get; set; }
+    /// <summary>
+    /// Gets the appropriate object for testing <see cref="Recipe.craftingSurfaces"/> and <see cref="Entity.buildSurfaces"/>.
+    /// </summary>
+    public Location? CraftingSurface => platform ?? planet;
 }
 
 /// <summary>

--- a/Yafc.Model/Model/RecipeParameters.cs
+++ b/Yafc.Model/Model/RecipeParameters.cs
@@ -15,20 +15,23 @@ public enum WarningFlags {
     UselessQuality = 1 << 5,
     ExcessProductivity = 1 << 6,
 
+    MaximumForMessage = RecipeNotAllowed - 1,
+    // Warnings
+    RecipeNotAllowed = 1 << 11,
+    EntityNotAllowed = 1 << 12,
+
+    MaximumForWarning = EntityNotSpecified - 1,
     // Static errors
-    EntityNotSpecified = 1 << 8,
-    FuelNotSpecified = 1 << 9,
-    FuelTemperatureExceedsMaximum = 1 << 10,
-    FuelDoesNotProvideEnergy = 1 << 11,
-    FuelWithTemperatureNotLinked = 1 << 12,
+    EntityNotSpecified = 1 << 17,
+    FuelNotSpecified = 1 << 18,
+    FuelTemperatureExceedsMaximum = 1 << 19,
+    FuelDoesNotProvideEnergy = 1 << 20,
+    FuelWithTemperatureNotLinked = 1 << 21,
 
     // Solution errors
-    DeadlockCandidate = 1 << 16,
-    OverproductionRequired = 1 << 17,
-    ExceedsBuiltCount = 1 << 18,
-
-    // Not implemented warnings
-    TemperatureForIngredientNotMatch = 1 << 24,
+    DeadlockCandidate = 1 << 26,
+    OverproductionRequired = 1 << 27,
+    ExceedsBuiltCount = 1 << 28,
 }
 
 public class UsedModule {
@@ -181,6 +184,24 @@ internal class RecipeParameters(float recipeTime, float fuelUsagePerSecondPerBui
             if (recipe.target is Recipe { maximumProductivity: float maxProd } && activeEffects.productivity > maxProd) {
                 warningFlags |= WarningFlags.ExcessProductivity;
                 activeEffects.productivity = maxProd;
+            }
+
+            if (row.linkRoot.effectiveSurface.CraftingSurface is { } surface) {
+                if (recipe.target is Recipe { craftingSurfaces: { } surfaces } && !surfaces.Contains(surface)) {
+                    warningFlags |= WarningFlags.RecipeNotAllowed;
+                }
+                else if (recipe.target is { sourceEntity.factorioType: "asteroid-chunk" }) {
+                    if (surface.factorioType is not "surface") {
+                        warningFlags |= WarningFlags.RecipeNotAllowed;
+                    }
+                }
+                else if (recipe.target is { sourceEntity.spawnLocations: { } spawns } && !spawns.Contains(surface)) {
+                    warningFlags |= WarningFlags.RecipeNotAllowed;
+                }
+
+                if (row.entity?.target.buildSurfaces is { } buildSurfaces && !buildSurfaces.Contains(surface)) {
+                    warningFlags |= WarningFlags.EntityNotAllowed;
+                }
             }
 
             recipeTime /= activeEffects.speedMod;

--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -228,8 +228,11 @@ internal partial class FactorioDataDeserializer {
         progress.Report((LSs.ProgressLoading, LSs.ProgressLoadingRecipes));
         DeserializePrototypes(raw, "recipe", DeserializeRecipe, progress, errorCollector);
         progress.Report((LSs.ProgressLoading, LSs.ProgressLoadingLocations));
-        DeserializePrototypes(raw, "planet", DeserializeLocation, progress, errorCollector);
+        DeserializePrototypes(raw, "surface-property", DeserializeProperty, progress, errorCollector);
+        // The default values for surface properties must be loaded before the surfaces.
+        DeserializePrototypes(raw, "planet", DeserializeSurface, progress, errorCollector);
         DeserializePrototypes(raw, "space-location", DeserializeLocation, progress, errorCollector);
+        DeserializePrototypes(raw, "surface", DeserializeSurface, progress, errorCollector);
         rootAccessible.Add(GetObject<Location>("nauvis"));
         progress.Report((LSs.ProgressLoading, LSs.ProgressLoadingQualities));
         DeserializePrototypes(raw, "quality", DeserializeQuality, progress, errorCollector);
@@ -611,6 +614,10 @@ internal partial class FactorioDataDeserializer {
             EnsureLaunchRecipe(item, launchProducts);
         }
 
+        if (item.factorioType == "space-platform-starter-pack") {
+            item.launchCreatesSurface = table.Get("surface", "space-platform");
+        }
+
         if (table.Get("weight", out int weight)) {
             item.weight = weight;
         }
@@ -881,20 +888,27 @@ nextWeightCalculation:;
         return null;
     }
 
+    private void DeserializeProperty(LuaTable table, ErrorCollector collector) {
+        if (!table.Get("name", out string? name) || string.IsNullOrEmpty(name)) {
+            collector.Error("Ignoring an unnamed surface_condition.", ErrorSeverity.MinorDataLoss);
+        }
+        else if (!table.Get("default_value", out float value)) {
+            collector.Error($"Ignoring an surface_condition {name} with no default value.", ErrorSeverity.MinorDataLoss);
+        }
+        else {
+            defaultSurfacePropertyValues[name] = value;
+        }
+    }
+
     private void DeserializeLocation(LuaTable table, ErrorCollector collector) {
-        Location location = DeserializeCommon<Location>(table, "space-location");
-        if (table.Get("map_gen_settings", out LuaTable? mapGen)) {
-            if (mapGen.Get("autoplace_controls", out LuaTable? controls)) {
-                location.placementControls = [.. controls.ObjectElements.Keys.OfType<string>()];
-            }
-            if (mapGen.Get<LuaTable>("autoplace_settings").Get<LuaTable>("entity").Get<LuaTable>("settings") is LuaTable entities) {
-                location.entitySpawns = [.. entities.ObjectElements.Keys.OfType<string>()];
-            }
-            if (mapGen.Get<LuaTable>("autoplace_settings").Get<LuaTable>("tile").Get<LuaTable>("settings") is LuaTable tiles) {
-                foreach (string tile in tiles.ObjectElements.Keys.Cast<string>()) {
-                    allObjects.OfType<Tile>().Single(t => t.name == tile).locations.Add(location);
-                }
-            }
+        Location location;
+        if (table["type"] is "surface") {
+            // space-platform's type is "surface" and its name is in surface-name.space-platform
+            location = DeserializeCommon<Location>(table, "surface");
+        }
+        else {
+            // Everything else (both planets and space-locations) are named in [space-location-name]
+            location = DeserializeCommon<Location>(table, "space-location");
         }
 
         if (table.Get("asteroid_spawn_definitions", out LuaTable? spawns)) {
@@ -903,6 +917,41 @@ nextWeightCalculation:;
                     location.entitySpawns.Add(asteroid);
                 }
             }
+        }
+    }
+
+    private void DeserializeSurface(LuaTable table, ErrorCollector collector) {
+        DeserializeLocation(table, collector);
+        Surface surface = GetObject<Surface>(table);
+        ReadLocationProperties(surface, table, collector);
+
+        if (table.Get("map_gen_settings", out LuaTable? mapGen)) {
+            if (mapGen.Get("autoplace_controls", out LuaTable? controls)) {
+                surface.placementControls = [.. controls.ObjectElements.Keys.OfType<string>()];
+            }
+            if (mapGen.Get<LuaTable>("autoplace_settings").Get<LuaTable>("entity").Get<LuaTable>("settings") is LuaTable entities) {
+                surface.entitySpawns.AddRange(entities.ObjectElements.Keys.OfType<string>());
+            }
+            if (mapGen.Get<LuaTable>("autoplace_settings").Get<LuaTable>("tile").Get<LuaTable>("settings") is LuaTable tiles) {
+                foreach (string tile in tiles.ObjectElements.Keys.Cast<string>()) {
+                    allObjects.OfType<Tile>().Single(t => t.name == tile).locations.Add(surface);
+                }
+            }
+        }
+
+        surface.hasLightning = table["lightning_properties"] is LuaTable;
+    }
+
+    private void ReadLocationProperties(Surface surface, LuaTable table, ErrorCollector collector) {
+        foreach ((string property, float value) in defaultSurfacePropertyValues) {
+            surface.properties[property] = value;
+        }
+        foreach ((object propertyName, object? value) in table.Get<LuaTable>("surface_properties")?.ObjectElements ?? []) {
+            if (propertyName is not string property || string.IsNullOrEmpty(property) || value is not double d) {
+                collector.Error($"{surface.name} sets an invalid property {propertyName}; ignored.", ErrorSeverity.MinorDataLoss);
+                continue;
+            }
+            surface.properties[property] = (float)d;
         }
     }
 

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
@@ -111,6 +111,11 @@ internal partial class FactorioDataDeserializer {
         Item totalItemOutput = createSpecialItem("item-total-output", LSs.SpecialItemTotalProduction, LSs.SpecialItemTotalProductionDescription, "__base__/graphics/icons/signal/signal_O.png");
         formerAliases["Special.total-item-input"] = totalItemInput;
         formerAliases["Special.total-item-output"] = totalItemOutput;
+
+        var surface = createSpecialObject(false, SpecialNames.PlanetSurface, "", "", "__core__/graphics/icons/technology/constants/constant-planet.png", "signal-P");
+        // Extract the interesting portion of constant-planet.png into the object icon
+        surface.iconSpec = [new("blank.png") { size = 64 }, surface.iconSpec![0] with { size = 128, x = 16, y = 8 }];
+        surface.showInExplorers = false;
     }
 
     /// <summary>

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Context.cs
@@ -31,6 +31,8 @@ internal partial class FactorioDataDeserializer {
     private int rocketCapacity;
     private int defaultItemWeight;
     private int constantCombinatorCapacity = 18;
+    private readonly Dictionary<string, float> defaultSurfacePropertyValues = [];
+    private readonly Dictionary<FactorioObject, List<(string property, float min, float max)>> surfaceRequirements = [];
 
     internal static readonly Version v0_18 = new Version(0, 18);
     internal static readonly Version v2_0 = new Version(2, 0);
@@ -165,6 +167,9 @@ internal partial class FactorioDataDeserializer {
         else if (typeof(TReturn).IsAssignableTo(typeof(Entity))) {
             key = (typeof(Entity), name);
         }
+        else if (typeof(TReturn).IsAssignableTo(typeof(Location))) {
+            key = (typeof(Location), name);
+        }
 
         if (registeredObjects.TryGetValue(key, out FactorioObject? existing)) {
             if (existing is TReturn result) {
@@ -232,6 +237,20 @@ internal partial class FactorioDataDeserializer {
                 "transport-belt" => typeof(EntityBelt),
                 "unit-spawner" => typeof(EntitySpawner),
                 _ => typeof(Entity)
+            };
+        }
+        else if (key.Type == typeof(Location)) {
+            if (!prototypes.TryGetValue(("space-location", name), out type) && !prototypes.TryGetValue(("surface", name), out type)) {
+                // To add another prototype that can be loaded as a location, add another check above.
+                // If necessary, also add an entry to the switch below, so each individual type is constructed as the correct C# type.
+                throw new ArgumentException($"data.raw does not contain an object named '{name}' that can be loaded as a(n) {typeof(TReturn).Name}", nameof(name));
+            }
+
+            tActual = type switch {
+                // The C# types to be used for the locations in data.raw[type]:
+                "surface" => typeof(Surface),
+                "planet" => typeof(Surface),
+                _ => typeof(Location)
             };
         }
         else {
@@ -489,13 +508,29 @@ internal partial class FactorioDataDeserializer {
         asteroids.Seal();
 
         // step 2 - fill maps
-
+        List<(string property, float min, float max)>? requirements; // The case order makes inline definition unpleasant.
         foreach (var o in allObjects) {
             switch (o) {
                 case RecipeOrTechnology recipeOrTechnology:
                     if (recipeOrTechnology is Recipe recipe) {
                         recipe.FallbackLocalization(recipe.mainProduct, LSs.LocalizationFallbackDescriptionRecipeToCreate);
                         recipe.technologyUnlock = recipeUnlockers.GetArray(recipe);
+
+                        if (recipe.sourceEntity is { } source) {
+                            if (source.factorioType is not "asteroid-chunk") {
+                                // Mining, but not asteroid collection
+                                // This requires lazy initialization. Entity spawn locations are loaded in later iterations of this loop.
+                                recipe.lazyCraftingSurfaces = new(() => source.spawnLocations);
+                            }
+                        }
+                        else if (recipe.sourceTiles.Count > 0) {
+                            // fluid pumping
+                            recipe.lazyCraftingSurfaces = new([.. recipe.sourceTiles.SelectMany(t => t.locations).Distinct()]);
+                        }
+                        else if (surfaceRequirements.TryGetValue(recipe, out requirements)) {
+                            // normal recipe, with limitations
+                            recipe.lazyCraftingSurfaces = new(getSurfacesWithProperties(requirements));
+                        }
                     }
 
                     recipeOrTechnology.crafters = actualRecipeCrafters.GetArray(recipeOrTechnology);
@@ -535,6 +570,16 @@ internal partial class FactorioDataDeserializer {
                     }
 
                     entity.sourceEntities = [.. asteroids.GetArray(entity.name)];
+
+                    List<Surface>? buildSurfaces = null;
+                    if (surfaceRequirements.TryGetValue(entity, out requirements)) {
+                        buildSurfaces = getSurfacesWithProperties(requirements);
+                    }
+                    if (entity.factorioType is "lightning-attractor") {
+                        buildSurfaces = [.. (buildSurfaces ?? allObjects.OfType<Surface>()).Where(p => p.hasLightning)];
+                    }
+                    entity.buildSurfaces = buildSurfaces;
+
                     break;
                 case Location location:
                     location.technologyUnlock = locationUnlockers.GetArray(location);
@@ -681,6 +726,26 @@ internal partial class FactorioDataDeserializer {
         static int countNonDsrRecipes(IEnumerable<Recipe> recipes)
             => recipes.Count(r => !r.name.Contains("StackedRecipe-") && !r.name.Contains("DSR_HighPressure-")
                 && r.specialType is not FactorioObjectSpecialType.Recycling and not FactorioObjectSpecialType.Voiding);
+
+        // Gets the surfaces that satisfy the supplied requirements, or null if all surfaces do.
+        List<Surface>? getSurfacesWithProperties(List<(string, float, float)> properties) {
+            List<Surface> allowedLocations = [];
+            bool allLocationsAllowed = true;
+
+            foreach (var location in allObjects.OfType<Surface>()) {
+                foreach (var (name, min, max) in properties) {
+                    if (!location.properties.TryGetValue(name, out float value) || value < min || value > max) {
+                        allLocationsAllowed = false;
+                        goto nextLocation;
+                    }
+                }
+                allowedLocations.Add(location);
+
+nextLocation:;
+            }
+
+            return allLocationsAllowed ? null : allowedLocations;
+        }
     }
 
     private Recipe CreateSpecialRecipe(FactorioObject production, string category, LocalizableString specialRecipeKey) {
@@ -748,6 +813,19 @@ internal partial class FactorioDataDeserializer {
                     if (!entities[spawner.capturedEntityName].captureAmmo.Contains(ammo)) {
                         entities[spawner.capturedEntityName].captureAmmo.Add(ammo);
                     }
+                }
+            }
+        }
+    }
+
+    private void ReadRequiredSurfaceProperties(LuaTable table, FactorioObject obj) {
+        if (table["surface_conditions"] is LuaTable surfaceConditions) {
+            var surfaceRequirements = this.surfaceRequirements[obj] = [];
+            foreach (LuaTable condition in surfaceConditions.ArrayElements<LuaTable>()) {
+                if (condition.Get("property", out string? property)) {
+                    float min = condition.Get("min", float.MinValue);
+                    float max = condition.Get("max", float.MaxValue);
+                    surfaceRequirements.Add((property, min, max));
                 }
             }
         }

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
@@ -677,6 +677,8 @@ internal partial class FactorioDataDeserializer {
                 }
             }
         }
+
+        ReadRequiredSurfaceProperties(table, entity);
     }
 
     private void DeserializeAsteroidChunk(LuaTable table, ErrorCollector errorCollector) {

--- a/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
@@ -67,6 +67,8 @@ internal partial class FactorioDataDeserializer {
             recipe.allowedModuleCategories = [.. categories.ArrayElements<string>()];
         }
 
+        ReadRequiredSurfaceProperties(table, recipe);
+
         void tryReadCategories(object? maybeTable, Recipe recipe) {
             if (maybeTable is LuaTable categories) {
                 foreach (var category in categories.ArrayElements<string>()) {

--- a/Yafc.UI/ImGui/ImGuiUtils.cs
+++ b/Yafc.UI/ImGui/ImGuiUtils.cs
@@ -176,6 +176,28 @@ public static class ImGuiUtils {
         return evt;
     }
 
+    public static ButtonEvent BuildRedButton(this ImGui gui, Icon icon, float size = 1.5f, bool invertedColors = false) {
+        Rect iconRect;
+
+        using (gui.EnterGroup(new Padding(0.3f))) {
+            iconRect = gui.AllocateRect(size, size, RectAlignment.Middle);
+        }
+
+        var evt = gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.Error);
+
+        if (gui.isBuilding) {
+            SchemeColor color = invertedColors ? SchemeColor.ErrorText : SchemeColor.Error;
+
+            if (gui.IsMouseOver(gui.lastRect)) {
+                color = invertedColors ? SchemeColor.Error : SchemeColor.ErrorText;
+            }
+
+            gui.DrawIcon(iconRect, icon, color);
+        }
+
+        return evt;
+    }
+
     /// <summary>
     /// Draw a button that displays an icon and inverts its colors when hovered.
     /// </summary>

--- a/Yafc.UI/ImGui/ImGuiUtils.cs
+++ b/Yafc.UI/ImGui/ImGuiUtils.cs
@@ -176,20 +176,29 @@ public static class ImGuiUtils {
         return evt;
     }
 
-    public static ButtonEvent BuildRedButton(this ImGui gui, Icon icon, float size = 1.5f, bool invertedColors = false) {
+    /// <summary>
+    /// Draw a button that displays an icon and inverts its colors when hovered.
+    /// </summary>
+    /// <param name="icon">The <see cref="Icon"/> to draw.</param>
+    /// <param name="iconColor">The color to use when drawing the icon.</param>
+    /// <param name="backColor">The color to use when drawing the background.</param>
+    /// <param name="size">The size of the icon. The button will be slightly larger.</param>
+    /// <remarks><paramref name="iconColor"/> and <paramref name="backColor"/> swap meanings when the mouse is hovering over this button.</remarks>
+    /// <returns>A <see cref="ButtonEvent"/> describing the user's interaction with the button.</returns>
+    public static ButtonEvent BuildIconButton(this ImGui gui, Icon icon, SchemeColor iconColor, SchemeColor backColor, float size = 1.5f) {
         Rect iconRect;
 
         using (gui.EnterGroup(new Padding(0.3f))) {
             iconRect = gui.AllocateRect(size, size, RectAlignment.Middle);
         }
 
-        var evt = gui.BuildButton(gui.lastRect, SchemeColor.None, SchemeColor.Error);
+        var evt = gui.BuildButton(gui.lastRect, backColor, iconColor);
 
         if (gui.isBuilding) {
-            SchemeColor color = invertedColors ? SchemeColor.ErrorText : SchemeColor.Error;
+            SchemeColor color = iconColor;
 
             if (gui.IsMouseOver(gui.lastRect)) {
-                color = invertedColors ? SchemeColor.Error : SchemeColor.ErrorText;
+                color = backColor;
             }
 
             gui.DrawIcon(iconRect, icon, color);

--- a/Yafc/Data/Postprocess1.1.lua
+++ b/Yafc/Data/Postprocess1.1.lua
@@ -1,4 +1,4 @@
--- This file is run after all mods are loaded, to translate some data from 1.1 to 2.0 formats.
+-- This file is run after all mods are loaded, to translate some data from 1.1 (or earlier) to 2.0 formats.
 -- Other data (e.g. recipe ingredients/products) is loaded version-agnostically.
 
 -- Create spawn location data
@@ -70,3 +70,7 @@ for _, module in pairs(data.raw.module) do
 		end
 	end
 end
+
+-- Yafc needs defines.prototypes["space-location"] to deserialize planets, including the synthetic nauvis added to 1.1 data.
+-- This could be added to Defines1.1.lua, but that file is supposed to be auto-generated.
+defines.prototypes["space-location"] = { planet = 0 }

--- a/Yafc/Data/locale/en/yafc.cfg
+++ b/Yafc/Data/locale/en/yafc.cfg
@@ -849,22 +849,26 @@ production-table-craft-anywhere=Anywhere
 production-table-craft-on-surface=On the surface of __1__
 production-table-craft-in-orbit=On __1__ at __2__
 
-warning-description-deadlock-candidate=Contains recursive links that cannot be matched. No solution exists.
-warning-description-overproduction-required=This model cannot be solved exactly, it requires some overproduction. You can allow overproduction for any link. This recipe contains one of the possible candidates.
-warning-description-entity-not-specified=Crafter not specified. Solution is inaccurate.
-warning-description-fuel-not-specified=Fuel not specified. Solution is inaccurate.
-warning-description-fluid-with-temperature=This recipe uses fuel with temperature. Should link with producing entity to determine temperature.
-warning-description-fluid-too-hot=Fluid temperature is higher than generator maximum. Some energy is wasted.
-warning-description-fuel-does-not-provide-energy=This fuel cannot provide any energy to this building. The building won't work.
-warning-description-has-max-fuel-consumption=This building has max fuel consumption. The rate at which it works is limited by it.
-warning-description-ingredient-temperature-range=This recipe cares about ingredient temperature, and the temperature range does not match.
-warning-description-assumes-reactor-formation=Assumes reactor formation from preferences. __YAFC__warning-description-click-for-preferences__
 warning-description-assumes-nauvis-solar=Energy production values assume Nauvis solar ratio (70% power output). Don't forget accumulators.
-warning-description-needs-more-buildings=This recipe requires more buildings than are currently built.
+warning-description-assumes-reactor-formation=Assumes reactor formation from preferences. __YAFC__warning-description-click-for-preferences__
+warning-description-has-max-fuel-consumption=This building has max fuel consumption. The rate at which it works is limited by it.
 warning-description-asteroid-collectors=The speed of asteroid collectors depends heavily on location and travel speed. It also depends on the distance between adjacent collectors. These dependencies are not modeled. Expect widely varied performance.
 warning-description-assumes-fulgoran-lightning=Energy production values assume Fulgoran storms and attractors in a square grid.\nThe accumulator estimate tries to store 10% of the energy captured by the attractors.
 warning-description-useless-quality=The quality bonus on this recipe has no effect. Make sure the recipe produces items and that all milestones for the next quality are unlocked. __YAFC__warning-description-click-for-milestones__
 warning-description-excess-productivity-bonus=This building has a larger productivity bonus (from base effect, research, and/or modules) than allowed by the recipe. Please make sure you entered productivity research levels, not percent bonuses. __YAFC__warning-description-click-for-preferences__
+warning-description-recipe-not-allowed=This recipe cannot be crafted at the selected location. Change the selected location or choose a different recipe.
+warning-description-entity-not-allowed=This crafter cannot be built at the selected location. Change the selected location or choose a different crafter.
+
+warning-description-entity-not-specified=Crafter not specified. Solution is inaccurate.
+warning-description-fuel-not-specified=Fuel not specified. Solution is inaccurate.
+warning-description-fluid-too-hot=Fluid temperature is higher than generator maximum. Some energy is wasted.
+warning-description-fuel-does-not-provide-energy=This fuel cannot provide any energy to this building. The building won't work.
+warning-description-fluid-with-temperature=This recipe uses fuel with temperature. Should link with producing entity to determine temperature.
+
+warning-description-deadlock-candidate=Contains recursive links that cannot be matched. No solution exists.
+warning-description-overproduction-required=This model cannot be solved exactly, it requires some overproduction. You can allow overproduction for any link. This recipe contains one of the possible candidates.
+warning-description-needs-more-buildings=This recipe requires more buildings than are currently built.
+
 warning-description-click-for-preferences=(Click to open the preferences)
 warning-description-click-for-milestones=(Click to open the milestones window)
 

--- a/Yafc/Data/locale/en/yafc.cfg
+++ b/Yafc/Data/locale/en/yafc.cfg
@@ -369,7 +369,7 @@ page-settings-name-hint=Input name
 select-icon=Select icon
 page-settings-icon-hint=And select icon
 page-settings-create-header=Create new page
-page-settings-edit-header=Edit page icon and name
+page-settings-edit-header=Edit page settings
 header-settings-create-header=Create new header
 header-settings-edit-header=Edit icon and name
 create=Create
@@ -843,6 +843,12 @@ production-table-alert-recipe-exists=Recipe already exists
 production-table-query-add-copy=Add a second copy of __1__?
 production-table-add-copy=Add a copy
 
+production-page-craft-header=Craft this page
+production-table-craft-header=Craft this table
+production-table-craft-anywhere=Anywhere
+production-table-craft-on-surface=On the surface of __1__
+production-table-craft-in-orbit=On __1__ at __2__
+
 warning-description-deadlock-candidate=Contains recursive links that cannot be matched. No solution exists.
 warning-description-overproduction-required=This model cannot be solved exactly, it requires some overproduction. You can allow overproduction for any link. This recipe contains one of the possible candidates.
 warning-description-entity-not-specified=Crafter not specified. Solution is inaccurate.
@@ -867,3 +873,12 @@ default-new-page-name=New page
 
 ; ExceptionScreen.cs
 exception-ignore-future-errors=Ignore future errors
+
+; SelectSurfacePanel.cs
+set-ingame-location=Set in-game location
+select-on-surface=On the surface of:
+select-in-orbit=__1__ in orbit around:
+cannot-land-here=Cannot land on __1__
+no-planet-selected=No planet selected
+clear-child-surface-selection=Reset to parent's setting
+clear-root-surface-selection=Allow all entities and recipes

--- a/Yafc/Widgets/ImmediateWidgets.cs
+++ b/Yafc/Widgets/ImmediateWidgets.cs
@@ -510,6 +510,38 @@ public static class ImmediateWidgets {
             return false;
         }
     }
+
+    /// <summary>
+    /// Draws a button that shows the current crafting location.
+    /// </summary>
+    /// <param name="effective">The current effective surface to display.</param>
+    /// <param name="buttonHeader"><see cref="LSs.ProductionPageCraftHeader"/> or <see cref="LSs.ProductionTableCraftHeader"/>, as appropriate to the
+    /// data being displayed.</param>
+    public static bool BuildSurfaceButton(this ImGui gui, SelectedSurface effective, LocalizableString0 buttonHeader) {
+        if (Database.locations.count == 1) {
+            return false; // Nothing to do; only one surface is available.
+        }
+
+        using (gui.EnterGroup(new(.5f))) {
+            gui.spacing = 0;
+            gui.BuildText(buttonHeader, TextBlockDisplayStyle.Centered);
+            if (effective.planet is null) {
+                gui.BuildText(LSs.ProductionTableCraftAnywhere, TextBlockDisplayStyle.Centered);
+            }
+            else {
+                string text;
+                if (effective.platform is null) {
+                    text = LSs.ProductionTableCraftOnSurface.L(effective.planet.locName);
+                }
+                else {
+                    text = LSs.ProductionTableCraftInOrbit.L(effective.platform.locName, effective.planet.locName);
+                }
+                gui.BuildText(text, TextBlockDisplayStyle.Centered, maxWidth: gui.width - 1);
+            }
+        }
+
+        return gui.BuildButton(gui.lastRect, SchemeColor.Primary, SchemeColor.Grey);
+    }
 }
 
 /// <summary>

--- a/Yafc/Widgets/ImmediateWidgets.cs
+++ b/Yafc/Widgets/ImmediateWidgets.cs
@@ -518,8 +518,8 @@ public static class ImmediateWidgets {
     /// <param name="buttonHeader"><see cref="LSs.ProductionPageCraftHeader"/> or <see cref="LSs.ProductionTableCraftHeader"/>, as appropriate to the
     /// data being displayed.</param>
     public static bool BuildSurfaceButton(this ImGui gui, SelectedSurface effective, LocalizableString0 buttonHeader) {
-        if (Database.locations.count == 1) {
-            return false; // Nothing to do; only one surface is available.
+        if (Database.locations.count < 3) {
+            return false; // Nothing to do; the only locations are nauvis and (for 2.0 and later) space-location-unknown.
         }
 
         using (gui.EnterGroup(new(.5f))) {

--- a/Yafc/Widgets/MainScreenTabBar.cs
+++ b/Yafc/Widgets/MainScreenTabBar.cs
@@ -102,7 +102,7 @@ public class MainScreenTabBar {
         if (changePage > 0) {
             if (changePage == 1) {
                 if (changePageTo == screen.activePage) {
-                    ProjectPageSettingsPanel.Show(changePageTo);
+                    ProjectPageSettingsPanel.ShowEdit(changePageTo!);
                 }
                 else {
                     screen.SetActivePage(changePageTo);
@@ -119,7 +119,7 @@ public class MainScreenTabBar {
         bool isActive = screen.activePage == page;
         if (gui.BuildContextMenuButton(LSs.EditPageProperties, icon: Icon.Edit)) {
             _ = gui.CloseDropdown();
-            ProjectPageSettingsPanel.Show(page);
+            ProjectPageSettingsPanel.ShowEdit(page);
         }
         if (!isSecondary && !isActive) {
             if (gui.BuildContextMenuButton(LSs.OpenSecondaryPage, LSs.ShortcutCtrlClick, Icon.Secondary)) {

--- a/Yafc/Widgets/PseudoScreen.cs
+++ b/Yafc/Widgets/PseudoScreen.cs
@@ -109,19 +109,15 @@ public abstract class PseudoScreen : IKeyboardFocus {
 /// <typeparam name="T">The type of result the panel can generate.</typeparam>
 public abstract class PseudoScreenWithResult<T>(float width = 40f) : PseudoScreen(width) {
     /// <summary>
-    /// If not <see langword="null"/>, called after the panel is closed. The parameters are <c>hasResult</c> and <c>result</c>: If a result is available, the first parameter will
-    /// be <see langword="true"/>, and the second parameter will have the result. The result may be <see langword="null"/>, depending on the kind of panel that was displayed.
+    /// If not <see langword="null"/>, called with the selected value after the panel is confirmed. Not called if the panel is cancelled.
+    /// If you need to react to cancel, use <see cref="PseudoScreen.cleanupCallback"/>, which is called unconditionally after this returns
+    /// (if applicable).
     /// </summary>
-    /// <remarks>Note that the <see cref="PseudoScreen.cleanupCallback"/> will be called after invoking this callback.</remarks>
-    protected Action<bool, T?>? completionCallback;
+    protected Action<T>? completionCallback;
 
-    protected void CloseWithResult(T? result) {
-        completionCallback?.Invoke(true, result);
-        base.Close();
-    }
-
-    protected override void Close() {
-        completionCallback?.Invoke(false, default);
+    protected void CloseWithResult(T result) {
+        completionCallback?.Invoke(result);
         base.Close();
     }
 }
+

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -132,7 +132,7 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
         var evt = gui.BuildButton(gui.lastRect, SchemeColor.PureBackground, SchemeColor.Grey, button: 0);
         if (evt) {
             if (gui.actionParameter == SDL.SDL_BUTTON_MIDDLE) {
-                ProjectPageSettingsPanel.Show(element);
+                ProjectPageSettingsPanel.ShowEdit(element);
                 dropDown?.Close();
             }
             else {
@@ -410,7 +410,7 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
         }
 
         if (gui.BuildContextMenuButton(LSs.MenuLegacySummary) && gui.CloseDropdown()) {
-            ProjectPageSettingsPanel.Show(null, (name, icon) => Instance.AddProjectPage(name, icon, typeof(ProductionSummary), true, true));
+            ProjectPageSettingsPanel.ShowCreate(false, (name, icon, _) => Instance.AddProjectPage(name, icon, typeof(ProductionSummary), true, true));
         }
 
         if (gui.BuildContextMenuButton(LSs.Neie, LSs.ShortcutCtrlX.L(ImGuiUtils.ScanToString(SDL.SDL_Scancode.SDL_SCANCODE_N))) && gui.CloseDropdown()) {

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -501,13 +501,13 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
         }
 
         saveConfirmationActive = true;
-        var (hasChoice, choice) = await MessageBox.Show(LSs.QuerySaveChanges, unsavedCount, LSs.Save, LSs.DontSave);
+        bool? choice = await MessageBox.Show(LSs.QuerySaveChanges, unsavedCount, LSs.Save, LSs.DontSave);
         saveConfirmationActive = false;
-        if (!hasChoice) {
+        if (choice == null) {
             return false;
         }
 
-        if (choice) {
+        if (choice.Value) {
             bool saved = await SaveProject();
             if (!saved) {
                 return false;
@@ -529,8 +529,8 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
             var release = JsonSerializer.Deserialize<GithubReleaseInfo>(result)!;
             string version = release.tag_name.StartsWith('v') ? release.tag_name[1..] : release.tag_name;
             if (new Version(version) > YafcLib.version) {
-                var (_, answer) = await MessageBox.Show(LSs.NewVersionAvailable, LSs.NewVersionNumber.L(release.tag_name), LSs.VisitReleasePage, LSs.Close);
-                if (answer) {
+                bool? answer = await MessageBox.Show(LSs.NewVersionAvailable, LSs.NewVersionNumber.L(release.tag_name), LSs.VisitReleasePage, LSs.Close);
+                if (answer.GetValueOrDefault()) {
                     Ui.VisitLink(release.html_url);
                 }
 
@@ -539,7 +539,7 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
             MessageBox.Show(LSs.NoNewerVersion, LSs.RunningLatestVersion, LSs.Ok);
         }
         catch (Exception) {
-            MessageBox.Show((hasAnswer, answer) => {
+            MessageBox.Show(answer => {
                 if (answer) {
                     Ui.VisitLink(AboutScreen.Github + "/releases");
                 }

--- a/Yafc/Windows/MessageBox.cs
+++ b/Yafc/Windows/MessageBox.cs
@@ -17,16 +17,25 @@ public class MessageBox : PseudoScreenWithResult<bool> {
         this.no = no;
     }
 
-    public static void Show(Action<bool, bool>? result, string title, string message, string yes, string? no) {
+    public static void Show(Action<bool>? result, string title, string message, string yes, string? no) {
         MessageBox instance = new MessageBox(title, message, yes, no) { completionCallback = result };
         MainScreen.Instance.ShowPseudoScreen(instance);
     }
 
     public static void Show(string title, string message, string yes) => Show(null, title, message, yes, null);
 
-    public static Task<(bool haveChoice, bool choice)> Show(string title, string message, string yes, string? no) {
-        TaskCompletionSource<(bool, bool)> tcs = new TaskCompletionSource<(bool, bool)>();
-        Show((a, b) => tcs.TrySetResult((a, b)), title, message, yes, no);
+    /// <summary>
+    /// Display a dialog with yes/no/cancel behavior. <see langword="await">ing the <see cref="Task"> yields <see langword="true"/> if the user
+    /// selected the '<paramref name="yes"/>' option, <see langword="false"/> if the user selected the '<paramref name="no"/>' option, or
+    /// <see langword="null"/> if the user pressed Escape or otherwise cancelled the dialog.
+    /// </summary>
+    public static Task<bool?> Show(string title, string message, string yes, string? no) {
+        TaskCompletionSource<bool?> tcs = new();
+        MessageBox instance = new MessageBox(title, message, yes, no) {
+            completionCallback = a => tcs.TrySetResult(a),
+            cleanupCallback = () => tcs.TrySetResult(null)
+        };
+        MainScreen.Instance.ShowPseudoScreen(instance);
         return tcs.Task;
     }
 

--- a/Yafc/Windows/ProjectPageSettingsPanel.cs
+++ b/Yafc/Windows/ProjectPageSettingsPanel.cs
@@ -251,11 +251,7 @@ public class ProjectPageSettingsPanel : PseudoScreen {
         if (page != null) {
             var existing = project.FindPage(page.guid);
             if (existing != null) {
-                MessageBox.Show((haveChoice, choice) => {
-                    if (!haveChoice) {
-                        return;
-                    }
-
+                MessageBox.Show(choice => {
                     if (choice) {
                         project.RemovePage(existing);
                     }

--- a/Yafc/Windows/ProjectPageSettingsPanel.cs
+++ b/Yafc/Windows/ProjectPageSettingsPanel.cs
@@ -10,24 +10,32 @@ using SDL2;
 using Yafc.I18n;
 using Yafc.Model;
 using Yafc.UI;
+using Yafc.Windows;
 
 namespace Yafc;
 
 public class ProjectPageSettingsPanel : PseudoScreen {
     private static readonly JsonSerializerOptions jsonSerializerOptions = new() { PropertyNamingPolicy = JsonNamingPolicy.CamelCase };
     private readonly ProjectPage? editingPage;
+    private readonly ProductionTable? editingTable;
     private string name;
+    private SelectedSurface selectedSurface;
+    private readonly bool includeSurface;
     private FactorioObject? icon;
-    private readonly Action<string, FactorioObject?>? callback;
+    private readonly Action<string, FactorioObject?, SelectedSurface>? callback;
 
-    private ProjectPageSettingsPanel(ProjectPage? editingPage, Action<string, FactorioObject?>? callback) {
+    private ProjectPageSettingsPanel(ProjectPage? editingPage, bool includeSurface, Action<string, FactorioObject?, SelectedSurface>? callback) {
         this.editingPage = editingPage;
         name = editingPage?.name ?? "";
         icon = editingPage?.icon;
+        editingTable = editingPage?.content as ProductionTable;
+        this.includeSurface = includeSurface;
+        selectedSurface = editingTable?.selectedSurface ?? new();
+
         this.callback = callback;
     }
 
-    private void Build(ImGui gui, Action<FactorioObject?> setIcon) {
+    private void Build(ImGui gui, Action<FactorioObject?> setIcon, Action<SelectedSurface> setSurface) {
         _ = gui.BuildTextInput(name, out name, LSs.PageSettingsNameHint, setKeyboardFocus: editingPage == null ? SetKeyboardFocus.OnFirstPanelDraw : SetKeyboardFocus.No);
         if (gui.BuildFactorioObjectButton(icon, new ButtonDisplayStyle(4f, MilestoneDisplay.None, SchemeColor.Grey) with { UseScaleSetting = false }) == Click.Left) {
             SelectSingleObjectPanel.Select(Database.objects.all, new(LSs.SelectIcon), setIcon);
@@ -36,18 +44,25 @@ public class ProjectPageSettingsPanel : PseudoScreen {
         if (icon == null && gui.isBuilding) {
             gui.DrawText(gui.lastRect, LSs.PageSettingsIconHint, RectAlignment.Middle);
         }
+
+        if (includeSurface && gui.BuildSurfaceButton(selectedSurface, LSs.ProductionPageCraftHeader)) {
+            SelectSurfaceScreen.Show(selectedSurface, LSs.ClearRootSurfaceSelection, setSurface);
+        }
     }
 
-    public static void Show(ProjectPage? page, Action<string, FactorioObject?>? callback = null)
-        => MainScreen.Instance.ShowPseudoScreen(new ProjectPageSettingsPanel(page, callback));
+    public static void ShowEdit(ProjectPage page)
+        => MainScreen.Instance.ShowPseudoScreen(new ProjectPageSettingsPanel(page, page.content is ProductionTable, null));
+
+    public static void ShowCreate(bool includeSurface, Action<string, FactorioObject?, SelectedSurface>? callback = null)
+        => MainScreen.Instance.ShowPseudoScreen(new ProjectPageSettingsPanel(null, includeSurface, callback));
 
     public override void Build(ImGui gui) {
-        gui.spacing = 3f;
+        gui.spacing = 2f;
         BuildHeader(gui, editingPage == null ? LSs.PageSettingsCreateHeader : LSs.PageSettingsEditHeader);
         Build(gui, s => {
             icon = s;
             Rebuild();
-        });
+        }, result => selectedSurface = result);
 
         using (gui.EnterRow(0.5f, RectAllocator.RightRow)) {
             if (editingPage == null && gui.BuildButton(LSs.Create, active: !string.IsNullOrEmpty(name))) {
@@ -86,12 +101,19 @@ public class ProjectPageSettingsPanel : PseudoScreen {
             return;
         }
         if (editingPage is null) {
-            callback?.Invoke(name, icon);
+            callback?.Invoke(name, icon, selectedSurface);
         }
-        else if (editingPage.name != name || editingPage.icon != icon) {
-            editingPage.RecordUndo(true).name = name!; // null-forgiving: The button is disabled if name is null or empty.
-            editingPage.icon = icon;
+        else {
+            if (editingPage.name != name || editingPage.icon != icon) {
+                editingPage.RecordUndo(true).name = name!; // null-forgiving: The button is disabled if name is null or empty.
+                editingPage.icon = icon;
+            }
+
+            if (editingTable != null && selectedSurface != editingTable.selectedSurface) {
+                editingTable.RecordUndo().selectedSurface = selectedSurface;
+            }
         }
+
         Close();
     }
 

--- a/Yafc/Windows/SelectObjectPanel.cs
+++ b/Yafc/Windows/SelectObjectPanel.cs
@@ -14,7 +14,7 @@ namespace Yafc;
 /// </summary>
 /// <typeparam name="TResult">The type of result the panel can generate.</typeparam>
 /// <typeparam name="TDisplay">The type of object (derived from <see cref="FactorioObject"/>) the panel will display.</typeparam>
-public abstract class SelectObjectPanel<TResult, TDisplay> : PseudoScreenWithResult<TResult> where TDisplay : FactorioObject {
+public abstract class SelectObjectPanel<TResult, TDisplay> : PseudoScreenWithResult<TResult?> where TDisplay : FactorioObject {
     private readonly SearchableList<TDisplay?> list;
     private string? header;
     private Rect searchBox;
@@ -74,22 +74,18 @@ public abstract class SelectObjectPanel<TResult, TDisplay> : PseudoScreenWithRes
         this.list.filter = default;
         this.list.data = data;
         Rebuild();
-        completionCallback = (hasResult, result) => {
-            if (hasResult) {
-                mapResult(result, obj => {
-                    if (obj is TDisplay u) {
-                        if (options.Ordering is DataUtils.FavoritesComparer<TDisplay> favoritesComparer) {
-                            favoritesComparer.AddToFavorite(u);
-                        }
+        completionCallback = result => mapResult(result, obj => {
+            if (obj is TDisplay u) {
+                if (options.Ordering is DataUtils.FavoritesComparer<TDisplay> favoritesComparer) {
+                    favoritesComparer.AddToFavorite(u);
+                }
 
-                        selectItem(u);
-                    }
-                    else if (allowNone) {
-                        selectItem(null);
-                    }
-                });
+                selectItem(u);
             }
-        };
+            else if (allowNone) {
+                selectItem(null);
+            }
+        });
     }
 
     private void ElementDrawer(ImGui gui, TDisplay? element, int index) {

--- a/Yafc/Windows/SelectObjectPanel.cs
+++ b/Yafc/Windows/SelectObjectPanel.cs
@@ -90,7 +90,7 @@ public abstract class SelectObjectPanel<TResult, TDisplay> : PseudoScreenWithRes
 
     private void ElementDrawer(ImGui gui, TDisplay? element, int index) {
         if (element == null) {
-            ButtonEvent evt = gui.BuildIconButton(Icon.Close, SchemeColor.Error, SchemeColor.ErrorText);
+            ButtonEvent evt = gui.BuildRedButton(Icon.Close);
             if (noneTooltip != null) {
                 _ = evt.WithTooltip(gui, noneTooltip);
             }

--- a/Yafc/Windows/SelectObjectPanel.cs
+++ b/Yafc/Windows/SelectObjectPanel.cs
@@ -90,7 +90,7 @@ public abstract class SelectObjectPanel<TResult, TDisplay> : PseudoScreenWithRes
 
     private void ElementDrawer(ImGui gui, TDisplay? element, int index) {
         if (element == null) {
-            ButtonEvent evt = gui.BuildRedButton(Icon.Close);
+            ButtonEvent evt = gui.BuildIconButton(Icon.Close, SchemeColor.Error, SchemeColor.ErrorText);
             if (noneTooltip != null) {
                 _ = evt.WithTooltip(gui, noneTooltip);
             }

--- a/Yafc/Windows/SelectSurfacePanel.cs
+++ b/Yafc/Windows/SelectSurfacePanel.cs
@@ -1,0 +1,121 @@
+﻿using System;
+using System.Linq;
+using Yafc.I18n;
+using Yafc.Model;
+using Yafc.UI;
+
+namespace Yafc.Windows;
+
+/// <summary>
+/// A pseudoscreen for selecting the surface assigned to a particular table.
+/// </summary>
+internal class SelectSurfaceScreen : PseudoScreenWithResult<SelectedSurface> {
+    private SelectSurfaceScreen(SelectedSurface selected, LocalizableString0 clearSelection) {
+        platformPanel = new(20, new System.Numerics.Vector2(40, 2.5f), BuildPlatformItem, collapsible: true) {
+            data = [null, .. Database.locations.all.OfType<Surface>().Where(s => s.factorioType is "surface")]
+        };
+        planetPanel = new(30, new System.Numerics.Vector2(40, 2.5f), BuildPlanetItem, collapsible: true) {
+            data = [.. Database.locations.all.Where(l => l.factorioType is not "surface" && l.name != "space-location-unknown")]
+        };
+        selectedSurface = selected with { }; // Clone
+        this.clearSelection = clearSelection;
+    }
+
+    private readonly VirtualScrollList<Surface?> platformPanel;
+    private readonly VirtualScrollList<Location> planetPanel;
+    // The text for the 'clear' button.
+    private readonly string clearSelection;
+    // The active selection, initialized to a copy of the value from the model.
+    private readonly SelectedSurface selectedSurface;
+
+    private bool CanSave => selectedSurface.planet != null && (selectedSurface.platform != null || selectedSurface.planet.factorioType is "planet");
+
+    /// <summary>
+    /// Show a panel that allows the user to select a location, for the purposes of crafting limitations and solar panel calculations.
+    /// </summary>
+    /// <param name="selected">The currently selected value, to initialize the UI</param>
+    /// <param name="clearSelection"><see cref="LSs.ClearRootSurfaceSelection"/> or <see cref="LSs.ClearChildSurfaceSelection"/>, as appropriate to
+    /// the data being edited.</param>
+    /// <param name="callback">A callback called with the selected value when the user confirms the dialog.</param>
+    public static void Show(SelectedSurface selected, LocalizableString0 clearSelection, Action<SelectedSurface> callback)
+        => MainScreen.Instance.ShowPseudoScreen(new SelectSurfaceScreen(selected, clearSelection) { completionCallback = callback });
+
+    public override void Build(ImGui gui) {
+        gui.BuildText(LSs.SetIngameLocation, TextBlockDisplayStyle.Centered with { Font = Font.header });
+        platformPanel.Build(gui);
+        var barRect = gui.AllocateRect(gui.width - 2, 0.5f, RectAlignment.Middle);
+        barRect = barRect.LeftPart(barRect.Width - 1);
+        gui.DrawRectangle(barRect, SchemeColor.PureForeground);
+        gui.AllocateSpacing();
+        planetPanel.Build(gui);
+
+        gui.allocator = RectAllocator.Center;
+        if (gui.BuildRedButton(clearSelection)) {
+            CloseWithResult(new());
+        }
+
+        if (CanSave) {
+            if (gui.BuildButton(LSs.Done)) {
+                CloseWithResult(selectedSurface);
+            }
+        }
+        else if (selectedSurface.planet is null) {
+            gui.BuildButton(LSs.NoPlanetSelected, active: false);
+        }
+        else {
+            gui.BuildButton(LSs.CannotLandHere.L(selectedSurface.planet.locName), active: false);
+        }
+    }
+
+    public void BuildPlatformItem(ImGui gui, Surface? surface, int _) {
+        if (BuildButton(gui, selectedSurface.platform, surface)) {
+            selectedSurface.platform = surface;
+        }
+    }
+
+    public void BuildPlanetItem(ImGui gui, Location planet, int _) {
+        if (BuildButton(gui, selectedSurface.planet, planet)) {
+            selectedSurface.planet = planet;
+        }
+    }
+
+    private bool BuildButton(ImGui gui, Location? selected, Location? toDraw) {
+        SchemeColor color = SchemeColor.None;
+        if (selectedSurface != null && selected == toDraw) {
+            color = SchemeColor.Primary;
+        }
+
+        using (gui.EnterRow()) {
+            gui.AllocateSpacing();
+            if (toDraw is null) {
+                gui.BuildIcon(Database.planetSurface.GetIcon(), 2);
+                gui.AllocateSpacing();
+                gui.allocator = RectAllocator.RemainingRow;
+                gui.BuildText(LSs.SelectOnSurface);
+            }
+            else {
+                gui.BuildFactorioObjectIcon(toDraw);
+                gui.AllocateSpacing();
+                gui.allocator = RectAllocator.RemainingRow;
+                if (toDraw.factorioType is "surface") {
+                    gui.BuildText(LSs.SelectInOrbit.L(toDraw.locName));
+                }
+                else {
+                    gui.BuildText(toDraw.locName);
+                }
+            }
+        }
+
+        if (gui.BuildButton(gui.lastRect, color, SchemeColor.Grey)) {
+            Rebuild();
+            return true;
+        }
+        return false;
+    }
+
+    protected override void ReturnPressed() {
+        if (CanSave) {
+            CloseWithResult(selectedSurface);
+        }
+    }
+}

--- a/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -8,37 +8,30 @@ using Yafc.UI;
 
 namespace Yafc;
 
-public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBuilder> {
+public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBuilder?> {
     private static readonly ModuleCustomizationScreen Instance = new ModuleCustomizationScreen();
 
     private RecipeRow? recipe;
     private ProjectModuleTemplate? template;
-    private ModuleTemplateBuilder? modules;
+    private ModuleTemplateBuilder? builder;
     private bool closeRequestedByEnter;
 
     public static void Show(RecipeRow recipe) {
         Instance.template = null;
         Instance.recipe = recipe;
-        Instance.modules = recipe.modules?.GetBuilder();
+        Instance.builder = recipe.modules?.GetBuilder();
         Instance.closeRequestedByEnter = false;
-        Instance.completionCallback = (hasResult, builder) => {
-            if (hasResult) {
-                recipe.RecordUndo().modules = builder?.Build(recipe);
-            }
-        };
+        Instance.completionCallback = builder => recipe.RecordUndo().modules = builder?.Build(recipe);
         MainScreen.Instance.ShowPseudoScreen(Instance);
     }
 
     public static void Show(ProjectModuleTemplate template) {
         Instance.recipe = null;
         Instance.template = template;
-        Instance.modules = template.template.GetBuilder();
+        Instance.builder = template.template.GetBuilder();
         Instance.closeRequestedByEnter = false;
-        Instance.completionCallback = (hasResult, builder) => {
-            if (hasResult) {
-                template.RecordUndo().template = builder!.Build(template);
-            }
-        };
+        // null-forgiving: builder cannot become null, and CloseWithResult(null) is not called with a null recipe.
+        Instance.completionCallback = builder => template.RecordUndo().template = builder!.Build(template);
         MainScreen.Instance.ShowPseudoScreen(Instance);
     }
 
@@ -115,9 +108,9 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
             }
         }
 
-        if (modules == null) {
+        if (builder == null) {
             if (gui.BuildButton(LSs.ModuleCustomizationEnable)) {
-                modules = new ModuleTemplateBuilder();
+                builder = new ModuleTemplateBuilder();
             }
         }
         else {
@@ -133,7 +126,7 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
 
             gui.BuildText(LSs.ModuleCustomizationBeaconModules, Font.subheader);
 
-            if (modules.beacon == null) {
+            if (builder.beacon == null) {
                 gui.BuildText(LSs.ModuleCustomizationUsingDefaultBeacons);
                 if (gui.BuildButton(LSs.ModuleCustomizationOverrideBeacons)) {
                     SelectBeacon(gui);
@@ -146,13 +139,13 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
                 }
             }
             else {
-                if (gui.BuildFactorioObjectButtonWithText(modules.beacon) == Click.Left) {
+                if (gui.BuildFactorioObjectButtonWithText(builder.beacon) == Click.Left) {
                     SelectBeacon(gui);
                 }
 
-                string modulesNotBeacons = LSs.ModuleCustomizationUseNumberOfModulesInBeacons.L(modules.beacon.target.moduleSlots);
+                string modulesNotBeacons = LSs.ModuleCustomizationUseNumberOfModulesInBeacons.L(builder.beacon.target.moduleSlots);
                 gui.BuildText(modulesNotBeacons, TextBlockDisplayStyle.WrappedText);
-                DrawRecipeModules(gui, modules.beacon, ref effects);
+                DrawRecipeModules(gui, builder.beacon, ref effects);
             }
 
             if (recipe?.entity?.target.effectReceiver.baseEffect is { } baseEffect) {
@@ -202,7 +195,7 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
 
         if (closeRequestedByEnter) {
             closeRequestedByEnter = false;
-            CloseWithResult(modules);
+            CloseWithResult(builder);
             return;
         }
 
@@ -218,12 +211,12 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
             }
             if (gui.BuildButton(LSs.Done)) {
                 closeRequestedByEnter = false;
-                CloseWithResult(modules);
+                CloseWithResult(builder);
                 return;
             }
 
             gui.allocator = RectAllocator.LeftRow;
-            if (modules != null && recipe != null && gui.BuildRedButton(LSs.ModuleCustomizationRemove)) {
+            if (builder != null && recipe != null && gui.BuildRedButton(LSs.ModuleCustomizationRemove)) {
                 closeRequestedByEnter = false;
                 CloseWithResult(null);
                 return;
@@ -232,22 +225,22 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
     }
 
     private void SelectBeacon(ImGui gui) {
-        if (modules!.beacon is null) { // null-forgiving: Both calls are from places where we know modules is not null
+        if (builder!.beacon is null) { // null-forgiving: Both calls are from places where we know modules is not null
             gui.BuildObjectQualitySelectDropDown(Database.allBeacons, sel => {
-                modules.beacon = sel;
+                builder.beacon = sel;
                 contents.Rebuild();
             }, new(LSs.SelectBeacon, Quality.Normal));
         }
         else {
-            QualitySelectOptions<EntityBeacon> options = new(LSs.SelectBeacon, modules.beacon.quality);
+            QualitySelectOptions<EntityBeacon> options = new(LSs.SelectBeacon, builder.beacon.quality);
             options.SelectedQualitiesChanged += gui => {
                 gui.CloseDropdown();
-                modules.beacon = modules.beacon.With(options.SelectedQuality!);
+                builder.beacon = builder.beacon.With(options.SelectedQuality!);
                 contents.Rebuild();
             };
 
             gui.BuildObjectQualitySelectDropDownWithNone(Database.allBeacons, sel => {
-                modules.beacon = sel;
+                builder.beacon = sel;
                 contents.Rebuild();
             }, options);
         }
@@ -268,7 +261,7 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
     private void DrawRecipeModules(ImGui gui, IObjectWithQuality<EntityBeacon>? beacon, ref ModuleEffects effects) {
         int remainingModules = recipe?.entity?.target.moduleSlots ?? 0;
         using var grid = gui.EnterInlineGrid(3f, 1f);
-        var list = beacon != null ? modules!.beaconList : modules!.list;// null-forgiving: Both calls are from places where we know modules is not null
+        var list = beacon != null ? builder!.beaconList : builder!.list;// null-forgiving: Both calls are from places where we know modules is not null
         for (int i = 0; i < list.Count; i++) {
             grid.Next();
             (IObjectWithQuality<Module> module, int fixedCount) = list[i];
@@ -308,7 +301,7 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
                 }
             }
             else {
-                int beaconCount = IntegerMath.CeilingDivide(modules.beaconList.Sum(x => x.fixedCount), beacon.target.moduleSlots);
+                int beaconCount = IntegerMath.CeilingDivide(builder.beaconList.Sum(x => x.fixedCount), beacon.target.moduleSlots);
                 effects.AddModules(module, fixedCount * beacon.GetBeaconEfficiency() * beacon.target.GetProfile(beaconCount));
             }
         }

--- a/Yafc/Workspace/ProductionTable/ProductionTableFlatHierarchy.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableFlatHierarchy.cs
@@ -141,10 +141,17 @@ public class FlatHierarchy<TRow, TGroup>(DataGrid<TRow> grid, Action<ImGui, TGro
                 nextRowTextColor = SchemeColor.BackgroundText;
             }
 
-            bool isError = recipe is RecipeRow r && r.warningFlags >= WarningFlags.EntityNotSpecified;
+            bool isWarning = recipe is RecipeRow { warningFlags: > WarningFlags.MaximumForMessage };
+            bool isError = recipe is RecipeRow { warningFlags: > WarningFlags.MaximumForWarning };
             if (isError) {
                 nextRowBackgroundColor = SchemeColor.Error;
                 nextRowTextColor = SchemeColor.PureForeground;
+                nextRowIsHighlighted = true;
+            }
+            else if (isWarning) {
+                nextRowBackgroundColor = SchemeColor.WarningAlt;
+                nextRowTextColor = SchemeColor.WarningText;
+                nextRowIsHighlighted = true;
             }
 
             if (recipe != null) {
@@ -175,7 +182,7 @@ public class FlatHierarchy<TRow, TGroup>(DataGrid<TRow> grid, Action<ImGui, TGro
                         MoveFlatHierarchy(gui.GetDraggingObject<TRow>()!, recipe);
                     }
 
-                    if (nextRowIsHighlighted || isError) {
+                    if (nextRowIsHighlighted) {
                         rect.X += depWidth;
                         rect.Width -= depWidth;
                         gui.DrawRectangle(rect, nextRowBackgroundColor);

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -8,6 +8,7 @@ using Yafc.Core;
 using Yafc.I18n;
 using Yafc.Model;
 using Yafc.UI;
+using Yafc.Windows;
 
 namespace Yafc;
 
@@ -135,6 +136,13 @@ public class ProductionTableView : ProjectPageView<ProductionTable> {
                     gui.ShowDropDown(delegate (ImGui imgui) {
                         DrawRecipeTagSelect(imgui, recipe);
 
+                        if (recipe.subgroup != null && imgui.BuildSurfaceButton(recipe.subgroup.effectiveSurface, LSs.ProductionTableCraftHeader)
+                            && imgui.CloseDropdown()) {
+
+                            SelectSurfaceScreen.Show(recipe.subgroup.effectiveSurface, LSs.ClearChildSurfaceSelection,
+                                result => recipe.subgroup.RecordUndo().selectedSurface = result);
+                        }
+
                         if (recipe.recipe == null && imgui.BuildButton(LSs.EditPageProperties) && imgui.CloseDropdown()) {
                             HeaderRowSettingsPanel.Show(recipe);
                         }
@@ -180,7 +188,7 @@ public class ProductionTableView : ProjectPageView<ProductionTable> {
                             view._focusManager.CancelFocus(recipe);
                             _ = recipe.owner.RecordUndo().recipes.Remove(recipe);
                         }
-                    });
+                    }, 25);
                     break;
                 case Click.Right when recipe.subgroup?.expanded ?? false: // With expanded subgroup
                     unpackNestedTable();
@@ -228,8 +236,9 @@ public class ProductionTableView : ProjectPageView<ProductionTable> {
         }
 
         public override void BuildMenu(ImGui gui) {
-            BuildRecipeButtons(gui, view.model);
+            var model = view.model;
 
+            BuildRecipeButtons(gui, model);
             gui.BuildText(LSs.ProductionTableExportToBlueprint, TextBlockDisplayStyle.WrappedText);
             using (gui.EnterRow()) {
                 gui.BuildText(LSs.ExportBlueprintAmountPer);
@@ -248,12 +257,12 @@ public class ProductionTableView : ProjectPageView<ProductionTable> {
             }
 
             if (gui.BuildButton(LSs.ProductionTableRemoveZeroBuildingRecipes) && gui.CloseDropdown()) {
-                RemoveZeroRecipes(view.model);
+                RemoveZeroRecipes(model);
             }
 
             if (gui.BuildRedButton(LSs.ProductionTableClearRecipes) && gui.CloseDropdown()) {
                 view._focusManager.Clear();
-                view.model.RecordUndo().recipes.Clear();
+                model.RecordUndo().recipes.Clear();
             }
 
             if (InputSystem.Instance.control && gui.BuildButton(LSs.ProductionTableAddAllRecipes) && gui.CloseDropdown()) {
@@ -272,10 +281,10 @@ public class ProductionTableView : ProjectPageView<ProductionTable> {
 
                     foreach (var quality in Database.qualities.all) {
                         foreach (var product in recipe.products) {
-                            view.RebuildIf(view.model.CreateLink(product.goods.With(quality)));
+                            view.RebuildIf(model.CreateLink(product.goods.With(quality)));
                         }
 
-                        view.model.AddRecipe(recipe.With(quality), DefaultVariantOrdering);
+                        model.AddRecipe(recipe.With(quality), DefaultVariantOrdering);
                     }
 goodsHaveNoProduction:;
                 }
@@ -887,7 +896,10 @@ goodsHaveNoProduction:;
 
     public override float CalculateWidth() => flatHierarchyBuilder.width;
 
-    public static void CreateProductionSheet() => ProjectPageSettingsPanel.Show(null, (name, icon) => MainScreen.Instance.AddProjectPage(name, icon, typeof(ProductionTable), true, true));
+    public static void CreateProductionSheet() => ProjectPageSettingsPanel.ShowCreate(true, (name, icon, surface) => {
+        var page = MainScreen.Instance.AddProjectPage(name, icon, typeof(ProductionTable), true, true);
+        ((ProductionTable)(page.content)).selectedSurface = surface;
+    });
 
     private static readonly IComparer<Goods> DefaultVariantOrdering =
         new DataUtils.FactorioObjectComparer<Goods>((x, y) => (y.ApproximateFlow() / MathF.Abs(y.Cost())).CompareTo(x.ApproximateFlow() / MathF.Abs(x.Cost())));

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -956,7 +956,9 @@ goodsHaveNoProduction:;
             IObjectWithQuality<RecipeOrTechnology> qualityRecipe = rec.With(goods.quality);
             RebuildIf(context.CreateLink(goods));
 
-            if (!context.Contains(qualityRecipe) || (await MessageBox.Show(LSs.ProductionTableAlertRecipeExists, LSs.ProductionTableQueryAddCopy.L(rec.locName), LSs.ProductionTableAddCopy, LSs.Cancel)).choice) {
+            if (!context.Contains(qualityRecipe) || (await MessageBox.Show(LSs.ProductionTableAlertRecipeExists,
+                LSs.ProductionTableQueryAddCopy.L(rec.locName), LSs.ProductionTableAddCopy, LSs.Cancel)).GetValueOrDefault()) {
+
                 context.AddRecipe(qualityRecipe, DefaultVariantOrdering, selectedFuel, spentFuel);
             }
         }

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -56,11 +56,15 @@ public class ProductionTableView : ProjectPageView<ProductionTable> {
             }
 
             if (row.warningFlags != 0) {
-                bool isError = row.warningFlags >= WarningFlags.EntityNotSpecified;
+                bool isWarning = row.warningFlags > WarningFlags.MaximumForMessage;
+                bool isError = row.warningFlags > WarningFlags.MaximumForWarning;
                 ButtonEvent evt;
 
                 if (isError) {
-                    evt = gui.BuildRedButton(Icon.Error, invertedColors: true);
+                    evt = gui.BuildIconButton(Icon.Error, SchemeColor.Background, SchemeColor.Error);
+                }
+                else if (isWarning) {
+                    evt = gui.BuildIconButton(Icon.Warning, SchemeColor.Background, SchemeColor.WarningAlt);
                 }
                 else {
                     using (gui.EnterGroup(ImGuiUtils.DefaultIconPadding)) {
@@ -75,6 +79,10 @@ public class ProductionTableView : ProjectPageView<ProductionTable> {
                         if (isError) {
                             g.boxColor = SchemeColor.Error;
                             g.textColor = SchemeColor.ErrorText;
+                        }
+                        else if (isWarning) {
+                            g.boxColor = SchemeColor.WarningAlt;
+                            g.textColor = SchemeColor.WarningText;
                         }
                         foreach (var (flag, key) in WarningsMeaning) {
                             if ((row.warningFlags & flag) != 0) {
@@ -1602,22 +1610,25 @@ goodsHaveNoProduction:;
 
     private static readonly Dictionary<WarningFlags, LocalizableString0> WarningsMeaning = new()
     {
-        {WarningFlags.DeadlockCandidate, LSs.WarningDescriptionDeadlockCandidate},
-        {WarningFlags.OverproductionRequired, LSs.WarningDescriptionOverproductionRequired},
-        {WarningFlags.EntityNotSpecified, LSs.WarningDescriptionEntityNotSpecified},
-        {WarningFlags.FuelNotSpecified, LSs.WarningDescriptionFuelNotSpecified},
-        {WarningFlags.FuelWithTemperatureNotLinked, LSs.WarningDescriptionFluidWithTemperature},
-        {WarningFlags.FuelTemperatureExceedsMaximum, LSs.WarningDescriptionFluidTooHot},
-        {WarningFlags.FuelDoesNotProvideEnergy, LSs.WarningDescriptionFuelDoesNotProvideEnergy},
-        {WarningFlags.FuelUsageInputLimited, LSs.WarningDescriptionHasMaxFuelConsumption},
-        {WarningFlags.TemperatureForIngredientNotMatch, LSs.WarningDescriptionIngredientTemperatureRange},
-        {WarningFlags.ReactorsNeighborsFromPrefs, LSs.WarningDescriptionAssumesReactorFormation},
         {WarningFlags.AssumesNauvisSolarRatio, LSs.WarningDescriptionAssumesNauvisSolar},
-        {WarningFlags.ExceedsBuiltCount, LSs.WarningDescriptionNeedsMoreBuildings},
+        {WarningFlags.ReactorsNeighborsFromPrefs, LSs.WarningDescriptionAssumesReactorFormation},
+        {WarningFlags.FuelUsageInputLimited, LSs.WarningDescriptionHasMaxFuelConsumption},
         {WarningFlags.AsteroidCollectionNotModelled, LSs.WarningDescriptionAsteroidCollectors},
         {WarningFlags.AssumesFulgoraAndModel, LSs.WarningDescriptionAssumesFulgoranLightning},
         {WarningFlags.UselessQuality, LSs.WarningDescriptionUselessQuality},
         {WarningFlags.ExcessProductivity, LSs.WarningDescriptionExcessProductivityBonus},
+        {WarningFlags.RecipeNotAllowed, LSs.WarningDescriptionRecipeNotAllowed},
+        {WarningFlags.EntityNotAllowed, LSs.WarningDescriptionEntityNotAllowed},
+
+        {WarningFlags.EntityNotSpecified, LSs.WarningDescriptionEntityNotSpecified},
+        {WarningFlags.FuelNotSpecified, LSs.WarningDescriptionFuelNotSpecified},
+        {WarningFlags.FuelTemperatureExceedsMaximum, LSs.WarningDescriptionFluidTooHot},
+        {WarningFlags.FuelDoesNotProvideEnergy, LSs.WarningDescriptionFuelDoesNotProvideEnergy},
+        {WarningFlags.FuelWithTemperatureNotLinked, LSs.WarningDescriptionFluidWithTemperature},
+
+        {WarningFlags.DeadlockCandidate, LSs.WarningDescriptionDeadlockCandidate},
+        {WarningFlags.OverproductionRequired, LSs.WarningDescriptionOverproductionRequired},
+        {WarningFlags.ExceedsBuiltCount, LSs.WarningDescriptionNeedsMoreBuildings},
     };
 
     private static readonly (Icon icon, SchemeColor color)[] tagIcons = [

--- a/changelog.txt
+++ b/changelog.txt
@@ -22,6 +22,7 @@
 Version:
 Date:
     Features:
+        - Allow planet selection for production tables.
     Fixes:
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.20.0

--- a/changelog.txt
+++ b/changelog.txt
@@ -22,7 +22,7 @@
 Version:
 Date:
     Features:
-        - Allow planet selection for production tables.
+        - Allow planet selection for production tables, and complain if the selected recipe or entity can't be used there.
     Fixes:
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.20.0


### PR DESCRIPTION
This is a collection of three closely-related features: In order from oldest commit to newest:
## Load and display location dependencies
Recipes and entities that cannot be used in all locations display their allowed locations in the dependency explorer.
<img width="726" height="375" alt="image" src="https://github.com/user-attachments/assets/dec3166f-c106-4ab8-9514-d7ff8a3c5b32" />
In addition to checking the [surface](https://lua-api.factorio.com/latest/prototypes/PlanetPrototype.html#surface_properties) [properties](https://lua-api.factorio.com/latest/prototypes/EntityPrototype.html#surface_conditions):
1. Mining mechanics now depend on the surfaces where their entity appears, matching pumping mechanics and their tiles. (e.g. coal mining is only on Nauvis and Vulcanus)
Asteroid collection does not depend on a location: (a) the asteroid collectors have adequate surface restrictions, and (b) finding the appropriate restriction for Promethium collection is not straightforward.
1. Lightning collectors check their surface properties, plus whether the planet has lightning. (The Fulgoran collectors do not have surface conditions.)
1. There is a new space platform location that asteroid collectors, crushers, etc. require. This location depends on the corresponding starter-pack launch mechanic.
Mods that have multiple space platforms and/or multiple starter packs should be handled correctly, but I'm not aware of any.

## Select a location for each table
Pages and nested tables can be assigned to a location, with one of two new buttons:
<img width="998" height="394" alt="image" src="https://github.com/user-attachments/assets/55c7258d-7125-4be7-90f3-47a0f355d183" />

This opens a new window that allows selection or revert-to-parent.
<img width="418" height="453" alt="image" src="https://github.com/user-attachments/assets/8b2845aa-2f9a-44a9-9123-a19c15a00074" />
1. I'm not sure that icon does a good job of expressing "landed on". For now, it's only used in this one dialog.
1. This concept of location here is not the same as the dependency locations. All location dependencies are satisfied with just one object, but tables treat "Space platform at Nauvis" and "Space platform at Solar system edge" differently, for solar panel/accumulator purposes. (In a later PR)
1. I originally had the button for pages in the recipe header dropdown. (With the other "Add raw recipe" button.) That gives better UI consistency, but I think this is more discoverable?
1. Even in English, "On Space platform around Solar system edge" did not fit in the original dropdown. I made it some wider, but it may need to be more wider.
  a. I also clamped the text width. Longer texts in other languages will be squished horizontally instead of spilling.

## Check that location/recipe/entity match
After a location selection has been made for the (nested) table, notices will appear. In this case, the selection is "On the surface of Gleba":
<img width="542" height="434" alt="image" src="https://github.com/user-attachments/assets/d0cac9a7-8fe2-4730-bd12-32f10ae5034b" />
* Solid fuel from Ammonia is perfectly happy here, since the recipe doesn't have any restrictions. It's hard to reliably determine that Ammonia can only be produced on Aquilo and cannot be shipped elsewhere.