### PR TITLE
Support QualityPrototype chain_probability property

### DIFF
--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -853,14 +853,12 @@ public sealed class Quality : FactorioObject {
     internal float ApplyStandardBonus(float baseValue) => baseValue * (1 + .3f * level);
     // applies the +100% per level accumulator capacity bonus
     internal float ApplyAccumulatorCapacityBonus(float baseValue) => baseValue * (1 + level);
-    // Applies the standard +30% per level bonus, but rounded down the nearest 1%.
+    // Applies the standard +30% per level bonus, but rounded down to the nearest 0.01 (1%).
     // This applies to all modules except quality modules.
     // Example: Productivity 1 modules have a base bonus of .04 (4%).
     // The level 1 bonus (uncommon) gives .04 * 1.3 = .052 (5.2%), which is rounded down to 0.05 (5%).
-    internal float ApplyModuleBonus(float baseValue) => MathF.Floor(ApplyStandardBonus(baseValue) * 100) / 100;
-    // From Factorio 2.1, Quality module bonuses are rounded to the nearest 0.01% instead of 0.1%.
-    internal float ApplyQualityModuleBonus(float baseValue) => MathF.Floor(ApplyStandardBonus(baseValue) * 10_000) / 10_000;
-
+    // Quality modules are rounded more precisely than other modules, so the precision can optionally be specified.
+    internal float ApplyModuleBonus(float baseValue, int precisionScale = 100) => MathF.Floor(ApplyStandardBonus(baseValue) * precisionScale) / precisionScale;
     // applies the .2 per level beacon transmission bonus
     internal float ApplyBeaconBonus(float baseValue) => baseValue + level * .2f;
 
@@ -1135,11 +1133,13 @@ public class ModuleSpecification {
     public float baseProductivity { get; internal set; }
     public float basePollution { get; internal set; }
     public float baseQuality { get; internal set; }
+    public int qualityPrecisionScale { get; internal set; }
+
     public float Consumption(Quality quality) => baseConsumption >= 0 ? baseConsumption : quality.ApplyModuleBonus(baseConsumption);
     public float Speed(Quality quality) => baseSpeed <= 0 ? baseSpeed : quality.ApplyModuleBonus(baseSpeed);
     public float Productivity(Quality quality) => baseProductivity <= 0 ? baseProductivity : quality.ApplyModuleBonus(baseProductivity);
     public float Pollution(Quality quality) => basePollution >= 0 ? basePollution : quality.ApplyModuleBonus(basePollution);
-    public float Quality(Quality quality) => baseQuality <= 0 ? baseQuality : quality.ApplyQualityModuleBonus(baseQuality);
+    public float Quality(Quality quality) => baseQuality <= 0 ? baseQuality : quality.ApplyModuleBonus(baseQuality, qualityPrecisionScale);
 }
 
 public struct TemperatureRange(int min, int max) {

--- a/Yafc.Model/Data/DataClasses.cs
+++ b/Yafc.Model/Data/DataClasses.cs
@@ -853,9 +853,14 @@ public sealed class Quality : FactorioObject {
     internal float ApplyStandardBonus(float baseValue) => baseValue * (1 + .3f * level);
     // applies the +100% per level accumulator capacity bonus
     internal float ApplyAccumulatorCapacityBonus(float baseValue) => baseValue * (1 + level);
-    // applies the standard +30% per level bonus, but with the exception that the result is floored to the nearest hundredth
-    // Modules use this: a 25% normal bonus is a 32% uncommon bonus, not 32.5%.
+    // Applies the standard +30% per level bonus, but rounded down the nearest 1%.
+    // This applies to all modules except quality modules.
+    // Example: Productivity 1 modules have a base bonus of .04 (4%).
+    // The level 1 bonus (uncommon) gives .04 * 1.3 = .052 (5.2%), which is rounded down to 0.05 (5%).
     internal float ApplyModuleBonus(float baseValue) => MathF.Floor(ApplyStandardBonus(baseValue) * 100) / 100;
+    // From Factorio 2.1, Quality module bonuses are rounded to the nearest 0.01% instead of 0.1%.
+    internal float ApplyQualityModuleBonus(float baseValue) => MathF.Floor(ApplyStandardBonus(baseValue) * 10_000) / 10_000;
+
     // applies the .2 per level beacon transmission bonus
     internal float ApplyBeaconBonus(float baseValue) => baseValue + level * .2f;
 
@@ -864,6 +869,7 @@ public sealed class Quality : FactorioObject {
     public float BeaconTransmissionBonus => .2f * level;
     public float BeaconConsumptionFactor { get; internal set; }
     public float UpgradeChance { get; internal set; }
+    public float ChainChance { get; internal set; }
 
     public static bool operator <(Quality left, Quality right) => left.level < right.level;
     public static bool operator >(Quality left, Quality right) => left.level > right.level;
@@ -1133,7 +1139,7 @@ public class ModuleSpecification {
     public float Speed(Quality quality) => baseSpeed <= 0 ? baseSpeed : quality.ApplyModuleBonus(baseSpeed);
     public float Productivity(Quality quality) => baseProductivity <= 0 ? baseProductivity : quality.ApplyModuleBonus(baseProductivity);
     public float Pollution(Quality quality) => basePollution >= 0 ? basePollution : quality.ApplyModuleBonus(basePollution);
-    public float Quality(Quality quality) => baseQuality <= 0 ? baseQuality : quality.ApplyModuleBonus(baseQuality);
+    public float Quality(Quality quality) => baseQuality <= 0 ? baseQuality : quality.ApplyQualityModuleBonus(baseQuality);
 }
 
 public struct TemperatureRange(int min, int max) {

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -551,7 +551,8 @@ public sealed class RecipeRow : ModelObject<ProductionTable>, IGroupedElement<Pr
             float runningProbability = 1;
             // Fill upgradeProbabilities with "this quality or better" probabilities.
             while (quality != null && quality < Quality.MaxAccessible) {
-                runningProbability *= quality.UpgradeChance;
+                bool isInitialUpgrade = quality == recipe.quality;
+                runningProbability *= isInitialUpgrade ? quality.UpgradeChance : quality.ChainChance;
                 upgradeProbabilities.Add(Math.Min(1, runningProbability * parameters.activeEffects.qualityMod));
                 quality = quality.nextQuality;
             }

--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -543,7 +543,12 @@ internal partial class FactorioDataDeserializer {
                 baseSpeed = effect.speed,
                 baseProductivity = effect.productivity,
                 basePollution = effect.pollution,
-                baseQuality = effect.quality,
+                // In Factorio 2.0, quality module effects on the prototype were 10x greater. To avoid version-specific
+                // logic in the UI, this is scaled during parsing. This is offset by multiplying 'next_probability' by
+                // 10 in the quality prototype.
+                baseQuality = factorioVersion < v2_1 ? effect.quality / 10f : effect.quality,
+                // In Factorio 2.0, quality module bonus was floored to 0.1% precision instead of 0.01%.
+                qualityPrecisionScale = factorioVersion < v2_1 ? 1_000 : 10_000,
             };
         }
         else if (table.Get("type", "") == "ammo" && table["ammo_type"] is LuaTable ammo_type) {

--- a/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
@@ -92,8 +92,17 @@ internal partial class FactorioDataDeserializer {
         }
         quality.BeaconConsumptionFactor = table.Get("beacon_power_usage_multiplier", 1f);
         quality.level = table.Get("level", 0);
-        quality.UpgradeChance = table.Get("next_probability", 0f);
-        quality.ChainChance = table.Get("chain_probability", MathUtils.Clamp(quality.UpgradeChance * 0.1f, 0f, 1f));
+        var upgradeChance = table.Get("next_probability", 0f);
+        if (factorioVersion < v2_1) {
+            // In Factorio 2.0, quality module effects on the prototype were 10x greater. To avoid version-specific
+            // logic in the UI, this is scaled on the module and offset by multiplying the initial upgrade chance by 10.
+            quality.UpgradeChance = upgradeChance * 10f;
+            quality.ChainChance = upgradeChance;
+        }
+        else {
+            quality.UpgradeChance = upgradeChance;
+            quality.ChainChance = table.Get("chain_probability", MathUtils.Clamp(quality.UpgradeChance * 0.1f, 0f, 1f));
+        }
     }
 
     private void UpdateRecipeCatalysts() {

--- a/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_RecipeAndTechnology.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Yafc.I18n;
 using Yafc.Model;
+using Yafc.UI;
 
 namespace Yafc.Parser;
 
@@ -92,6 +93,7 @@ internal partial class FactorioDataDeserializer {
         quality.BeaconConsumptionFactor = table.Get("beacon_power_usage_multiplier", 1f);
         quality.level = table.Get("level", 0);
         quality.UpgradeChance = table.Get("next_probability", 0f);
+        quality.ChainChance = table.Get("chain_probability", MathUtils.Clamp(quality.UpgradeChance * 0.1f, 0f, 1f));
     }
 
     private void UpdateRecipeCatalysts() {

--- a/Yafc/Data/locale/en/yafc.cfg
+++ b/Yafc/Data/locale/en/yafc.cfg
@@ -122,6 +122,7 @@ tooltip-header-unlocks-recipes=Unlocks recipe__plural_for_parameter__1__{1=|rest
 tooltip-header-unlocks-locations=Unlocks location__plural_for_parameter__1__{1=|rest=s}__
 tooltip-header-total-science-required=Total science required
 tooltip-quality-upgrade-chance=Upgrade chance: __1__ (multiplied by module bonus)
+tooltip-quality-chain-chance=Chance to skip this tier: __1__
 tooltip-header-quality-bonuses=Quality bonuses
 tooltip-no-normal-bonuses=Normal quality provides no bonuses.
 tooltip-quality-crafting-speed=Crafting speed:

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -700,6 +700,9 @@ doneDrawing:;
             if (quality.UpgradeChance > 0) {
                 gui.BuildText(LSs.TooltipQualityUpgradeChance.L(DataUtils.FormatAmount(quality.UpgradeChance, UnitOfMeasure.Percent)));
             }
+            if (quality.level > 0 && quality.ChainChance > 0) {
+                gui.BuildText(LSs.TooltipQualityChainChance.L(DataUtils.FormatAmount(quality.ChainChance, UnitOfMeasure.Percent)));
+            }
         }
 
         BuildSubHeader(gui, LSs.TooltipHeaderQualityBonuses);


### PR DESCRIPTION
## Overview

* Load `chain_probability` property from `QualityPrototype` during parsing.
* Use `chain_probability` to calculate subsequent upgrade chances after the initial roll.
* Update precision of quality module bonuses to 0.01% - Legendary Q3s are +6.25% in 2.1.
* Display chain probability in the tooltip for qualities.

 Fixes #666.

## Backwards compatibility with 2.0

With the addition of `chain_probability`, the values for quality tier & module prototypes have changed slightly.

Using Quality 3 modules as an example:

### Factorio 2.0

* All quality tiers have a `next_probability` value of `0.1`.
* Normal Quality 3 modules have an `effect` value of `0.25`.
* Legendary Quality 3 modules have an `effect` value of `0.25 * (1+.3*5) = 0.625` which is truncated to have the same precision as other module types, `0.62`.
  * Curiously, in the Factorio 2.0 UI this is displayed as `6.2%`. Perhaps they multiplied or divided the value by 10 before formatting it as a percentage.
  * It turns out that the most recent release (YAFC 2.19.0) has a bug, because it doesn't do this scaling before formatting. Legendary Quality 3 modules show `Quality: 62%` in the tooltip.

### Factorio 2.1

* All quality tiers have a `next_probability` value of `1`.
* All quality tiers have a `chain_probability` value of `0.1`.
* Normal Quality 3 modules have an `effect` value of `0.025`.
* Legendary Quality 3 modules have an `effect` value of `0.025 * (1+.3*5) = 0.0625` which is truncated with _more_ precision than other module types, remaining as `0.0625`.
  * In the Factorio 2.1 UI this is displayed as `6.25%`, which does not require any special cases when formatting.

To preserve backwards compatibility, I've divided 2.0 quality module effect values by 10 in the parser, and offset this by multiplying the initial upgrade chance by 10 in the quality tiers. This preserves the maths, and allows us to format quality module bonuses in the UI correctly for both versions without bifurcating any UI code paths.