### PR TITLE
Per-Monitor v2 DPI Awareness and cross-platform High DPI rendering

### DIFF
--- a/Yafc.UI/Core/DrawingSurface.cs
+++ b/Yafc.UI/Core/DrawingSurface.cs
@@ -19,7 +19,7 @@ public readonly struct TextureHandle(DrawingSurface surface, IntPtr handle) {
     }
 }
 
-public abstract class DrawingSurface(float pixelsPerUnit) : IDisposable {
+public abstract class DrawingSurface : IDisposable {
     public IntPtr renderer {
         get;
         protected set {
@@ -30,7 +30,7 @@ public abstract class DrawingSurface(float pixelsPerUnit) : IDisposable {
 
     public int rendererVersion { get; private set; }
 
-    public float pixelsPerUnit { get; set; } = pixelsPerUnit;
+    public abstract float pixelsPerUnit { get; }
 
     internal static RenderingUtils.BlitMapping[]? blitMapping;
 
@@ -103,7 +103,7 @@ public abstract class DrawingSurface(float pixelsPerUnit) : IDisposable {
     }
 }
 
-public abstract class SoftwareDrawingSurface(IntPtr surface, float pixelsPerUnit) : DrawingSurface(pixelsPerUnit) {
+public abstract class SoftwareDrawingSurface(IntPtr surface) : DrawingSurface {
     public IntPtr surface { get; protected set; } = surface;
 
     public override SDL.SDL_Rect SetClip(SDL.SDL_Rect clip) {
@@ -132,15 +132,18 @@ public abstract class SoftwareDrawingSurface(IntPtr surface, float pixelsPerUnit
 }
 
 public class MemoryDrawingSurface : SoftwareDrawingSurface {
+    public override float pixelsPerUnit { get; }
+
     public MemoryDrawingSurface(Vector2 size, float pixelsPerUnit) : this(size, ClampPixelsPerUnit(size, pixelsPerUnit), true) { }
 
     private MemoryDrawingSurface(Vector2 size, float pixelsPerUnit, bool __) :
-        base(SDL.SDL_CreateRGBSurfaceWithFormat(0, MathUtils.Round(size.X * pixelsPerUnit), MathUtils.Round(size.Y * pixelsPerUnit), 0, SDL.SDL_PIXELFORMAT_RGB888), pixelsPerUnit) {
+        base(SDL.SDL_CreateRGBSurfaceWithFormat(0, MathUtils.Round(size.X * pixelsPerUnit), MathUtils.Round(size.Y * pixelsPerUnit), 0, SDL.SDL_PIXELFORMAT_RGB888)) {
+        this.pixelsPerUnit = pixelsPerUnit;
         renderer = SDL.SDL_CreateSoftwareRenderer(surface);
         _ = SDL.SDL_SetRenderDrawBlendMode(renderer, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
     }
 
-    public static float ClampPixelsPerUnit(Vector2 size, float pixelsPerUnit) {
+    private static float ClampPixelsPerUnit(Vector2 size, float pixelsPerUnit) {
         float maxPPU = MathF.Min(65535 / size.X, 65535 / size.Y);
         return MathF.Min(maxPPU, pixelsPerUnit);
     }

--- a/Yafc.UI/Core/InputSystem.cs
+++ b/Yafc.UI/Core/InputSystem.cs
@@ -106,7 +106,7 @@ public sealed class InputSystem {
             return;
         }
 
-        Vector2 newMousePos = new Vector2(rawX / mouseOverWindow.pixelsPerUnit, rawY / mouseOverWindow.pixelsPerUnit);
+        Vector2 newMousePos = new Vector2(Window.DipsToUnits(rawX), Window.DipsToUnits(rawY));
         mouseDelta = newMousePos - mousePosition;
         mousePosition = newMousePos;
 

--- a/Yafc.UI/Core/Ui.cs
+++ b/Yafc.UI/Core/Ui.cs
@@ -18,19 +18,8 @@ public static partial class Ui {
     private static readonly Dictionary<uint, Window> windows = [];
     internal static void RegisterWindow(uint id, Window window) => windows[id] = window;
 
-    [LibraryImport("SHCore.dll", SetLastError = true)]
-    [return: MarshalAs(UnmanagedType.Bool)]
-    private static partial bool SetProcessDpiAwareness(int awareness);
     public static void Start() {
-        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
-            try {
-                _ = SetProcessDpiAwareness(2);
-            }
-            catch (Exception) {
-                logger.Information("DPI awareness setup failed"); // On older versions on Windows
-            }
-        }
-
+        SDL.SDL_SetHint("SDL_WINDOWS_DPI_SCALING", "1");
         int sdlInitResult = SDL.SDL_Init(SDL.SDL_INIT_VIDEO);
         if (sdlInitResult != 0) {
             logger.Error("SDL_Init failed ({Result}): {Error}", sdlInitResult, SDL.SDL_GetError());

--- a/Yafc.UI/Core/Ui.cs
+++ b/Yafc.UI/Core/Ui.cs
@@ -149,11 +149,11 @@ public static partial class Ui {
                             case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_MINIMIZED:
                                 window.Minimized();
                                 break;
-                            case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_MOVED:
-                                window.WindowMoved();
-                                break;
                             case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_RESIZED:
                                 window.WindowResize();
+                                break;
+                            case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_SIZE_CHANGED:
+                                window.SizeChanged();
                                 break;
                             case SDL.SDL_WindowEventID.SDL_WINDOWEVENT_MAXIMIZED:
                                 window.WindowMaximized();

--- a/Yafc.UI/Core/Ui.cs
+++ b/Yafc.UI/Core/Ui.cs
@@ -20,6 +20,8 @@ public static partial class Ui {
 
     public static void Start() {
         SDL.SDL_SetHint("SDL_WINDOWS_DPI_SCALING", "1");
+        // SDL2-compat on Wayland assumes that all SDL2 apps are not DPI aware, unless forcibly overriden.
+        SDL.SDL_SetHintWithPriority("SDL_VIDEO_WAYLAND_SCALE_TO_DISPLAY", "0", SDL.SDL_HintPriority.SDL_HINT_OVERRIDE);
         int sdlInitResult = SDL.SDL_Init(SDL.SDL_INIT_VIDEO);
         if (sdlInitResult != 0) {
             logger.Error("SDL_Init failed ({Result}): {Error}", sdlInitResult, SDL.SDL_GetError());

--- a/Yafc.UI/Core/Window.cs
+++ b/Yafc.UI/Core/Window.cs
@@ -90,6 +90,10 @@ public abstract class Window : IDisposable {
         return desiredUnitsToPixels;
     }
 
+    internal static float UnitsToDips(float units) => units * MathUtils.Round(96f / 6.8f);
+
+    internal static float DipsToUnits(float dips) => dips / MathUtils.Round(96f / 6.8f);
+
     protected internal void SetWindowTitle(string value) => SDL.SDL_SetWindowTitle(window, value);
 
     protected internal virtual void WindowResize() {

--- a/Yafc.UI/Core/Window.cs
+++ b/Yafc.UI/Core/Window.cs
@@ -118,7 +118,7 @@ public abstract class Window : IDisposable {
         repaintRequired = false;
 
         if (rootGui.IsRebuildRequired()) {
-            _ = rootGui.CalculateState(size.X, pixelsPerUnit);
+            _ = rootGui.CalculateState(surface, size.X);
         }
 
         MainRender();
@@ -134,7 +134,12 @@ public abstract class Window : IDisposable {
         _ = SDL.SDL_SetRenderDrawColor(surface.renderer, bgColor.r, bgColor.g, bgColor.b, bgColor.a);
         Rect fullRect = new Rect(default, contentSize);
         repaintCount++;
-        surface.Clear(rootGui.ToSdlRect(fullRect));
+        surface.Clear(new SDL.SDL_Rect {
+            x = MathUtils.Round(fullRect.X * surface.pixelsPerUnit),
+            y = MathUtils.Round(fullRect.Y * surface.pixelsPerUnit),
+            w = MathUtils.Round(fullRect.Width * surface.pixelsPerUnit),
+            h = MathUtils.Round(fullRect.Height * surface.pixelsPerUnit),
+        });
         rootGui.InternalPresent(surface, fullRect, fullRect);
     }
 

--- a/Yafc.UI/Core/Window.cs
+++ b/Yafc.UI/Core/Window.cs
@@ -18,7 +18,8 @@ public abstract class Window : IDisposable {
     internal bool visible;
     internal bool closed;
     internal long nextRepaintTime = long.MaxValue;
-    internal float pixelsPerUnit;
+    public float DisplayScale { get; private set; } = 1f;
+    internal float pixelsPerUnit { get => UnitsToDips(DisplayScale); }
     public virtual SchemeColor backgroundColor => SchemeColor.Background;
 
     private Tooltip? tooltip;
@@ -47,6 +48,7 @@ public abstract class Window : IDisposable {
             throw new InvalidOperationException($"surface must be set by a derived class before calling {nameof(Create)}.");
         }
 
+        UpdateDisplayScale();
         SDL.SDL_SetWindowIcon(window, GetIcon());
 
         _ = SDL.SDL_SetRenderDrawBlendMode(surface.renderer, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
@@ -69,25 +71,20 @@ public abstract class Window : IDisposable {
 
         return icon;
     }
-
-    internal static int CalculateUnitsToPixels(int display) {
-        _ = SDL.SDL_GetDisplayDPI(display, out float dpi, out _, out _);
-        _ = SDL.SDL_GetDisplayBounds(display, out var rect);
-        // 82x60 is the minimum screen size in units, plus some for borders
-        // DPI bellow 96 is more likely to be incorrectly reported value than desired,
-        //     see discussion in https://github.com/Yafc-CE/yafc-ce/issues/255#issuecomment-2508884418
-        //     => we treat is as "unknown" and revert to default 100% scaling
-        int desiredUnitsToPixels = dpi < 96 ? 13 : MathUtils.Round(dpi / 6.8f);
-
-        if (desiredUnitsToPixels * 82f >= rect.w) {
-            desiredUnitsToPixels = MathUtils.Floor(rect.w / 82f);
+    private void UpdateDisplayScale() {
+        if (surface is null) {
+            throw new InvalidOperationException($"surface must be set by a derived class before calling {nameof(UpdateDisplayScale)}.");
         }
 
-        if (desiredUnitsToPixels * 65f >= rect.h) {
-            desiredUnitsToPixels = MathUtils.Floor(rect.h / 65f);
-        }
+        SDL.SDL_GetWindowSize(window, out int windowWidth, out int _);
+        SDL.SDL_GetRendererOutputSize(surface.renderer, out int renderWidth, out int _);
+        var value = (float)renderWidth / windowWidth;
 
-        return desiredUnitsToPixels;
+        if (value != DisplayScale) {
+            DisplayScale = value;
+            rootGui.MarkEverythingForRebuild();
+            Repaint();
+        }
     }
 
     internal static float UnitsToDips(float units) => units * MathUtils.Round(96f / 6.8f);
@@ -96,24 +93,10 @@ public abstract class Window : IDisposable {
 
     protected internal void SetWindowTitle(string value) => SDL.SDL_SetWindowTitle(window, value);
 
-    protected internal virtual void WindowResize() {
-        rootGui.MarkEverythingForRebuild();
-        rootGui.Rebuild();
-    }
+    protected internal virtual void WindowResize() { }
 
-    internal void WindowMoved() {
-        if (surface is null) { throw new InvalidOperationException($"surface must be set by a derived class before calling {nameof(WindowMoved)}."); }
-
-        int index = SDL.SDL_GetWindowDisplayIndex(window);
-        int u2p = CalculateUnitsToPixels(index);
-
-        if (u2p != pixelsPerUnit) {
-            pixelsPerUnit = u2p;
-            surface.pixelsPerUnit = pixelsPerUnit;
-            repaintRequired = true;
-            rootGui.MarkEverythingForRebuild();
-            WindowResize();
-        }
+    protected internal virtual void SizeChanged() {
+        UpdateDisplayScale();
     }
 
     protected virtual void OnRepaint() { }

--- a/Yafc.UI/Core/WindowMain.cs
+++ b/Yafc.UI/Core/WindowMain.cs
@@ -14,16 +14,22 @@ public abstract class WindowMain(Padding padding, bool forceSoftwareRenderer) : 
             return;
         }
 
-        pixelsPerUnit = CalculateUnitsToPixels(display);
-        // Min width/height define the minimum size of the main window when it gets resized.
-        // The minimal size prevents issues/unreachable spots within the UI (like dialogs that do not size with the window size).
-        int minWidth = MathUtils.Round(85f * pixelsPerUnit);
-        int minHeight = MathUtils.Round(60f * pixelsPerUnit);
-        // Initial width/height define the initial size of the MainWindow when it is opened.
-        int initialWidthPixels = Math.Max(minWidth, MathUtils.Round(initialWidth * pixelsPerUnit));
-        int initialHeightPixels = Math.Max(minHeight, MathUtils.Round(initialHeight * pixelsPerUnit));
-        SDL.SDL_WindowFlags flags = SDL.SDL_WindowFlags.SDL_WINDOW_RESIZABLE | (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) ? 0 : SDL.SDL_WindowFlags.SDL_WINDOW_OPENGL);
+        // The minimum size is to prevent unreachable spots within the UI.
+        float minUnitWidth = 85f;
+        float minUnitHeight = 60f;
+        contentSize = new Vector2(
+            Math.Max(minUnitWidth, initialWidth),
+            Math.Max(minUnitHeight, initialHeight)
+        );
+        int width = MathUtils.Round(UnitsToDips(contentSize.X));
+        int height = MathUtils.Round(UnitsToDips(contentSize.Y));
 
+        SDL.SDL_WindowFlags flags =
+            SDL.SDL_WindowFlags.SDL_WINDOW_RESIZABLE |
+            SDL.SDL_WindowFlags.SDL_WINDOW_ALLOW_HIGHDPI;
+        if (!RuntimeInformation.IsOSPlatform(OSPlatform.Windows)) {
+            flags |= SDL.SDL_WindowFlags.SDL_WINDOW_OPENGL;
+        }
         if (maximized) {
             flags |= SDL.SDL_WindowFlags.SDL_WINDOW_MAXIMIZED;
         }
@@ -31,13 +37,16 @@ public abstract class WindowMain(Padding padding, bool forceSoftwareRenderer) : 
         window = SDL.SDL_CreateWindow(title,
             SDL.SDL_WINDOWPOS_CENTERED_DISPLAY(display),
             SDL.SDL_WINDOWPOS_CENTERED_DISPLAY(display),
-            initialWidthPixels, initialHeightPixels, flags
+            width, height, flags
         );
         if (window == IntPtr.Zero) {
             logger.Error("SDL_CreateWindow failed: {Error}", SDL.SDL_GetError());
         }
-        SDL.SDL_SetWindowMinimumSize(window, minWidth, minHeight);
-        WindowResize();
+        SDL.SDL_SetWindowMinimumSize(
+            window,
+            MathUtils.Round(UnitsToDips(minUnitWidth)),
+            MathUtils.Round(UnitsToDips(minUnitHeight)));
+
         surface = new MainWindowDrawingSurface(this, forceSoftwareRenderer);
         base.Create();
     }
@@ -64,7 +73,7 @@ public abstract class WindowMain(Padding padding, bool forceSoftwareRenderer) : 
 
     protected internal override void WindowResize() {
         SDL.SDL_GetWindowSize(window, out int windowWidth, out int windowHeight);
-        contentSize = new Vector2(windowWidth / pixelsPerUnit, windowHeight / pixelsPerUnit);
+        contentSize = new Vector2(DipsToUnits(windowWidth), DipsToUnits(windowHeight));
         base.WindowResize();
     }
 

--- a/Yafc.UI/Core/WindowMain.cs
+++ b/Yafc.UI/Core/WindowMain.cs
@@ -92,6 +92,8 @@ internal class MainWindowDrawingSurface : DrawingSurface {
 
     public override Window window { get; }
 
+    public override float pixelsPerUnit => window.pixelsPerUnit;
+
     /// <summary>
     /// Function <c>PickRenderDriver()</c> picks the best rendering backend available on the platform.
     ///
@@ -169,7 +171,7 @@ internal class MainWindowDrawingSurface : DrawingSurface {
         return selectedRenderDriver;
     }
 
-    public MainWindowDrawingSurface(WindowMain window, bool forceSoftwareRenderer) : base(window.pixelsPerUnit) {
+    public MainWindowDrawingSurface(WindowMain window, bool forceSoftwareRenderer) {
         this.window = window;
 
         renderer = SDL.SDL_CreateRenderer(window.window, PickRenderDriver(SDL.SDL_RendererFlags.SDL_RENDERER_PRESENTVSYNC, forceSoftwareRenderer), SDL.SDL_RendererFlags.SDL_RENDERER_PRESENTVSYNC);

--- a/Yafc.UI/Core/WindowUtility.cs
+++ b/Yafc.UI/Core/WindowUtility.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Numerics;
 using SDL2;
 
 namespace Yafc.UI;
@@ -17,17 +18,20 @@ public abstract class WindowUtility(Padding padding) : Window(padding) {
         if (parent != null) {
             parent.ChildWindow = this;
         }
-        contentSize.X = width;
-        int display = parent == null ? 0 : SDL.SDL_GetWindowDisplayIndex(parent.window);
-        pixelsPerUnit = CalculateUnitsToPixels(display);
-        contentSize = rootGui.CalculateState(width, pixelsPerUnit);
-        windowWidth = rootGui.UnitsToPixels(contentSize.X);
-        windowHeight = rootGui.UnitsToPixels(contentSize.Y);
-        var flags = SDL.SDL_WindowFlags.SDL_WINDOW_MOUSE_FOCUS;
+
+        contentSize = new Vector2(width, 0);
+        // Perform initial layout to dynamically calculate necessary window height.
+        contentSize = rootGui.CalculateState(width, UnitsToDips(1));
+
+        windowWidth = MathUtils.Round(UnitsToDips(contentSize.X));
+        windowHeight = MathUtils.Round(UnitsToDips(contentSize.Y));
+
+        var flags = SDL.SDL_WindowFlags.SDL_WINDOW_MOUSE_FOCUS | SDL.SDL_WindowFlags.SDL_WINDOW_ALLOW_HIGHDPI;
         if (parent != null) {
             flags |= SDL.SDL_WindowFlags.SDL_WINDOW_SKIP_TASKBAR | SDL.SDL_WindowFlags.SDL_WINDOW_ALWAYS_ON_TOP;
         }
 
+        int display = parent == null ? 0 : SDL.SDL_GetWindowDisplayIndex(parent.window);
         window = SDL.SDL_CreateWindow(title,
             SDL.SDL_WINDOWPOS_CENTERED_DISPLAY(display),
             SDL.SDL_WINDOWPOS_CENTERED_DISPLAY(display),
@@ -35,6 +39,7 @@ public abstract class WindowUtility(Padding padding) : Window(padding) {
             windowHeight,
             flags
         );
+
         surface = new UtilityWindowDrawingSurface(this);
         base.Create();
     }
@@ -42,23 +47,6 @@ public abstract class WindowUtility(Padding padding) : Window(padding) {
     protected internal override void WindowResize() {
         (surface as UtilityWindowDrawingSurface)!.OnResize(); // null-forgiving: Assuming WindowResize cannot be called before Create
         base.WindowResize();
-    }
-
-    private void CheckSizeChange() {
-        int newWindowWidth = rootGui.UnitsToPixels(contentSize.X);
-        int newWindowHeight = rootGui.UnitsToPixels(contentSize.Y);
-
-        if (windowWidth != newWindowWidth || windowHeight != newWindowHeight) {
-            windowWidth = newWindowWidth;
-            windowHeight = newWindowHeight;
-            SDL.SDL_SetWindowSize(window, newWindowWidth, newWindowHeight);
-            WindowResize();
-        }
-    }
-
-    protected override void MainRender() {
-        CheckSizeChange();
-        base.MainRender();
     }
 
     protected internal override void Close() {

--- a/Yafc.UI/Core/WindowUtility.cs
+++ b/Yafc.UI/Core/WindowUtility.cs
@@ -44,9 +44,9 @@ public abstract class WindowUtility(Padding padding) : Window(padding) {
         base.Create();
     }
 
-    protected internal override void WindowResize() {
-        (surface as UtilityWindowDrawingSurface)!.OnResize(); // null-forgiving: Assuming WindowResize cannot be called before Create
-        base.WindowResize();
+    protected internal override void SizeChanged() {
+        (surface as UtilityWindowDrawingSurface)?.OnSizeChanged();
+        base.SizeChanged();
     }
 
     protected internal override void Close() {
@@ -76,7 +76,7 @@ internal class UtilityWindowDrawingSurface : SoftwareDrawingSurface {
         _ = SDL.SDL_SetRenderDrawBlendMode(renderer, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
     }
 
-    public void OnResize() => InvalidateRenderer();
+    public void OnSizeChanged() => InvalidateRenderer();
 
     public override void Dispose() {
         base.Dispose();

--- a/Yafc.UI/Core/WindowUtility.cs
+++ b/Yafc.UI/Core/WindowUtility.cs
@@ -21,7 +21,7 @@ public abstract class WindowUtility(Padding padding) : Window(padding) {
 
         contentSize = new Vector2(width, 0);
         // Perform initial layout to dynamically calculate necessary window height.
-        contentSize = rootGui.CalculateState(width, UnitsToDips(1));
+        contentSize = rootGui.CalculateState(width);
 
         windowWidth = MathUtils.Round(UnitsToDips(contentSize.X));
         windowHeight = MathUtils.Round(UnitsToDips(contentSize.Y));

--- a/Yafc.UI/Core/WindowUtility.cs
+++ b/Yafc.UI/Core/WindowUtility.cs
@@ -62,7 +62,9 @@ public abstract class WindowUtility(Padding padding) : Window(padding) {
 internal class UtilityWindowDrawingSurface : SoftwareDrawingSurface {
     public override Window window { get; }
 
-    public UtilityWindowDrawingSurface(WindowUtility window) : base(IntPtr.Zero, window.pixelsPerUnit) {
+    public override float pixelsPerUnit => window.pixelsPerUnit;
+
+    public UtilityWindowDrawingSurface(WindowUtility window) : base(IntPtr.Zero) {
         this.window = window;
         InvalidateRenderer();
     }

--- a/Yafc.UI/ImGui/DropDownPanel.cs
+++ b/Yafc.UI/ImGui/DropDownPanel.cs
@@ -36,7 +36,7 @@ public abstract class AttachedPanel {
             var rect = source.TranslateRect(sourceRect, gui);
 
             if (ShouldBuild(source, sourceRect, gui, rect)) {
-                var contentSize = contents.CalculateState(width, gui.pixelsPerUnit);
+                var contentSize = contents.CalculateState(width);
                 var position = CalculatePosition(gui, rect, contentSize);
                 Rect parentRect = new Rect(position, contentSize);
                 gui.DrawPanel(parentRect, contents);

--- a/Yafc.UI/ImGui/ImGui.cs
+++ b/Yafc.UI/ImGui/ImGui.cs
@@ -23,7 +23,7 @@ public interface IPanel {
     void MouseMove(int mouseDownButton);
     void MouseScroll(int delta);
     void MarkEverythingForRebuild();
-    Vector2 CalculateState(float width, float pixelsPerUnit);
+    Vector2 CalculateState(float width);
     void Present(DrawingSurface surface, Rect position, Rect screenClip, ImGui parent);
     IPanel HitTest(Vector2 position);
     IPanel? Parent { get; }
@@ -132,12 +132,17 @@ public sealed partial class ImGui : IDisposable, IPanel {
 
     public void Repaint() => window?.Repaint();
 
-    public Vector2 CalculateState(float width, float _) {
+    public Vector2 CalculateState(float width) {
         if (IsRebuildRequired() || buildWidth != width || buildPixelsPerUnit != pixelsPerUnit) {
             BuildGui(width);
         }
 
         return contentSize;
+    }
+
+    public Vector2 CalculateState(DrawingSurface surface, float width) {
+        this.surface = surface;
+        return CalculateState(width);
     }
 
     public void Present(DrawingSurface surface, Rect position, Rect screenClip, ImGui? parent) {

--- a/Yafc.UI/ImGui/ImGui.cs
+++ b/Yafc.UI/ImGui/ImGui.cs
@@ -64,11 +64,13 @@ public sealed partial class ImGui : IDisposable, IPanel {
     }
 
     public readonly GuiBuilder? guiBuilder;
-    public Window? window { get; private set; }
+    private DrawingSurface? surface { get; set; }
+    public Window? window { get => surface?.window; }
     public ImGui? parent { get; private set; }
     IPanel? IPanel.Parent => parent;
     private bool rebuildRequested = true;
     private float buildWidth;
+    private float buildPixelsPerUnit;
     public bool mouseCapture { get; set; } = true;
     [MemberNotNullWhen(true, nameof(window))]
     public bool valid { get => field && window != null && window.visible; private set; } = true;
@@ -81,7 +83,7 @@ public sealed partial class ImGui : IDisposable, IPanel {
     }
     public int actionParameter { get; private set; }
     private long nextRebuildTimer = long.MaxValue;
-    public float pixelsPerUnit { get; private set; }
+    public float pixelsPerUnit { get => surface?.pixelsPerUnit ?? Window.UnitsToDips(1); }
 
     private readonly float scale = 1f;
     private readonly bool clip;
@@ -130,9 +132,8 @@ public sealed partial class ImGui : IDisposable, IPanel {
 
     public void Repaint() => window?.Repaint();
 
-    public Vector2 CalculateState(float width, float pixelsPerUnit) {
-        if (IsRebuildRequired() || buildWidth != width || this.pixelsPerUnit != pixelsPerUnit) {
-            this.pixelsPerUnit = pixelsPerUnit;
+    public Vector2 CalculateState(float width, float _) {
+        if (IsRebuildRequired() || buildWidth != width || buildPixelsPerUnit != pixelsPerUnit) {
             BuildGui(width);
         }
 
@@ -144,9 +145,8 @@ public sealed partial class ImGui : IDisposable, IPanel {
             this.parent = parent;
         }
 
-        pixelsPerUnit = surface.pixelsPerUnit;
-
-        if (IsRebuildRequired() || buildWidth != position.Width) {
+        this.surface = surface;
+        if (IsRebuildRequired() || buildWidth != position.Width || pixelsPerUnit != buildPixelsPerUnit) {
             BuildGui(position.Width);
         }
 
@@ -155,10 +155,8 @@ public sealed partial class ImGui : IDisposable, IPanel {
 
     private static readonly List<(SDL.SDL_Rect, RectangleBorder)> borders = [];
     internal void InternalPresent(DrawingSurface surface, Rect position, Rect screenClip) {
-        if (surface.window != null) {
-            window = surface.window;
-            window.SetNextRepaint(nextRebuildTimer);
-        }
+        this.surface = surface;
+        window?.SetNextRepaint(nextRebuildTimer);
 
         nint renderer = surface.renderer;
         SDL.SDL_Rect prevClip = default;

--- a/Yafc.UI/ImGui/ImGuiBuilding.cs
+++ b/Yafc.UI/ImGui/ImGuiBuilding.cs
@@ -249,6 +249,7 @@ public partial class ImGui {
         }
 
         buildWidth = width;
+        buildPixelsPerUnit = pixelsPerUnit;
         nextRebuildTimer = long.MaxValue;
         rebuildRequested = false;
         ClearDrawCommandList();

--- a/Yafc.UI/ImGui/ImGuiBuilding.cs
+++ b/Yafc.UI/ImGui/ImGuiBuilding.cs
@@ -76,7 +76,7 @@ public partial class ImGui {
         }
 
         panels.Add(new DrawCommand<IPanel>(rect, panel, 0));
-        _ = panel.CalculateState(rect.Width, pixelsPerUnit);
+        _ = panel.CalculateState(rect.Width);
     }
 
     private void ClearDrawCommandList() {

--- a/Yafc.UI/ImGui/ScrollArea.cs
+++ b/Yafc.UI/ImGui/ScrollArea.cs
@@ -50,7 +50,7 @@ public abstract class Scrollable(bool vertical, bool horizontal, bool collapsibl
 
         if (gui.isBuilding) {
             // Calculate required size, including padding if needed
-            requiredContentSize = MeasureContent(width, gui);
+            requiredContentSize = MeasureContent(width);
 
             if (requiredContentSize.Y > availableHeight && useBottomPadding) {
                 requiredContentSize.Y += BottomPaddingInPixels / gui.pixelsPerUnit;
@@ -162,7 +162,7 @@ public abstract class Scrollable(bool vertical, bool horizontal, bool collapsibl
 
     ///<summary>This method is called when the required area of the <see cref="Scrollable"/> for the provided <paramref name="width"/> is needed.</summary>
     /// <returns>The required area of the contents of the <see cref="Scrollable"/>.</returns>
-    public abstract Vector2 MeasureContent(float width, ImGui gui);
+    public abstract Vector2 MeasureContent(float width);
 
     public bool KeyDown(SDL.SDL_Keysym key) {
         if (gui?.enableDrawing != true) {
@@ -292,7 +292,7 @@ public abstract class ScrollAreaBase : Scrollable {
     public void RebuildContents() => contents.Rebuild();
 
     ///<summary>Calculates the content dimensions by (re)building the contents using <see cref="BuildContents"/></summary>
-    public override Vector2 MeasureContent(float width, ImGui gui) => contents.CalculateState(width, gui.pixelsPerUnit);
+    public override Vector2 MeasureContent(float width) => contents.CalculateState(width);
 }
 
 ///<summary>Area with scrollbars, which will be visible if it does not fit in the parent area in order to let the user fully view the content of the area.</summary>

--- a/Yafc/Widgets/MainScreenTabBar.cs
+++ b/Yafc/Widgets/MainScreenTabBar.cs
@@ -152,7 +152,7 @@ public class MainScreenTabBar {
         switch (gui.action) {
             case ImGuiAction.Build:
                 gui.DrawPanel(rect, tabs);
-                var measuredSize = tabs.CalculateState(0f, gui.pixelsPerUnit);
+                var measuredSize = tabs.CalculateState(0f);
                 maxScroll = MathF.Max(0f, measuredSize.X - rect.Width);
                 break;
             case ImGuiAction.MouseScroll:

--- a/Yafc/Widgets/PseudoScreen.cs
+++ b/Yafc/Widgets/PseudoScreen.cs
@@ -27,7 +27,7 @@ public abstract class PseudoScreen : IKeyboardFocus {
 
     public void Build(ImGui gui, Vector2 screenSize) {
         if (gui.isBuilding) {
-            var contentSize = contents.CalculateState(width, gui.pixelsPerUnit);
+            var contentSize = contents.CalculateState(width);
             var position = (screenSize - contentSize) / 2;
             Rect rect = new Rect(position, contentSize);
             gui.DrawPanel(rect, contents);

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -304,7 +304,7 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
             }
 
             if (pageSearch.query != null && gui.isBuilding) {
-                var searchSize = searchGui.CalculateState(30, gui.pixelsPerUnit);
+                var searchSize = searchGui.CalculateState(30);
                 gui.DrawPanel(new Rect(pageVisibleSize.X - searchSize.X, usedHeaderSpace, searchSize.X, searchSize.Y), searchGui);
             }
         }

--- a/Yafc/Workspace/ProjectPageView.cs
+++ b/Yafc/Workspace/ProjectPageView.cs
@@ -48,12 +48,12 @@ public abstract class ProjectPageView : Scrollable {
         if (gui.isBuilding) {
             gui.spacing = 0f;
             var position = gui.AllocateRect(0f, 0f, 0f).Position;
-            var headerSize = headerContent.CalculateState(visibleSize.X - ScrollbarSize, gui.pixelsPerUnit);
+            var headerSize = headerContent.CalculateState(visibleSize.X - ScrollbarSize);
             contentWidth = headerSize.X;
             headerHeight = headerSize.Y;
             var headerRect = gui.AllocateRect(visibleSize.X, headerHeight);
             position.Y += headerHeight;
-            var contentSize = bodyContent.CalculateState(visibleSize.X - ScrollbarSize, gui.pixelsPerUnit);
+            var contentSize = bodyContent.CalculateState(visibleSize.X - ScrollbarSize);
 
             if (contentSize.X > contentWidth) {
                 contentWidth = contentSize.X;
@@ -70,7 +70,7 @@ public abstract class ProjectPageView : Scrollable {
         base.Build(gui, visibleSize.Y - headerHeight, true);
     }
 
-    public override Vector2 MeasureContent(float _, ImGui gui) => new Vector2(contentWidth, contentHeight);
+    public override Vector2 MeasureContent(float _) => new Vector2(contentWidth, contentHeight);
 
     protected override void PositionContent(ImGui gui, Rect viewport) {
         headerContent.offset = new Vector2(-scrollX, 0);


### PR DESCRIPTION
## Overview

This PR improves how DPI scaling is handled on Windows, macOS, and Linux.

The primary methods of achieving this are:

* Windows: `SetProcessDpiAwareness(PROCESS_PER_MONITOR_DPI_AWARE)` → `SDL_HINT_WINDOWS_DPI_SCALING` 
  * The original Per-Monitor DPI awareness mode was introduced with Windows 8.1, whereas the SDL hint is not only simpler, but uses the superior Per-Monitor V2 introduced in Windows 10.
* macOS/Linux: `SDL_WINDOW_ALLOW_HIGHDPI` flag added to all SDL windows. This allows SDL to create pixel buffers larger than the window size reported by SDL.

The introduction of these flags has the side-effect of disconnecting the SDL coordinate system (used for window sizes and mouse events) from the size of the target pixel buffer.

To refer to this new coordinate system, the code uses the term DIPs (Density-Independent Pixels). Other terms used in high DPI contexts are logical units (not used due to YAFC having an existing "units" system) and points (used in Apple ecosystems, but can be confused with typographical contexts), so DIPs (used by Microsoft and Android) is the best choice.

Importantly, this approach mirrors how high DPI is handled in SDL3, hopefully paving the way for future migration. There is a documentation regarding [high DPI support on the SDL3 wiki](https://wiki.libsdl.org/SDL3/README-highdpi).

Fixes: #496, #639.

## Changes

* Much improved support on Windows for split-DPI, multi-monitor systems.
  * Windows automatically resizes windows dragged to a monitor with a different display scale, instead of YAFC updating its window size manually.
  * Minimum window size is updated (automatically) when moved to a window with a different display scale.
  * Window decorations are resized automatically when moved to a window with a different display scale.
* Drops reliance on `SDL_GetDisplayDPI` for calculating pixel density - per guidance on the [SDL2 wiki](https://wiki.libsdl.org/SDL2/SDL_GetDisplayDPI) - obviating the need to manually workaround EDID discrepancies.
* Refactors `pixelsPerUnit` properties for surface and `ImGui` instances by delegating to the owning window, removing the need for manual state synchronization.

## 🧪 Testing
- [x] **Windows:** Tested on my split-DPI, multi-monitor workstation.
- [x] **Linux (Wayland, sdl2-compat):** Tested and verified high DPI support on Fedora with sdl2-compat.
- [ ] **Linux (Wayland, sdl2):** _Pending_
- [ ] **Linux (X11):** _Pending_
- [ ] **macOS:** _Pending_

As this PR removes the workaround for misconfigured EDID values, it would be worth testing on a system previously affected by #255.