### PR TITLE
Fix: Handle slash inconsistency between some zip programs

### DIFF
--- a/Yafc.Parser.Tests/BackSlashTolerantZipArchiveTests.cs
+++ b/Yafc.Parser.Tests/BackSlashTolerantZipArchiveTests.cs
@@ -1,0 +1,114 @@
+using System.IO;
+using System.IO.Compression;
+using System.Text;
+
+namespace Yafc.Parser.Tests;
+
+public class BackslashTolerantZipArchiveTests : IDisposable
+{
+    static BackslashTolerantZipArchiveTests()
+    {
+        var ms = new MemoryStream();
+        using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            // clean entry
+            var clean = archive.CreateEntry("mod/info.json");
+            using (var s = clean.Open())
+                s.Write("clean"u8);
+            // dirty entry - using reflection to do rename to our testcase because ZipArchive normalizes FullName *facepalm*
+            var dirty = archive.CreateEntry("PLACEHOLDER");
+            using (var s = dirty.Open())
+                s.Write("dirty"u8);
+            RenameEntry(dirty, "asecretfolder\\info.json");
+        }
+        ms.Position = 0;
+        TestZip = ms;
+    }
+
+    public void Dispose()
+    {
+        TestZip.Position = 0;
+    }
+
+    /**
+    ZipArchiveEntry be sealed.
+    **/
+    static void RenameEntry(ZipArchiveEntry entry, string newName)
+    {
+        var nameField = typeof(ZipArchiveEntry).GetField(
+            "_storedEntryName",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance
+        );
+
+        var bytesField = typeof(ZipArchiveEntry).GetField(
+            "_storedEntryNameBytes",
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance
+        );
+
+        nameField!.SetValue(entry, newName);
+        bytesField!.SetValue(entry, Encoding.UTF8.GetBytes(newName));
+    }
+
+    public static readonly MemoryStream TestZip;
+
+    [Fact]
+    // It hurts my soul that I'm testing reflection for a test, but it felt too risky to trust it blindly. 
+    // So just ensuring the built-in logic of how ZipArchive handles duplicate names still throws during normalization
+    public void DuplicateEntryNames_AfterNormalization_Throws()
+    {
+        var ms = new MemoryStream();
+        using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
+        {
+            archive.CreateEntry("mod/info.json");
+            var dup = archive.CreateEntry("PLACEHOLDER");
+            using (var s = dup.Open())
+                s.Write("x"u8);
+            RenameEntry(dup, "mod\\info.json");
+        }
+        ms.Position = 0;
+
+        Assert.Throws<ArgumentException>(() => new BackslashTolerantZipArchive(ms));
+    }
+
+    [Fact]
+    public void FullName_IsNormalized()
+    {
+        TestZip.Position = 0;
+        using var archive = new BackslashTolerantZipArchive(TestZip, true);
+
+        Assert.Contains(archive.Entries, e => e.FullName == "mod/info.json");
+        Assert.DoesNotContain(archive.Entries, e => e.FullName.Contains('\\'));
+    }
+
+    [Fact]
+    public void GetEntry_NormalizesArgument()
+    {
+        using var archive = new BackslashTolerantZipArchive(TestZip, true);
+        Assert.NotNull(archive.GetEntry("mod/info.json"));
+        Assert.NotNull(archive.GetEntry("mod\\info.json"));
+    }
+
+    [Fact]
+    public void Dispose_ClosesUnderlyingStream_WhenLeaveOpenFalse()
+    {
+        var ms = new MemoryStream(TestZip.ToArray());
+        var archive = new BackslashTolerantZipArchive(ms, leaveOpen: false);
+        archive.Dispose();
+        Assert.Throws<ObjectDisposedException>(() => ms.ReadByte());
+    }
+
+    [Fact]
+    public void GetEntry_MissingEntry_ReturnsNull()
+    {
+        using var archive = new BackslashTolerantZipArchive(TestZip, leaveOpen: true);
+        Assert.Null(archive.GetEntry("nonexistent/file.lua"));
+    }
+
+    [Fact]
+    public void Entry_Name_IsAccessible()
+    {
+        using var archive = new BackslashTolerantZipArchive(TestZip, leaveOpen: true);
+        var entry = archive.GetEntry("mod/info.json")!;
+        Assert.Equal("info.json", entry.Name);
+    }
+}

--- a/Yafc.Parser.Tests/BackSlashTolerantZipArchiveTests.cs
+++ b/Yafc.Parser.Tests/BackSlashTolerantZipArchiveTests.cs
@@ -12,7 +12,7 @@ public class BackslashTolerantZipArchiveTests : IDisposable {
             var clean = archive.CreateEntry("mod/info.json");
             using (var s = clean.Open())
                 s.Write("clean"u8);
-            // dirty entry - using reflection to do rename to our testcase because ZipArchive normalizes FullName *facepalm*
+            // dirty entry - using reflection to do rename to our testcase because ZipArchive normalizes FullName (unlike powershell's compress-archive)
             var dirty = archive.CreateEntry("PLACEHOLDER");
             using (var s = dirty.Open())
                 s.Write("dirty"u8);
@@ -47,8 +47,7 @@ public class BackslashTolerantZipArchiveTests : IDisposable {
     public static readonly MemoryStream TestZip;
 
     [Fact]
-    // It hurts my soul that I'm testing reflection for a test, but it felt too risky to trust it blindly. 
-    // So just ensuring the built-in logic of how ZipArchive handles duplicate names still throws during normalization
+    // Ensuring ZipArchive handles duplicate names still throws during normalization
     public void DuplicateEntryNames_AfterNormalization_Throws() {
         var ms = new MemoryStream();
         using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true)) {

--- a/Yafc.Parser.Tests/BackSlashTolerantZipArchiveTests.cs
+++ b/Yafc.Parser.Tests/BackSlashTolerantZipArchiveTests.cs
@@ -1,16 +1,13 @@
-using System.IO;
+﻿using System.IO;
 using System.IO.Compression;
 using System.Text;
 
 namespace Yafc.Parser.Tests;
 
-public class BackslashTolerantZipArchiveTests : IDisposable
-{
-    static BackslashTolerantZipArchiveTests()
-    {
+public class BackslashTolerantZipArchiveTests : IDisposable {
+    static BackslashTolerantZipArchiveTests() {
         var ms = new MemoryStream();
-        using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
-        {
+        using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true)) {
             // clean entry
             var clean = archive.CreateEntry("mod/info.json");
             using (var s = clean.Open())
@@ -25,16 +22,14 @@ public class BackslashTolerantZipArchiveTests : IDisposable
         TestZip = ms;
     }
 
-    public void Dispose()
-    {
+    public void Dispose() {
         TestZip.Position = 0;
     }
 
     /**
     ZipArchiveEntry be sealed.
     **/
-    static void RenameEntry(ZipArchiveEntry entry, string newName)
-    {
+    static void RenameEntry(ZipArchiveEntry entry, string newName) {
         var nameField = typeof(ZipArchiveEntry).GetField(
             "_storedEntryName",
             System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance
@@ -54,11 +49,9 @@ public class BackslashTolerantZipArchiveTests : IDisposable
     [Fact]
     // It hurts my soul that I'm testing reflection for a test, but it felt too risky to trust it blindly. 
     // So just ensuring the built-in logic of how ZipArchive handles duplicate names still throws during normalization
-    public void DuplicateEntryNames_AfterNormalization_Throws()
-    {
+    public void DuplicateEntryNames_AfterNormalization_Throws() {
         var ms = new MemoryStream();
-        using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true))
-        {
+        using (var archive = new ZipArchive(ms, ZipArchiveMode.Create, leaveOpen: true)) {
             archive.CreateEntry("mod/info.json");
             var dup = archive.CreateEntry("PLACEHOLDER");
             using (var s = dup.Open())
@@ -71,8 +64,7 @@ public class BackslashTolerantZipArchiveTests : IDisposable
     }
 
     [Fact]
-    public void FullName_IsNormalized()
-    {
+    public void FullName_IsNormalized() {
         TestZip.Position = 0;
         using var archive = new BackslashTolerantZipArchive(TestZip, true);
 
@@ -81,16 +73,14 @@ public class BackslashTolerantZipArchiveTests : IDisposable
     }
 
     [Fact]
-    public void GetEntry_NormalizesArgument()
-    {
+    public void GetEntry_NormalizesArgument() {
         using var archive = new BackslashTolerantZipArchive(TestZip, true);
         Assert.NotNull(archive.GetEntry("mod/info.json"));
         Assert.NotNull(archive.GetEntry("mod\\info.json"));
     }
 
     [Fact]
-    public void Dispose_ClosesUnderlyingStream_WhenLeaveOpenFalse()
-    {
+    public void Dispose_ClosesUnderlyingStream_WhenLeaveOpenFalse() {
         var ms = new MemoryStream(TestZip.ToArray());
         var archive = new BackslashTolerantZipArchive(ms, leaveOpen: false);
         archive.Dispose();
@@ -98,15 +88,13 @@ public class BackslashTolerantZipArchiveTests : IDisposable
     }
 
     [Fact]
-    public void GetEntry_MissingEntry_ReturnsNull()
-    {
+    public void GetEntry_MissingEntry_ReturnsNull() {
         using var archive = new BackslashTolerantZipArchive(TestZip, leaveOpen: true);
         Assert.Null(archive.GetEntry("nonexistent/file.lua"));
     }
 
     [Fact]
-    public void Entry_Name_IsAccessible()
-    {
+    public void Entry_Name_IsAccessible() {
         using var archive = new BackslashTolerantZipArchive(TestZip, leaveOpen: true);
         var entry = archive.GetEntry("mod/info.json")!;
         Assert.Equal("info.json", entry.Name);

--- a/Yafc.Parser.Tests/IZipArchiveTests.cs
+++ b/Yafc.Parser.Tests/IZipArchiveTests.cs
@@ -1,7 +1,7 @@
-namespace Yafc.Parser.Tests;
+﻿namespace Yafc.Parser.Tests;
 
 public class IZipArchiveTests {
-    public static IEnumerable<object []> Archives() {
+    public static IEnumerable<object[]> Archives() {
         yield return [new BackslashTolerantZipArchive(TestZip, leaveOpen: true)];
         yield return [new ZipArchiveAdapter(TestZip, leaveOpen: true)];
     }

--- a/Yafc.Parser.Tests/IZipArchiveTests.cs
+++ b/Yafc.Parser.Tests/IZipArchiveTests.cs
@@ -1,4 +1,4 @@
-using Yafc.Parser.Tests;
+namespace Yafc.Parser.Tests;
 
 public class IZipArchiveTests {
     public static IEnumerable<object []> Archives() {

--- a/Yafc.Parser.Tests/IZipArchiveTests.cs
+++ b/Yafc.Parser.Tests/IZipArchiveTests.cs
@@ -1,0 +1,23 @@
+using Yafc.Parser.Tests;
+
+public class IZipArchiveTests {
+    public static IEnumerable<object []> Archives() {
+        yield return [new BackslashTolerantZipArchive(TestZip, leaveOpen: true)];
+        yield return [new ZipArchiveAdapter(TestZip, leaveOpen: true)];
+    }
+
+    private static MemoryStream TestZip => BackslashTolerantZipArchiveTests.TestZip;
+
+    [Theory]
+    [MemberData(nameof(Archives))]
+    internal void GetEntry_FindsExistingEntry(IZipArchive archive) {
+        Assert.NotNull(archive.GetEntry("mod/info.json"));
+    }
+
+    [Theory]
+    [MemberData(nameof(Archives))]
+    internal void FullName_IsAccessible(IZipArchive archive) {
+        var entry = archive.GetEntry("mod/info.json")!;
+        Assert.Contains("info.json", entry.FullName);
+    }
+}

--- a/Yafc.Parser/FactorioDataSource.cs
+++ b/Yafc.Parser/FactorioDataSource.cs
@@ -177,8 +177,8 @@ public static partial class FactorioDataSource {
         foreach (string fileName in Directory.EnumerateFiles(directory)) {
             if (fileName.EndsWith(".zip", StringComparison.OrdinalIgnoreCase)) {
                 FileStream fileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read);
-                ZipArchive zipArchive = new ZipArchive(fileStream);
-                var infoEntry = zipArchive.Entries.FirstOrDefault(x =>
+                IZipArchive zipArchive = new BackslashTolerantZipArchive(fileStream);
+                var infoEntry = zipArchive.Entries.FirstOrDefault(x => 
                     x.Name.Equals("info.json", StringComparison.OrdinalIgnoreCase) &&
                     x.FullName.IndexOf('/') == x.FullName.Length - "info.json".Length - 1);
 
@@ -186,6 +186,8 @@ public static partial class FactorioDataSource {
                     string folder = infoEntry.FullName[..^"info.json".Length];
 
                     // built-in mods are never zipped
+                    // unlike the directory loop above, we don't check isBuiltIn here. 
+                    // So we go through the malarkey of actually pulling .lua and .cfg files
                     foreach (var fileEntry in zipArchive.Entries.Where(e => e.FullName.EndsWith(".lua")).OrderBy(e => e.FullName)
                         .Concat(zipArchive.Entries.Where(e => e.FullName.EndsWith(".cfg")).OrderBy(e => e.FullName))) {
 
@@ -550,7 +552,7 @@ public static partial class FactorioDataSource {
         public bool expansion_shaders_required { get; set; }
         public bool expansion_required { get; set; }
 
-        public ZipArchive? zipArchive;
+        public IZipArchive? zipArchive;
         public readonly string folder;
         public readonly uint dataHash;
         /// <summary>
@@ -561,7 +563,7 @@ public static partial class FactorioDataSource {
         /// <param name="json">The bytes in this mod's info.json.</param>
         /// <param name="dataHash">A hash of the .lua and .cfg data in this mod.</param>
         /// <param name="infoHash">A hash of info.json in this built-in mod, or zero.</param>
-        public ModInfo(string folder, byte[] json, uint dataHash, uint infoHash, ZipArchive? zipArchive = null) {
+        public ModInfo(string folder, byte[] json, uint dataHash, uint infoHash, IZipArchive? zipArchive = null) {
             this.folder = folder;
             this.zipArchive = zipArchive;
             Newtonsoft.Json.JsonSerializer.Create().Populate(new StreamReader(new MemoryStream(json)), this);

--- a/Yafc.Parser/FactorioDataSource.cs
+++ b/Yafc.Parser/FactorioDataSource.cs
@@ -178,7 +178,7 @@ public static partial class FactorioDataSource {
             if (fileName.EndsWith(".zip", StringComparison.OrdinalIgnoreCase)) {
                 FileStream fileStream = new FileStream(fileName, FileMode.Open, FileAccess.Read);
                 IZipArchive zipArchive = new BackslashTolerantZipArchive(fileStream);
-                var infoEntry = zipArchive.Entries.FirstOrDefault(x => 
+                var infoEntry = zipArchive.Entries.FirstOrDefault(x =>
                     x.Name.Equals("info.json", StringComparison.OrdinalIgnoreCase) &&
                     x.FullName.IndexOf('/') == x.FullName.Length - "info.json".Length - 1);
 

--- a/Yafc.Parser/ZipArchive/BackslashTolerantZipArchive.cs
+++ b/Yafc.Parser/ZipArchive/BackslashTolerantZipArchive.cs
@@ -1,0 +1,40 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+
+internal sealed class BackslashTolerantZipEntry: IZipEntry
+   {
+       private readonly ZipArchiveEntry _entry;
+       public string FullName { get; }
+       public string Name => _entry.Name;
+       public long Length => _entry.Length;
+       public uint Crc32 => _entry.Crc32;
+       public Stream Open() => _entry.Open();
+
+       internal BackslashTolerantZipEntry(ZipArchiveEntry entry)
+       {
+           _entry = entry;
+           FullName = entry.FullName.Replace('\\', '/');
+       }
+
+       public static implicit operator ZipArchiveEntry(BackslashTolerantZipEntry e) => e._entry;
+   }
+
+internal sealed class BackslashTolerantZipArchive : IZipArchive
+{
+    readonly ZipArchive _archive;
+    readonly Dictionary<string, BackslashTolerantZipEntry> _entries;
+
+    public BackslashTolerantZipArchive(Stream stream, bool leaveOpen = false) {
+        _archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen);
+        _entries = _archive.Entries.ToDictionary(e => e.FullName.Replace('\\','/'), e => new BackslashTolerantZipEntry(e), StringComparer.Ordinal);
+        Entries = _entries.Values.ToList().AsReadOnly();
+    }
+    public IReadOnlyCollection<IZipEntry> Entries { get; }
+
+    public IZipEntry? GetEntry(string path) => _entries.TryGetValue(path.Replace('\\', '/'), out var entry) ? entry: null;
+
+    public void Dispose() => _archive.Dispose();
+}

--- a/Yafc.Parser/ZipArchive/BackslashTolerantZipArchive.cs
+++ b/Yafc.Parser/ZipArchive/BackslashTolerantZipArchive.cs
@@ -1,38 +1,35 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
 
-internal sealed class BackslashTolerantZipEntry: IZipEntry
-   {
-       private readonly ZipArchiveEntry _entry;
-       public string FullName { get; }
-       public string Name => _entry.Name;
-       public long Length => _entry.Length;
-       public uint Crc32 => _entry.Crc32;
-       public Stream Open() => _entry.Open();
+internal sealed class BackslashTolerantZipEntry : IZipEntry {
+    private readonly ZipArchiveEntry _entry;
+    public string FullName { get; }
+    public string Name => _entry.Name;
+    public long Length => _entry.Length;
+    public uint Crc32 => _entry.Crc32;
+    public Stream Open() => _entry.Open();
 
-       internal BackslashTolerantZipEntry(ZipArchiveEntry entry)
-       {
-           _entry = entry;
-           FullName = entry.FullName.Replace('\\', '/');
-       }
-   }
+    internal BackslashTolerantZipEntry(ZipArchiveEntry entry) {
+        _entry = entry;
+        FullName = entry.FullName.Replace('\\', '/');
+    }
+}
 
-internal sealed class BackslashTolerantZipArchive : IZipArchive
-{
+internal sealed class BackslashTolerantZipArchive : IZipArchive {
     readonly ZipArchive _archive;
     readonly Dictionary<string, BackslashTolerantZipEntry> _entries;
 
     public BackslashTolerantZipArchive(Stream stream, bool leaveOpen = false) {
         _archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen);
-        _entries = _archive.Entries.ToDictionary(e => e.FullName.Replace('\\','/'), e => new BackslashTolerantZipEntry(e), StringComparer.Ordinal);
+        _entries = _archive.Entries.ToDictionary(e => e.FullName.Replace('\\', '/'), e => new BackslashTolerantZipEntry(e), StringComparer.Ordinal);
         Entries = _entries.Values.ToList().AsReadOnly();
     }
     public IReadOnlyCollection<IZipEntry> Entries { get; }
 
-    public IZipEntry? GetEntry(string path) => _entries.TryGetValue(path.Replace('\\', '/'), out var entry) ? entry: null;
+    public IZipEntry? GetEntry(string path) => _entries.TryGetValue(path.Replace('\\', '/'), out var entry) ? entry : null;
 
     public void Dispose() => _archive.Dispose();
 }

--- a/Yafc.Parser/ZipArchive/BackslashTolerantZipArchive.cs
+++ b/Yafc.Parser/ZipArchive/BackslashTolerantZipArchive.cs
@@ -18,8 +18,6 @@ internal sealed class BackslashTolerantZipEntry: IZipEntry
            _entry = entry;
            FullName = entry.FullName.Replace('\\', '/');
        }
-
-       public static implicit operator ZipArchiveEntry(BackslashTolerantZipEntry e) => e._entry;
    }
 
 internal sealed class BackslashTolerantZipArchive : IZipArchive

--- a/Yafc.Parser/ZipArchive/IZipArchive.cs
+++ b/Yafc.Parser/ZipArchive/IZipArchive.cs
@@ -1,8 +1,8 @@
-using System;
+﻿using System;
 using System.Collections.Generic;
 using System.IO;
 
-internal interface IZipArchive: IDisposable {
+internal interface IZipArchive : IDisposable {
     IReadOnlyCollection<IZipEntry> Entries { get; }
     IZipEntry? GetEntry(string path);
 }
@@ -11,7 +11,7 @@ internal interface IZipEntry {
     string FullName { get; }
     string Name { get; }
     long Length { get; }
-    uint Crc32 {get;}
+    uint Crc32 { get; }
     Stream Open();
 
 }

--- a/Yafc.Parser/ZipArchive/IZipArchive.cs
+++ b/Yafc.Parser/ZipArchive/IZipArchive.cs
@@ -1,0 +1,17 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+
+internal interface IZipArchive: IDisposable {
+    IReadOnlyCollection<IZipEntry> Entries { get; }
+    IZipEntry? GetEntry(string path);
+}
+
+internal interface IZipEntry {
+    string FullName { get; }
+    string Name { get; }
+    long Length { get; }
+    uint Crc32 {get;}
+    Stream Open();
+
+}

--- a/Yafc.Parser/ZipArchive/ZipArchiveAdapter.cs
+++ b/Yafc.Parser/ZipArchive/ZipArchiveAdapter.cs
@@ -1,9 +1,9 @@
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.IO;
 using System.IO.Compression;
 using System.Linq;
 
-internal sealed class ZipArchiveAdapter: IZipArchive {
+internal sealed class ZipArchiveAdapter : IZipArchive {
     readonly ZipArchive _archive;
 
     public ZipArchiveAdapter(Stream stream, bool leaveOpen = false) {
@@ -13,14 +13,14 @@ internal sealed class ZipArchiveAdapter: IZipArchive {
 
     public IReadOnlyCollection<IZipEntry> Entries { get; }
 
-    public IZipEntry? GetEntry (string path) => _archive.GetEntry(path) is {} e ? new ZipEntryAdapter(e): null;
+    public IZipEntry? GetEntry(string path) => _archive.GetEntry(path) is { } e ? new ZipEntryAdapter(e) : null;
     public void Dispose() => _archive.Dispose();
 }
 
-internal sealed class ZipEntryAdapter(ZipArchiveEntry entry): IZipEntry {
-public string FullName => entry.FullName;
-       public string Name => entry.Name;
-       public long Length => entry.Length;
-       public uint Crc32 => entry.Crc32;
-       public Stream Open() => entry.Open();
+internal sealed class ZipEntryAdapter(ZipArchiveEntry entry) : IZipEntry {
+    public string FullName => entry.FullName;
+    public string Name => entry.Name;
+    public long Length => entry.Length;
+    public uint Crc32 => entry.Crc32;
+    public Stream Open() => entry.Open();
 }

--- a/Yafc.Parser/ZipArchive/ZipArchiveAdapter.cs
+++ b/Yafc.Parser/ZipArchive/ZipArchiveAdapter.cs
@@ -1,0 +1,26 @@
+using System.Collections.Generic;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+
+internal sealed class ZipArchiveAdapter: IZipArchive {
+    readonly ZipArchive _archive;
+
+    public ZipArchiveAdapter(Stream stream, bool leaveOpen = false) {
+        _archive = new ZipArchive(stream, ZipArchiveMode.Read, leaveOpen);
+        Entries = _archive.Entries.Select(e => (IZipEntry)new ZipEntryAdapter(e)).ToList().AsReadOnly();
+    }
+
+    public IReadOnlyCollection<IZipEntry> Entries { get; }
+
+    public IZipEntry? GetEntry (string path) => _archive.GetEntry(path) is {} e ? new ZipEntryAdapter(e): null;
+    public void Dispose() => _archive.Dispose();
+}
+
+internal sealed class ZipEntryAdapter(ZipArchiveEntry entry): IZipEntry {
+public string FullName => entry.FullName;
+       public string Name => entry.Name;
+       public long Length => entry.Length;
+       public uint Crc32 => entry.Crc32;
+       public Stream Open() => entry.Open();
+}


### PR DESCRIPTION
Add BackslashTolerantZipArchive, a wrapper (adapter) so as to not explode if we write some solid testing for FactorioDataSource (interfaces baybeee), and hopefully revelvant tests for both the adapter and the actual backslash-tolerant system.

Issue detailed in https://github.com/Yafc-CE/yafc-ce/issues/680

Basically, made a drop-in replacement with tests.
Noticed if we got FactorioDataSource all tested, we'd be doing some hacky stuff with setup, so made a wrapper to support either ZipArchive or BackslashTolerantZipArchive via an interface, IZipArchive.
Wrote tests for both the wrapper and the backslash tolerant class.
Went mad.
Made PR.

Notably, I had a 2 year old coming up to me every 45 seconds - 3 minutes. So lemme know if something in this seems.. disjointed.