### PR TITLE
Fixed locale so that game mechanic "frozen" is used

### DIFF
--- a/Yafc/Data/locale/en/yafc.cfg
+++ b/Yafc/Data/locale/en/yafc.cfg
@@ -140,7 +140,7 @@ tooltip-entity-spoils-after-no-production=After __1__ of no production, spoils i
 tooltip-entity-expires-after-no-production=Expires after __1__ of no production
 tooltip-entity-absorbs-pollution=Absorption: __1__ __2__ per minute
 tooltip-entity-emits-pollution=Emission: __1__ __2__ per minute
-tooltip-entity-requires-heat=Requires __1__ heat on cold planets.
+tooltip-entity-requires-heat=Requires __1__ heat on frozen planets.
 tooltip-item-spoils=After __1__, spoils into
 
 ; AboutScreen.cs
@@ -421,7 +421,7 @@ shopping-list-heat-period=.
 shopping-list-decompose=Decompose
 shopping-list-export-blueprint=Export to blueprint
 shopping-list-export-blueprint-hint=Blueprint string will be copied to the clipboard.
-shopping-list-these-require-heat=These entities require __1__ heat on cold planets.
+shopping-list-these-require-heat=These entities require __1__ heat on frozen planets.
 
 ; WelcomeScreen.cs
 welcome-project-file-location=Project file location


### PR DESCRIPTION
Only a minor clarification change.
I was confused when reading that a entity needs heat on "cold" planets and was not able to immediately link it to the "freezing/frozen" mechanic introduced with 2.0/Aquilo, so I'm proposing to change the wording slightly to fit into the nomenclature the game/engine uses.