### PR TITLE
fix: Yafc.Model: Account for machine base quality in recipe calculations

### DIFF
--- a/Yafc.Model/Model/RecipeParameters.cs
+++ b/Yafc.Model/Model/RecipeParameters.cs
@@ -176,6 +176,7 @@ internal class RecipeParameters(float recipeTime, float fuelUsagePerSecondPerBui
             activeEffects.productivity += productivity;
             activeEffects.speed += speed;
             activeEffects.consumption += consumption;
+            activeEffects.quality += entity.target.effectReceiver.baseEffect.quality;
 
             if (recipe.target is Recipe { maximumProductivity: float maxProd } && activeEffects.productivity > maxProd) {
                 warningFlags |= WarningFlags.ExcessProductivity;

--- a/Yafc/Data/locale/en/yafc.cfg
+++ b/Yafc/Data/locale/en/yafc.cfg
@@ -69,6 +69,7 @@ map-generation-density-unknown=Generates on map (density unknown)
 entity-crafts=Crafts
 entity-crafting-speed=Crafting speed: __1__
 entity-crafting-productivity=Crafting productivity: __1__
+entity-crafting-quality=Crafting quality: __1__
 entity-energy-consumption=Energy consumption: __1__
 entity-module-slots=Module slots: __1__
 ; __1__ is the list, and __2__ is the length of the list

--- a/Yafc/Widgets/ObjectTooltip.cs
+++ b/Yafc/Widgets/ObjectTooltip.cs
@@ -251,6 +251,9 @@ doneDrawing:;
                     if (baseEffect.productivity != 0f) {
                         gui.BuildText(LSs.EntityCraftingProductivity.L(DataUtils.FormatAmount(baseEffect.productivity, UnitOfMeasure.Percent)));
                     }
+                    if (baseEffect.quality != 0f) {
+                        gui.BuildText(LSs.EntityCraftingQuality.L(DataUtils.FormatAmount(baseEffect.quality, UnitOfMeasure.Percent)));
+                    }
                     if (baseEffect.consumption != 0f) {
                         gui.BuildText(LSs.EntityEnergyConsumption.L(DataUtils.FormatAmount(baseEffect.consumption, UnitOfMeasure.Percent)));
                     }

--- a/changelog.txt
+++ b/changelog.txt
@@ -31,6 +31,7 @@ Date:
         - Don't log an exception when a cache file is simply absent.
         - Show the per-cycle amount for every science pack in a technology tooltip, instead of only the first.
         - Fix text disappearing on the welcome screen and other secondary windows.
+        - Account for machine base quality in recipe calculations.
     Internal changes:
         - Upgrade to .NET 10.
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
YAFC currently completely ignores machine base quality, so when, say, it calculates with Maraxsis Hydro plants, it will not account for the 50% quality.

Fixes #428 

Before:
<img width="2494" height="1571" alt="Screenshot From 2026-07-15 09-07-35" src="https://github.com/user-attachments/assets/74635714-1ae8-420f-855d-316bc86a6d13" />

After:
<img width="2494" height="1571" alt="Screenshot From 2026-07-15 09-08-26" src="https://github.com/user-attachments/assets/c86bc28b-2d2f-4443-8d40-732ec8573393" />
