### PR TITLE
Fix invisible text on welcome screen

### DIFF
--- a/Yafc.UI/Core/WindowUtility.cs
+++ b/Yafc.UI/Core/WindowUtility.cs
@@ -80,6 +80,9 @@ internal class UtilityWindowDrawingSurface : SoftwareDrawingSurface {
     }
 
     private void InvalidateRenderer() {
+        if (renderer != IntPtr.Zero) {
+            SDL.SDL_DestroyRenderer(renderer);
+        }
         surface = SDL.SDL_GetWindowSurface(window.window);
         renderer = SDL.SDL_CreateSoftwareRenderer(surface);
         _ = SDL.SDL_SetRenderDrawBlendMode(renderer, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);

--- a/Yafc.UI/ImGui/ImGuiBuilding.cs
+++ b/Yafc.UI/ImGui/ImGuiBuilding.cs
@@ -92,7 +92,7 @@ public partial class ImGui {
         }
     }
 
-    public readonly ImGuiCache<TextCache, (FontFile.FontSize size, string text, uint wrapWidth)>.Cache textCache = new ImGuiCache<TextCache, (FontFile.FontSize size, string text, uint wrapWidth)>.Cache();
+    public readonly TextCache.Cache textCache = new TextCache.Cache();
 
     public FontFile.FontSize GetFontSize(Font? font = null) => (font ?? Font.text).GetFontSize(pixelsPerUnit);
 

--- a/Yafc.UI/ImGui/ImGuiCache.cs
+++ b/Yafc.UI/ImGui/ImGuiCache.cs
@@ -72,7 +72,7 @@ public sealed class TextCache : ImGuiCache<TextCache, (FontFile.FontSize size, s
     }
 
     public void Render(DrawingSurface surface, SDL.SDL_Rect position, SDL.SDL_Color color) {
-        if (texture.surface != surface) {
+        if (!texture.valid || texture.surface != surface) {
             texture = texture.Destroy();
             texture = surface.CreateTextureFromSurface(this.surface);
             curColor = RenderingUtils.White;

--- a/Yafc.UI/ImGui/ImGuiCache.cs
+++ b/Yafc.UI/ImGui/ImGuiCache.cs
@@ -5,13 +5,59 @@ using SDL2;
 
 namespace Yafc.UI;
 
+/// <summary>
+/// A base class for resources that are cached between render cycles.
+/// </summary>
+/// <typeparam name="T">The concrete derived type of the cached resource.</typeparam>
+/// <typeparam name="TKey">The type from which to derive and uniquely identify the resource.</typeparam>
+/// <example>
+/// <code>
+/// public sealed class CacheableItem : ImGuiCache<CacheableItem, string> {
+///     public string DerivedData { get; }
+///
+///     private CacheableItem(string key) {
+///         // Perform expensive operations here to derive the resource from the key.
+///         DerivedData = $"Processed_{key}";
+///     }
+///
+///     protected override CacheableItem CreateForKey(string key) => new CacheableItem(key);
+///
+///     public override void Dispose() {
+///         // Cleanup resources when the item is purged.
+///     }
+/// }
+///
+/// // Usage during a render frame:
+/// var item = itemCache.GetCached("my_key");
+/// // item.DerivedData will be "Processed_my_key"
+///
+/// // At the end of the render frame:
+/// itemCache.PurgeUnused(); // Disposes items that were not retrieved this frame
+/// </code>
+/// </example>
 public abstract class ImGuiCache<T, TKey> : IDisposable where T : ImGuiCache<T, TKey> where TKey : IEquatable<TKey> {
     private static readonly T Constructor = (T)RuntimeHelpers.GetUninitializedObject(typeof(T));
 
+    /// <summary>
+    /// Represents a pool of cached items for a cacheable resource type.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// Call <see cref="GetCached"/> to return an existing item from the cache, or cache and return a new one
+    /// constructed from the provided key.
+    /// </para>
+    /// <para>
+    /// At the end of a cache cycle, call <see cref="PurgeUnused"/> to dispose of any items from the preceding cycle
+    /// that were not used on the current cycle.
+    /// </para>
+    /// </remarks>
     public sealed class Cache : IDisposable {
         private readonly Dictionary<TKey, T> activeCached = [];
         private readonly HashSet<TKey> unused = [];
 
+        /// <summary>
+        /// Retrieves an existing item from the cache, or constructs a new one from the provided key and caches it.
+        /// </summary>
         public T GetCached(TKey key) {
             if (activeCached.TryGetValue(key, out var value)) {
                 _ = unused.Remove(key);
@@ -21,6 +67,9 @@ public abstract class ImGuiCache<T, TKey> : IDisposable where T : ImGuiCache<T, 
             return activeCached[key] = Constructor.CreateForKey(key);
         }
 
+        /// <summary>
+        /// Disposes of any cached items that were not accessed via <see cref="GetCached"/> during the current cycle.
+        /// </summary>
         public void PurgeUnused() {
             foreach (var key in unused) {
                 if (activeCached.Remove(key, out var value)) {
@@ -31,6 +80,9 @@ public abstract class ImGuiCache<T, TKey> : IDisposable where T : ImGuiCache<T, 
             unused.UnionWith(activeCached.Keys);
         }
 
+        /// <summary>
+        /// Disposes of all items in the cache and clears the pool.
+        /// </summary>
         public void Dispose() {
             foreach (var item in activeCached) {
                 item.Value.Dispose();

--- a/changelog.txt
+++ b/changelog.txt
@@ -30,6 +30,7 @@ Date:
         - Ensure technology levels can always be specified, even with super-long technology names.
         - Don't log an exception when a cache file is simply absent.
         - Show the per-cycle amount for every science pack in a technology tooltip, instead of only the first.
+        - Fix text disappearing on the welcome screen and other secondary windows.
     Internal changes:
         - Upgrade to .NET 10.
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
I discovered a reliable method to reproduce some of the behaviour described in #496 and #519. If `WindowUtility` is flagged as resizable, resizing any derived window (such as the welcome screen) causes all text to disappear.

<img width="633" height="558" alt="image" src="https://github.com/user-attachments/assets/91c28301-5f5c-4697-a0dd-85f2aba93506" />

Recreating the renderer if it's changed since the previous render resolves the issue. I also added a call to `DestroyRenderer` to avoid a minor memory leak.