### PR TITLE
Replace PseudoScreen static downscaling with semi-transparent backdrop

### DIFF
--- a/Yafc.UI/Rendering/AlphaRect.cs
+++ b/Yafc.UI/Rendering/AlphaRect.cs
@@ -1,0 +1,16 @@
+﻿using SDL2;
+
+namespace Yafc.UI;
+
+/// <summary>Draw a solid rectangle with optionally configurable transparency.</summary>
+/// <remarks>
+/// Due to <see cref="ImGui"/>'s bucketed rendering, <c>AlphaRect</c> renderables will be drawn at a z-index higher than
+/// that of standard <see cref="ImGui"/> rectangles.
+/// </remarks>
+public class AlphaRect(byte alpha = 255) : IRenderable {
+    public void Render(DrawingSurface surface, SDL.SDL_Rect position, SDL.SDL_Color color) {
+        SDL.SDL_SetRenderDrawBlendMode(surface.renderer, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
+        SDL.SDL_SetRenderDrawColor(surface.renderer, color.r, color.g, color.b, (byte)(color.a * alpha / 255));
+        SDL.SDL_RenderFillRect(surface.renderer, ref position);
+    }
+}

--- a/Yafc/Widgets/PseudoScreen.cs
+++ b/Yafc/Widgets/PseudoScreen.cs
@@ -7,6 +7,7 @@ namespace Yafc;
 
 // Pseudo screen is not an actual screen, it is a panel shown in the middle of the main screen
 public abstract class PseudoScreen : IKeyboardFocus {
+    public readonly ImGui backdrop;
     public readonly ImGui contents;
     protected readonly float width;
     protected bool opened;
@@ -17,21 +18,36 @@ public abstract class PseudoScreen : IKeyboardFocus {
 
     protected PseudoScreen(float width = 40f) {
         this.width = width;
+        backdrop = new ImGui(BuildBackdrop, default);
         contents = new ImGui(Build, ImGuiUtils.DefaultScreenPadding) {
-            boxColor = SchemeColor.PureBackground
+            boxColor = SchemeColor.PureBackground,
+            boxShadow = RectangleBorder.Full
         };
     }
 
     public virtual void Open() => opened = true;
     public abstract void Build(ImGui gui);
 
+    private Vector2 screenSize;
+
+    protected void BuildBackdrop(ImGui gui) {
+        if (gui.isBuilding) {
+            gui.DrawRenderable(new Rect(default, screenSize), new AlphaRect(200), SchemeColor.PureBackground);
+        }
+    }
+
     public void Build(ImGui gui, Vector2 screenSize) {
         if (gui.isBuilding) {
+            if (screenSize != this.screenSize) {
+                this.screenSize = screenSize;
+                backdrop.Rebuild();
+            }
+            gui.DrawPanel(new Rect(default, screenSize), backdrop);
+
             var contentSize = contents.CalculateState(width);
             var position = (screenSize - contentSize) / 2;
-            Rect rect = new Rect(position, contentSize);
-            gui.DrawPanel(rect, contents);
-            gui.DrawRectangle(rect, SchemeColor.None, RectangleBorder.Full);
+            var contentsRect = new Rect(position, contentSize);
+            gui.DrawPanel(contentsRect, contents);
         }
     }
 
@@ -61,7 +77,10 @@ public abstract class PseudoScreen : IKeyboardFocus {
         MainScreen.Instance.ClosePseudoScreen(this);
     }
 
-    public void Rebuild() => contents.Rebuild();
+    public void Rebuild() {
+        backdrop.Rebuild();
+        contents.Rebuild();
+    }
 
     public virtual bool KeyDown(SDL.SDL_Keysym key) {
         if (key.scancode == SDL.SDL_Scancode.SDL_SCANCODE_ESCAPE) {

--- a/Yafc/Windows/DependencyExplorer.cs
+++ b/Yafc/Windows/DependencyExplorer.cs
@@ -36,7 +36,7 @@ public class DependencyExplorer : PseudoScreen {
         this.current = current;
     }
 
-    public static void Show(FactorioObject target) => _ = MainScreen.Instance.ShowPseudoScreen(new DependencyExplorer(target));
+    public static void Show(FactorioObject target) => MainScreen.Instance.ShowPseudoScreen(new DependencyExplorer(target));
 
     private void DrawFactorioObject(ImGui gui, FactorioId id) {
         FactorioObject obj = Database.objects[id];

--- a/Yafc/Windows/ErrorListPanel.cs
+++ b/Yafc/Windows/ErrorListPanel.cs
@@ -21,7 +21,7 @@ public class ErrorListPanel : PseudoScreen {
         }
     }
 
-    public static void Show(ErrorCollector collector) => _ = MainScreen.Instance.ShowPseudoScreen(new ErrorListPanel(collector));
+    public static void Show(ErrorCollector collector) => MainScreen.Instance.ShowPseudoScreen(new ErrorListPanel(collector));
     public override void Build(ImGui gui) {
         if (collector.severity == ErrorSeverity.Critical) {
             BuildHeader(gui, LSs.ErrorLoadingFailed);

--- a/Yafc/Windows/HeaderRowSettingsPanel.cs
+++ b/Yafc/Windows/HeaderRowSettingsPanel.cs
@@ -31,7 +31,8 @@ public class HeaderRowSettingsPanel : PseudoScreen {
         }
     }
 
-    public static void Show(RecipeRow? row, Action<string?, FactorioObject?>? callback = null) => _ = MainScreen.Instance.ShowPseudoScreen(new HeaderRowSettingsPanel(row, callback));
+    public static void Show(RecipeRow? row, Action<string?, FactorioObject?>? callback = null)
+        => MainScreen.Instance.ShowPseudoScreen(new HeaderRowSettingsPanel(row, callback));
 
     public override void Build(ImGui gui) {
         gui.spacing = 3f;

--- a/Yafc/Windows/ImageSharePanel.cs
+++ b/Yafc/Windows/ImageSharePanel.cs
@@ -21,7 +21,7 @@ public class ImageSharePanel : PseudoScreen {
         header = name + " (" + surfaceData.w + "x" + surfaceData.h + ")";
         cleanupCallback = surface.Dispose;
 
-        _ = MainScreen.Instance.ShowPseudoScreen(this);
+        MainScreen.Instance.ShowPseudoScreen(this);
     }
 
     public override void Build(ImGui gui) {

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -561,8 +561,15 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
     }
 
     public void ShowPseudoScreen(PseudoScreen screen) {
+        if (!Ui.IsMainThread()) {
+            // If we're not on the UI thread, relocate there.
+            // This is hopefully unnecessary (the Rebuild calls were not protected), but there are too many calls to quickly validate.
+            Ui.DispatchInMainThread(x => ShowPseudoScreen((PseudoScreen)x!), screen);
+            return;
+        }
+
         if (topScreen == null) {
-            Ui.DispatchInMainThread(x => fadeDrawer.CreateDownscaledImage(), null);
+            fadeDrawer.CreateDownscaledImage();
         }
         project.undo.Suspend();
         screen.Rebuild();

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -80,7 +80,7 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
         DataUtils.SetupForProject(project);
         this.project = project;
         if (project.justCreated) {
-            _ = ShowPseudoScreen(new MilestonesPanel());
+            ShowPseudoScreen(new MilestonesPanel());
             project.AssureFirstPage();
         }
 
@@ -406,7 +406,7 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
 
         BuildSubHeader(gui, LSs.MenuHeaderTools);
         if (gui.BuildContextMenuButton(LSs.Milestones) && gui.CloseDropdown()) {
-            _ = ShowPseudoScreen(new MilestonesPanel());
+            ShowPseudoScreen(new MilestonesPanel());
         }
 
         if (gui.BuildContextMenuButton(LSs.Preferences) && gui.CloseDropdown()) {
@@ -560,7 +560,7 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
         ShowTooltip(objectTooltip);
     }
 
-    public bool ShowPseudoScreen(PseudoScreen screen) {
+    public void ShowPseudoScreen(PseudoScreen screen) {
         if (topScreen == null) {
             Ui.DispatchInMainThread(x => fadeDrawer.CreateDownscaledImage(), null);
         }
@@ -569,7 +569,6 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
         pseudoScreens.Insert(0, screen);
         screen.Open();
         rootGui.Rebuild();
-        return true;
     }
 
     public void ClosePseudoScreen(PseudoScreen screen) {

--- a/Yafc/Windows/MainScreen.cs
+++ b/Yafc/Windows/MainScreen.cs
@@ -25,8 +25,6 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
     private readonly List<PseudoScreen> pseudoScreens = [];
     private readonly VirtualScrollList<ProjectPage> allPages;
     private readonly MainScreenTabBar tabBar;
-    private readonly FadeDrawer fadeDrawer = new FadeDrawer();
-
     private PseudoScreen? topScreen;
     public Project project { get; private set; }
     private ProjectPage? _activePage;
@@ -225,29 +223,23 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
     }
 
     protected override void BuildContent(ImGui gui) {
-        if (pseudoScreens.Count > 0) {
-            var top = pseudoScreens[0];
-            if (gui.isBuilding) {
-                gui.DrawRenderable(new Rect(default, size), fadeDrawer, SchemeColor.None);
-            }
+        BuildTabBar(gui);
+        BuildPage(gui);
 
-            if (top != topScreen) {
-                topScreen = top;
-                _ = InputSystem.Instance.SetDefaultKeyboardFocus(top);
+        if (pseudoScreens.Count > 0) {
+            if (topScreen != pseudoScreens[0]) {
+                topScreen = pseudoScreens[0];
+                InputSystem.Instance.SetDefaultKeyboardFocus(topScreen);
             }
-            top.Build(gui, size);
+            topScreen.Build(gui, size);
         }
-        else {
-            if (topScreen != null) {
-                project.undo.Resume();
-                _ = InputSystem.Instance.SetDefaultKeyboardFocus(this);
-                topScreen = null;
-                if (analysisUpdatePending) {
-                    ReRunAnalysis();
-                }
+        else if (topScreen != null) {
+            topScreen = null;
+            InputSystem.Instance.SetDefaultKeyboardFocus(this);
+            project.undo.Resume();
+            if (analysisUpdatePending) {
+                ReRunAnalysis();
             }
-            BuildTabBar(gui);
-            BuildPage(gui);
         }
     }
 
@@ -568,9 +560,6 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
             return;
         }
 
-        if (topScreen == null) {
-            fadeDrawer.CreateDownscaledImage();
-        }
         project.undo.Suspend();
         screen.Rebuild();
         pseudoScreens.Insert(0, screen);
@@ -736,42 +725,6 @@ public partial class MainScreen : WindowMain, IKeyboardFocus, IProgress<(string,
     public bool KeyUp(SDL.SDL_Keysym key) => true;
 
     public void FocusChanged(bool focused) { }
-
-    private class FadeDrawer : IRenderable {
-        private SDL.SDL_Rect srcRect;
-        private TextureHandle blurredFade;
-
-        public void CreateDownscaledImage() {
-            nint renderer = Instance.surface!.renderer; // null-forgiving: surface has been set earlier in the render loop.
-            blurredFade = blurredFade.Destroy();
-            var texture = Instance.surface.BeginRenderToTexture(out var size);
-            Instance.MainRender();
-            Instance.surface.EndRenderToTexture();
-            for (int i = 0; i < 2; i++) {
-                SDL.SDL_Rect halfSize = new SDL.SDL_Rect() { w = size.w / 2, h = size.h / 2 };
-                var halfTexture = Instance.surface.CreateTexture(SDL.SDL_PIXELFORMAT_RGBA8888, (int)SDL.SDL_TextureAccess.SDL_TEXTUREACCESS_TARGET, halfSize.w, halfSize.h);
-                _ = SDL.SDL_SetRenderTarget(renderer, halfTexture.handle);
-                var bgColor = SchemeColor.PureBackground.ToSdlColor();
-                _ = SDL.SDL_SetRenderDrawColor(renderer, bgColor.r, bgColor.g, bgColor.b, bgColor.a);
-                _ = SDL.SDL_RenderClear(renderer);
-                _ = SDL.SDL_SetTextureBlendMode(texture.handle, SDL.SDL_BlendMode.SDL_BLENDMODE_BLEND);
-                _ = SDL.SDL_SetTextureAlphaMod(texture.handle, 120);
-                _ = SDL.SDL_RenderCopy(renderer, texture.handle, ref size, ref halfSize);
-                _ = texture.Destroy();
-                texture = halfTexture;
-                size = halfSize;
-            }
-            _ = SDL.SDL_SetRenderTarget(renderer, IntPtr.Zero);
-            srcRect = size;
-            blurredFade = texture;
-        }
-
-        public void Render(DrawingSurface surface, SDL.SDL_Rect position, SDL.SDL_Color color) {
-            if (blurredFade.valid) {
-                _ = SDL.SDL_RenderCopy(surface.renderer, blurredFade.handle, ref srcRect, ref position);
-            }
-        }
-    }
 
     public void Report((string, string) value) => logger.Information("Status: {primary}, {secondary}", value.Item1, value.Item2); // TODO
 

--- a/Yafc/Windows/MessageBox.cs
+++ b/Yafc/Windows/MessageBox.cs
@@ -19,7 +19,7 @@ public class MessageBox : PseudoScreenWithResult<bool> {
 
     public static void Show(Action<bool, bool>? result, string title, string message, string yes, string? no) {
         MessageBox instance = new MessageBox(title, message, yes, no) { completionCallback = result };
-        _ = MainScreen.Instance.ShowPseudoScreen(instance);
+        MainScreen.Instance.ShowPseudoScreen(instance);
     }
 
     public static void Show(string title, string message, string yes) => Show(null, title, message, yes, null);

--- a/Yafc/Windows/MilestonesEditor.cs
+++ b/Yafc/Windows/MilestonesEditor.cs
@@ -26,7 +26,7 @@ public class MilestonesEditor : PseudoScreen {
         milestoneList.data = Project.current.settings.milestones;
     }
 
-    public static void Show() => _ = MainScreen.Instance.ShowPseudoScreen(Instance);
+    public static void Show() => MainScreen.Instance.ShowPseudoScreen(Instance);
 
     private void MilestoneDrawer(ImGui gui, FactorioObject element, int index) {
         using (gui.EnterRow()) {

--- a/Yafc/Windows/NeverEnoughItemsPanel.cs
+++ b/Yafc/Windows/NeverEnoughItemsPanel.cs
@@ -406,7 +406,7 @@ public class NeverEnoughItemsPanel : PseudoScreen, IComparer<NeverEnoughItemsPan
             return;
         }
         Instance.SetItem(goods);
-        _ = MainScreen.Instance.ShowPseudoScreen(Instance);
+        MainScreen.Instance.ShowPseudoScreen(Instance);
     }
     int IComparer<RecipeEntry>.Compare(RecipeEntry x, RecipeEntry y) {
         if (x.entryStatus != y.entryStatus) {

--- a/Yafc/Windows/PreferencesScreen.cs
+++ b/Yafc/Windows/PreferencesScreen.cs
@@ -282,11 +282,11 @@ public class PreferencesScreen : PseudoScreen {
 
     public static void ShowProgression() {
         Instance.tabControl.SetActivePage(PROGRESSION_PAGE);
-        _ = MainScreen.Instance.ShowPseudoScreen(Instance);
+        MainScreen.Instance.ShowPseudoScreen(Instance);
     }
     public static void ShowGeneral() {
         Instance.tabControl.SetActivePage(GENERAL_PAGE);
-        _ = MainScreen.Instance.ShowPseudoScreen(Instance);
+        MainScreen.Instance.ShowPseudoScreen(Instance);
     }
-    public static void ShowPreviousState() => _ = MainScreen.Instance.ShowPseudoScreen(Instance);
+    public static void ShowPreviousState() => MainScreen.Instance.ShowPseudoScreen(Instance);
 }

--- a/Yafc/Windows/ProjectPageSettingsPanel.cs
+++ b/Yafc/Windows/ProjectPageSettingsPanel.cs
@@ -38,7 +38,8 @@ public class ProjectPageSettingsPanel : PseudoScreen {
         }
     }
 
-    public static void Show(ProjectPage? page, Action<string, FactorioObject?>? callback = null) => _ = MainScreen.Instance.ShowPseudoScreen(new ProjectPageSettingsPanel(page, callback));
+    public static void Show(ProjectPage? page, Action<string, FactorioObject?>? callback = null)
+        => MainScreen.Instance.ShowPseudoScreen(new ProjectPageSettingsPanel(page, callback));
 
     public override void Build(ImGui gui) {
         gui.spacing = 3f;

--- a/Yafc/Windows/SelectObjectPanel.cs
+++ b/Yafc/Windows/SelectObjectPanel.cs
@@ -60,7 +60,7 @@ public abstract class SelectObjectPanel<TResult, TDisplay> : PseudoScreenWithRes
     protected void Select(IEnumerable<TDisplay> list, bool allowNone, ObjectSelectOptions<TDisplay> options, Action<TDisplay?> selectItem,
         Action<TResult?, Action<TDisplay?>> mapResult, string? noneTooltip = null) {
 
-        _ = MainScreen.Instance.ShowPseudoScreen(this);
+        MainScreen.Instance.ShowPseudoScreen(this);
         this.options = options as QualitySelectOptions<TDisplay>;
         this.noneTooltip = noneTooltip;
         header = options.Header;

--- a/Yafc/Windows/ShoppingListScreen.cs
+++ b/Yafc/Windows/ShoppingListScreen.cs
@@ -52,7 +52,7 @@ public class ShoppingListScreen : PseudoScreen {
         _ = gui.BuildFactorioObjectButtonBackground(gui.lastRect, element.obj);
     }
 
-    public static void Show(List<RecipeRow> recipes) => _ = MainScreen.Instance.ShowPseudoScreen(new ShoppingListScreen(recipes));
+    public static void Show(List<RecipeRow> recipes) => MainScreen.Instance.ShowPseudoScreen(new ShoppingListScreen(recipes));
 
     private void RebuildData() {
         decomposed = false;

--- a/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleCustomizationScreen.cs
@@ -26,7 +26,7 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
                 recipe.RecordUndo().modules = builder?.Build(recipe);
             }
         };
-        _ = MainScreen.Instance.ShowPseudoScreen(Instance);
+        MainScreen.Instance.ShowPseudoScreen(Instance);
     }
 
     public static void Show(ProjectModuleTemplate template) {
@@ -39,7 +39,7 @@ public class ModuleCustomizationScreen : PseudoScreenWithResult<ModuleTemplateBu
                 template.RecordUndo().template = builder!.Build(template);
             }
         };
-        _ = MainScreen.Instance.ShowPseudoScreen(Instance);
+        MainScreen.Instance.ShowPseudoScreen(Instance);
     }
 
     public override void Build(ImGui gui) {

--- a/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleFillerParametersScreen.cs
@@ -15,7 +15,7 @@ public class ModuleFillerParametersScreen : PseudoScreen {
     private readonly ModuleFillerParameters modules;
     private readonly VirtualScrollList<KeyValuePair<EntityCrafter, BeaconOverrideConfiguration>> overrideList;
 
-    public static void Show(ModuleFillerParameters parameters) => _ = MainScreen.Instance.ShowPseudoScreen(new ModuleFillerParametersScreen(parameters));
+    public static void Show(ModuleFillerParameters parameters) => MainScreen.Instance.ShowPseudoScreen(new ModuleFillerParametersScreen(parameters));
 
     private ModuleFillerParametersScreen(ModuleFillerParameters modules) {
         this.modules = modules;

--- a/Yafc/Workspace/ProductionTable/ModuleTemplateConfiguration.cs
+++ b/Yafc/Workspace/ProductionTable/ModuleTemplateConfiguration.cs
@@ -16,7 +16,7 @@ public class ModuleTemplateConfiguration : PseudoScreen {
 
     public static void Show() {
         Instance.RefreshList();
-        _ = MainScreen.Instance.ShowPseudoScreen(Instance);
+        MainScreen.Instance.ShowPseudoScreen(Instance);
     }
 
     private void RefreshList() {

--- a/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionLinkSummaryScreen.cs
@@ -287,7 +287,7 @@ public class ProductionLinkSummaryScreen : PseudoScreen, IComparer<(RecipeRow ro
     }
 
 
-    public static void Show(ProductionLink link) => _ = MainScreen.Instance.ShowPseudoScreen(new ProductionLinkSummaryScreen(link));
+    public static void Show(ProductionLink link) => MainScreen.Instance.ShowPseudoScreen(new ProductionLinkSummaryScreen(link));
 
     public int Compare((RecipeRow row, float flow) x, (RecipeRow row, float flow) y) => y.flow.CompareTo(x.flow);
 }

--- a/Yafc/Workspace/ProductionTable/ProductionTableView.cs
+++ b/Yafc/Workspace/ProductionTable/ProductionTableView.cs
@@ -87,7 +87,7 @@ public class ProductionTableView : ProjectPageView<ProductionTable> {
                         PreferencesScreen.ShowGeneral();
                     }
                     else if (row.warningFlags.HasFlag(WarningFlags.UselessQuality)) {
-                        _ = MainScreen.Instance.ShowPseudoScreen(new MilestonesPanel());
+                        MainScreen.Instance.ShowPseudoScreen(new MilestonesPanel());
                     }
                     else if (row.warningFlags.HasFlag(WarningFlags.ExcessProductivity)) {
                         PreferencesScreen.ShowProgression();

--- a/changelog.txt
+++ b/changelog.txt
@@ -22,8 +22,9 @@
 Version:
 Date:
     Features:
-        - Yafc will cache rendered icons to improve mod load times.
         - Support Factorio 2.1.
+        - Improved handling of split-DPI, multi-monitor systems on Windows.
+        - Yafc will cache rendered icons to improve mod load times.
     Fixes:
         - Don't show spoilage information (e.g. "always fresh") for non-spoilable recipe products.
         - Several improvements loading Exotic Space Industries:Remembrance and its dependencies.
@@ -32,6 +33,7 @@ Date:
         - Show the per-cycle amount for every science pack in a technology tooltip, instead of only the first.
         - Fix text disappearing on the welcome screen and other secondary windows.
         - Account for machine base quality in recipe calculations.
+        - Fix transparency of background overlay when opening the preferences screen, NEIE, etc.
     Internal changes:
         - Upgrade to .NET 10.
 ----------------------------------------------------------------------------------------------------------------------


### PR DESCRIPTION
`MainScreen` is no longer forced to halt its background layout when a `PseudoScreen` is open. The underlying UI continues to render, allowing elements to reposition or resize, menus to close, etc.

**Before**
<img width="1789" height="1307" alt="image" src="https://github.com/user-attachments/assets/07bd679b-4178-4612-b3df-bac6781b8756" />

**After**
<img width="1789" height="1307" alt="image" src="https://github.com/user-attachments/assets/5c0d1be8-d293-4f39-a012-c790e17896e2" />

@DaleStan These changes have been implemented on top of the commits you began working on in #672.