### PR TITLE
refactor(core): Isolate Yafc.Model From Yafc.UI

### DIFF
--- a/Yafc.Core/Logging.cs
+++ b/Yafc.Core/Logging.cs
@@ -5,7 +5,7 @@ using Serilog.Core;
 using Serilog.Events;
 using Serilog.Formatting.Json;
 
-namespace Yafc.UI;
+namespace Yafc.Core;
 
 /// <summary>
 /// Contains default configuration for logging, to both a structured log file and to the console.

--- a/Yafc.Core/MathUtils.cs
+++ b/Yafc.Core/MathUtils.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace Yafc.UI;
+namespace Yafc.Core;
 
 public static class MathUtils {
     public static float Clamp(float value, float min, float max) {

--- a/Yafc.Core/Yafc.Core.csproj
+++ b/Yafc.Core/Yafc.Core.csproj
@@ -6,4 +6,10 @@
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
+  </ItemGroup>
+
 </Project>

--- a/Yafc.Model/Analysis/AutomationAnalysis.cs
+++ b/Yafc.Model/Analysis/AutomationAnalysis.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics;
 using Serilog;
-using Yafc.UI;
+using Yafc.Core;
 
 namespace Yafc.Model;
 

--- a/Yafc.Model/Analysis/CostAnalysis.cs
+++ b/Yafc.Model/Analysis/CostAnalysis.cs
@@ -5,8 +5,8 @@ using System.Linq;
 using System.Text;
 using Google.OrTools.LinearSolver;
 using Serilog;
+using Yafc.Core;
 using Yafc.I18n;
-using Yafc.UI;
 
 namespace Yafc.Model;
 

--- a/Yafc.Model/Analysis/Milestones.cs
+++ b/Yafc.Model/Analysis/Milestones.cs
@@ -6,8 +6,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Serilog;
+using Yafc.Core;
 using Yafc.I18n;
-using Yafc.UI;
 
 namespace Yafc.Model;
 

--- a/Yafc.Model/Analysis/TechnologyLoopsFinder.cs
+++ b/Yafc.Model/Analysis/TechnologyLoopsFinder.cs
@@ -1,6 +1,6 @@
-﻿using System.Linq;
+using System.Linq;
 using Serilog;
-using Yafc.UI;
+using Yafc.Core;
 
 namespace Yafc.Model;
 

--- a/Yafc.Model/Analysis/TechnologyLoopsFinder.cs
+++ b/Yafc.Model/Analysis/TechnologyLoopsFinder.cs
@@ -1,4 +1,4 @@
-using System.Linq;
+﻿using System.Linq;
 using Serilog;
 using Yafc.Core;
 

--- a/Yafc.Model/Data/DataUtils.cs
+++ b/Yafc.Model/Data/DataUtils.cs
@@ -10,7 +10,6 @@ using Google.OrTools.LinearSolver;
 using Serilog;
 using Yafc.Core;
 using Yafc.I18n;
-using Yafc.UI;
 
 namespace Yafc.Model;
 

--- a/Yafc.Model/Data/DataUtils.cs
+++ b/Yafc.Model/Data/DataUtils.cs
@@ -8,6 +8,7 @@ using System.Text;
 using System.Text.RegularExpressions;
 using Google.OrTools.LinearSolver;
 using Serilog;
+using Yafc.Core;
 using Yafc.I18n;
 using Yafc.UI;
 

--- a/Yafc.Model/Model/ProductionSummary.cs
+++ b/Yafc.Model/Model/ProductionSummary.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Threading.Tasks;
 using Yafc.I18n;
-using Yafc.UI;
 
 namespace Yafc.Model;
 

--- a/Yafc.Model/Model/ProductionTable.cs
+++ b/Yafc.Model/Model/ProductionTable.cs
@@ -7,8 +7,8 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using Google.OrTools.LinearSolver;
 using Serilog;
+using Yafc.Core;
 using Yafc.I18n;
-using Yafc.UI;
 
 namespace Yafc.Model;
 

--- a/Yafc.Model/Model/ProductionTableContent.cs
+++ b/Yafc.Model/Model/ProductionTableContent.cs
@@ -5,7 +5,6 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using Yafc.Core;
 using Yafc.I18n;
-using Yafc.UI;
 
 namespace Yafc.Model;
 

--- a/Yafc.Model/Serialization/ErrorCollector.cs
+++ b/Yafc.Model/Serialization/ErrorCollector.cs
@@ -3,8 +3,8 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
 using Serilog;
+using Yafc.Core;
 using Yafc.I18n;
-using Yafc.UI;
 
 namespace Yafc.Model;
 

--- a/Yafc.Model/Serialization/SerializationMap.cs
+++ b/Yafc.Model/Serialization/SerializationMap.cs
@@ -5,8 +5,8 @@ using System.Diagnostics.CodeAnalysis;
 using System.Reflection;
 using System.Text.Json;
 using Serilog;
+using Yafc.Core;
 using Yafc.I18n;
-using Yafc.UI;
 
 namespace Yafc.Model;
 

--- a/Yafc.Model/Yafc.Model.csproj
+++ b/Yafc.Model/Yafc.Model.csproj
@@ -11,7 +11,6 @@
       <PackageReference Include="Google.OrTools" Version="9.15.6755" />
       <ProjectReference Include="..\Yafc.Core\Yafc.Core.csproj" />
       <ProjectReference Include="..\Yafc.I18n\Yafc.I18n.csproj" />
-      <ProjectReference Include="..\Yafc.UI\Yafc.UI.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Yafc.Parser/Data/FactorioDataDeserializer.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer.cs
@@ -6,6 +6,7 @@ using System.Runtime.CompilerServices;
 using System.Threading.Tasks;
 using SDL2;
 using Serilog;
+using Yafc.Core;
 using Yafc.I18n;
 using Yafc.Model;
 using Yafc.UI;

--- a/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
+++ b/Yafc.Parser/Data/FactorioDataDeserializer_Entity.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
+using Yafc.Core;
 using Yafc.I18n;
 using Yafc.Model;
 using Yafc.UI;

--- a/Yafc.Parser/LuaContext.cs
+++ b/Yafc.Parser/LuaContext.cs
@@ -7,6 +7,7 @@ using System.Runtime.InteropServices;
 using System.Text;
 using System.Text.RegularExpressions;
 using Serilog;
+using Yafc.Core;
 using Yafc.I18n;
 using Yafc.Model;
 using Yafc.UI;

--- a/Yafc.Parser/MathExpression.cs
+++ b/Yafc.Parser/MathExpression.cs
@@ -9,6 +9,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Serilog;
+using Yafc.Core;
 using Yafc.UI;
 
 namespace Yafc.Parser;

--- a/Yafc.Parser/SoftwareScaler.cs
+++ b/Yafc.Parser/SoftwareScaler.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Runtime.CompilerServices;
 using SDL2;
+using Yafc.Core;
 using Yafc.UI;
 
 namespace Yafc.Parser;

--- a/Yafc.Parser/Yafc.Parser.csproj
+++ b/Yafc.Parser/Yafc.Parser.csproj
@@ -26,6 +26,7 @@
       <InternalsVisibleTo Include="Yafc.Parser.Tests" />
       <ProjectReference Include="..\Yafc.I18n\Yafc.I18n.csproj" />
       <ProjectReference Include="..\Yafc.Model\Yafc.Model.csproj" />
+      <ProjectReference Include="..\Yafc.UI\Yafc.UI.csproj" />
     </ItemGroup>
 
 </Project>

--- a/Yafc.Parser/Yafc.Parser.csproj
+++ b/Yafc.Parser/Yafc.Parser.csproj
@@ -24,6 +24,7 @@
 
     <ItemGroup>
       <InternalsVisibleTo Include="Yafc.Parser.Tests" />
+      <ProjectReference Include="..\Yafc.Core\Yafc.Core.csproj" />
       <ProjectReference Include="..\Yafc.I18n\Yafc.I18n.csproj" />
       <ProjectReference Include="..\Yafc.Model\Yafc.Model.csproj" />
       <ProjectReference Include="..\Yafc.UI\Yafc.UI.csproj" />

--- a/Yafc.UI/Core/DrawingSurface.cs
+++ b/Yafc.UI/Core/DrawingSurface.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Numerics;
 using SDL2;
+using Yafc.Core;
 
 namespace Yafc.UI;
 

--- a/Yafc.UI/Core/ExceptionScreen.cs
+++ b/Yafc.UI/Core/ExceptionScreen.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using SDL2;
 using Serilog;
+using Yafc.Core;
 using Yafc.I18n;
 
 namespace Yafc.UI;

--- a/Yafc.UI/Core/Ui.cs
+++ b/Yafc.UI/Core/Ui.cs
@@ -7,6 +7,7 @@ using System.Text;
 using System.Threading;
 using SDL2;
 using Serilog;
+using Yafc.Core;
 
 namespace Yafc.UI;
 

--- a/Yafc.UI/Core/Window.cs
+++ b/Yafc.UI/Core/Window.cs
@@ -2,6 +2,7 @@
 using System.Numerics;
 using SDL2;
 using Serilog;
+using Yafc.Core;
 
 namespace Yafc.UI;
 

--- a/Yafc.UI/Core/WindowMain.cs
+++ b/Yafc.UI/Core/WindowMain.cs
@@ -3,6 +3,7 @@ using System.Numerics;
 using System.Runtime.InteropServices;
 using SDL2;
 using Serilog;
+using Yafc.Core;
 
 namespace Yafc.UI;
 

--- a/Yafc.UI/ImGui/DropDownPanel.cs
+++ b/Yafc.UI/ImGui/DropDownPanel.cs
@@ -1,4 +1,5 @@
 ﻿using System.Numerics;
+using Yafc.Core;
 
 namespace Yafc.UI;
 

--- a/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
+++ b/Yafc.UI/ImGui/ImGuiTextInputHelper.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Runtime.InteropServices;
 using SDL2;
+using Yafc.Core;
 
 namespace Yafc.UI;
 

--- a/Yafc.UI/ImGui/ImGuiUtils.cs
+++ b/Yafc.UI/ImGui/ImGuiUtils.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using SDL2;
+using Yafc.Core;
 using Yafc.I18n;
 
 namespace Yafc.UI;

--- a/Yafc.UI/Rendering/Font.cs
+++ b/Yafc.UI/Rendering/Font.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.IO;
 using SDL2;
+using Yafc.Core;
 
 namespace Yafc.UI;
 

--- a/Yafc.UI/Rendering/IconAtlas.cs
+++ b/Yafc.UI/Rendering/IconAtlas.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using SDL2;
 using Serilog;
+using Yafc.Core;
 
 namespace Yafc.UI;
 

--- a/Yafc.UI/Rendering/RenderingUtils.cs
+++ b/Yafc.UI/Rendering/RenderingUtils.cs
@@ -3,6 +3,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Runtime.CompilerServices;
 using SDL2;
+using Yafc.Core;
 
 namespace Yafc.UI;
 

--- a/Yafc.UI/Yafc.UI.csproj
+++ b/Yafc.UI/Yafc.UI.csproj
@@ -9,9 +9,6 @@
 
     <ItemGroup>
       <PackageReference Include="SDL2-CS.NetCore" Version="2.0.8" />
-      <PackageReference Include="Serilog.Enrichers.Thread" Version="4.0.0" />
-      <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
-      <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Yafc/Program.cs
+++ b/Yafc/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using Serilog;
+using Yafc.Core;
 using Yafc.I18n;
 using Yafc.Model;
 using Yafc.Parser;

--- a/Yafc/Widgets/DataGrid.cs
+++ b/Yafc/Widgets/DataGrid.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Numerics;
 using System.Reflection;
 using SDL2;
+using Yafc.Core;
 
 namespace Yafc.UI;
 

--- a/Yafc/Widgets/MainScreenTabBar.cs
+++ b/Yafc/Widgets/MainScreenTabBar.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Numerics;
 using SDL2;
+using Yafc.Core;
 using Yafc.I18n;
 using Yafc.Model;
 using Yafc.UI;

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -9,6 +9,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using SDL2;
 using Serilog;
+using Yafc.Core;
 using Yafc.I18n;
 using Yafc.Model;
 using Yafc.UI;

--- a/Yafc/Windows/NeverEnoughItemsPanel.cs
+++ b/Yafc/Windows/NeverEnoughItemsPanel.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using Yafc.Core;
 using Yafc.I18n;
 using Yafc.Model;
 using Yafc.UI;

--- a/Yafc/Windows/ShoppingListScreen.cs
+++ b/Yafc/Windows/ShoppingListScreen.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Numerics;
 using SDL2;
 using Yafc.Blueprints;
+using Yafc.Core;
 using Yafc.I18n;
 using Yafc.Model;
 using Yafc.UI;

--- a/Yafc/Windows/WelcomeScreen.cs
+++ b/Yafc/Windows/WelcomeScreen.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Newtonsoft.Json.Linq;
 using SDL2;
 using Serilog;
+using Yafc.Core;
 using Yafc.I18n;
 using Yafc.Model;
 using Yafc.Parser;

--- a/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Numerics;
+using Yafc.Core;
 using Yafc.I18n;
 using Yafc.Model;
 using Yafc.UI;

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Numerics;
 using SDL2;
 using Yafc.Blueprints;
+using Yafc.Core;
 using Yafc.I18n;
 using Yafc.Model;
 using Yafc.UI;

--- a/Yafc/YafcLib.cs
+++ b/Yafc/YafcLib.cs
@@ -6,6 +6,7 @@ using System.Runtime.InteropServices;
 using System.Threading;
 using SDL2;
 using Serilog;
+using Yafc.Core;
 using Yafc.Model;
 using Yafc.Parser;
 using Yafc.UI;


### PR DESCRIPTION
## Summary
Closes #644.

This PR removes the remaining non-threading `Yafc.Model -> Yafc.UI` dependency by moving shared, non-UI infrastructure out of `Yafc.UI` and into `Yafc.Core`. It satisfies the stated ultimate success criterion of #574 by removing the `Yafc.UI` project reference from `Yafc.Model.csproj` while keeping parser/UI decoupling tracked separately in #668.

## Changes
- Move `MathUtils` from `Yafc.UI` to `Yafc.Core` and update model, parser, UI, and application call sites to import the Core namespace.
- Move `Logging` from `Yafc.UI` to `Yafc.Core`, preserving the existing Serilog file/console sink configuration and stack-trace enrichment behavior.
- Move the Serilog sink/enricher package references from `Yafc.UI.csproj` to `Yafc.Core.csproj`, where the logging implementation now lives.
- Remove stale `using Yafc.UI;` imports from model files that no longer use UI symbols.
- Remove the `Yafc.Model -> Yafc.UI` project reference after the remaining model usages are routed through `Yafc.Core`.
- Add explicit `Yafc.Core` and temporary direct `Yafc.UI` references to `Yafc.Parser.csproj`, alongside the existing `Yafc.I18n` and `Yafc.Model` references, so parser dependencies are no longer hidden behind transitive references. The direct parser-to-UI reference is an intermediate state tracked by #668 and does not close #668.
- Restore the `TechnologyLoopsFinder.cs` encoding required by the repository formatting configuration.

## Validation
- `mise exec -- dotnet build Yafc.Parser\Yafc.Parser.csproj`
- `mise exec -- dotnet build Yafc.Model\Yafc.Model.csproj`
- `mise exec -- dotnet build FactorioCalc.sln`
- `dotnet format --verify-no-changes --diagnostics IDE0055 --severity info --verbosity normal`

## Notes
- `Yafc.Model` now references `Yafc.Core` and `Yafc.I18n`, but not `Yafc.UI`.
- A `Yafc.Model` comment still documents the numeric compatibility between `FactorioObject.iconId` and `Yafc.UI.Icon`; this is not a compile-time dependency.
- The broader parser/icon rendering split remains tracked by #668.