### PR TITLE
fix: Windows libs being copied to non-Windows builds

### DIFF
--- a/Yafc.Model.Tests/Yafc.Model.Tests.csproj
+++ b/Yafc.Model.Tests/Yafc.Model.Tests.csproj
@@ -20,15 +20,19 @@
   </ItemGroup>
 
   <ItemGroup>
-    <ContentWithTargetPath Include="..\Yafc\lib\windows\lua*" Condition="('$(RuntimeIdentifier)' == 'win-x64') Or ('$(OS)' == 'Windows_NT')">
+    <ContentWithTargetPath Include="..\Yafc\lib\windows\lua*" Condition="'$(RuntimeIdentifier)' == 'win-x64' Or ('$(RuntimeIdentifier)' == '' And $([MSBuild]::IsOSPlatform('Windows')))">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <TargetPath>%(Filename)%(Extension)</TargetPath>
     </ContentWithTargetPath>
-    <ContentWithTargetPath Include="..\Yafc\lib\osx\lua*" Condition="'$(RuntimeIdentifier)' == 'osx-x64'">
+    <ContentWithTargetPath Include="..\Yafc\lib\osx\liblua*" Condition="'$(RuntimeIdentifier)' == 'osx-x64' Or ('$(RuntimeIdentifier)' == '' And $([MSBuild]::IsOSPlatform('OSX')) And '$(SystemArchitecture)' == 'x64')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <TargetPath>%(Filename)%(Extension)</TargetPath>
     </ContentWithTargetPath>
-    <ContentWithTargetPath Include="..\Yafc\lib\linux\lua*" Condition="'$(RuntimeIdentifier)' == 'linux-x64'">
+    <ContentWithTargetPath Include="..\Yafc\lib\osx-arm64\liblua*" Condition="'$(RuntimeIdentifier)' == 'osx-arm64' Or ('$(RuntimeIdentifier)' == '' And $([MSBuild]::IsOSPlatform('OSX')) And '$(SystemArchitecture)' == 'arm64')">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+      <TargetPath>%(Filename)%(Extension)</TargetPath>
+    </ContentWithTargetPath>
+    <ContentWithTargetPath Include="..\Yafc\lib\linux\liblua*" Condition="'$(RuntimeIdentifier)' == 'linux-x64' Or ('$(RuntimeIdentifier)' == '' And $([MSBuild]::IsOSPlatform('Linux')))">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <TargetPath>%(Filename)%(Extension)</TargetPath>
     </ContentWithTargetPath>

--- a/Yafc/Yafc.csproj
+++ b/Yafc/Yafc.csproj
@@ -16,19 +16,19 @@
     <None Update="image.ico">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
-    <ContentWithTargetPath Include="lib\windows\*" Condition="('$(RuntimeIdentifier)' == 'win-x64') Or ('$(OS)' == 'Windows_NT')">
+    <ContentWithTargetPath Include="lib\windows\*" Condition="'$(RuntimeIdentifier)' == 'win-x64' Or ('$(RuntimeIdentifier)' == '' And $([MSBuild]::IsOSPlatform('Windows')))">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <TargetPath>%(Filename)%(Extension)</TargetPath>
     </ContentWithTargetPath>
-    <ContentWithTargetPath Include="lib\osx\*" Condition="'$(RuntimeIdentifier)' == 'osx-x64'">
+    <ContentWithTargetPath Include="lib\osx\*" Condition="'$(RuntimeIdentifier)' == 'osx-x64' Or ('$(RuntimeIdentifier)' == '' And $([MSBuild]::IsOSPlatform('OSX')) And '$(SystemArchitecture)' == 'x64')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <TargetPath>%(Filename)%(Extension)</TargetPath>
     </ContentWithTargetPath>
-    <ContentWithTargetPath Include="lib\osx-arm64\*" Condition="'$(RuntimeIdentifier)' == 'osx-arm64'">
+    <ContentWithTargetPath Include="lib\osx-arm64\*" Condition="'$(RuntimeIdentifier)' == 'osx-arm64' Or ('$(RuntimeIdentifier)' == '' And $([MSBuild]::IsOSPlatform('OSX')) And '$(SystemArchitecture)' == 'arm64')">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <TargetPath>%(Filename)%(Extension)</TargetPath>
     </ContentWithTargetPath>
-    <ContentWithTargetPath Include="lib\linux\*" Condition="'$(RuntimeIdentifier)' == 'linux-x64'">
+    <ContentWithTargetPath Include="lib\linux\*" Condition="'$(RuntimeIdentifier)' == 'linux-x64' Or ('$(RuntimeIdentifier)' == '' And $([MSBuild]::IsOSPlatform('Linux')))">
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
       <TargetPath>%(Filename)%(Extension)</TargetPath>
     </ContentWithTargetPath>


### PR DESCRIPTION
Fix MSBuild copying Windows libs to every build (when publishing on Windows).

The `'$(OS)' == 'Windows_NT'` condition was always passing when building on Windows, so files matching `lib/windows/*` were getting copied to all builds, even macOS/Linux releases.

I've tested this config on Windows using `dotnet publish` with and without specifying a `--runtime` argument to ensure the right libs are copied. I have not tested building on macOS/Linux without the `--runtime` argument, but the build conditions support that for completeness.