### PR TITLE
Compat: For Krastorio2, always enable first biomatter

### DIFF
--- a/Yafc/Data/Mod-fixes/Krastorio2.data-updates.lua
+++ b/Yafc/Data/Mod-fixes/Krastorio2.data-updates.lua
@@ -1,3 +1,14 @@
+-- First biomass comes from the player hand-mining spawner corpses.
+--
+-- With only K2 enabled, this is enabled/reachable automatically.
+-- With Space Exploration also installed, YAFC fails to autodetect this.
+--
+-- For simplicity's sake, we'll always enable it to be safe, as it's a core K2 mechanic.
+data.script_enabled:insert{
+    type = "item",
+    name = "kr-biomass"
+}
+
 if not mods["space-exploration"] then
     -- Unlock the initial science lab
     data.script_enabled:insert{


### PR DESCRIPTION
Ensure that Krastorio2's biomatter (`kr-biomass` in prototypes) growth loop is always enabled.

In Krastorio2, the first biomatter comes from the player hand-mining spawner corpses.

When Space Exploration is also enabled in the mod set, YAFC can no longer auto-enable the recipe for making biomatter from biomatter.

Since the biomatter growth loop is a core K2 mechanic, it seemed like something that should always be enabled.