### PR TITLE
Set helpers.stage when parsing data (#689)

### DIFF
--- a/Yafc.Parser/LuaContext.cs
+++ b/Yafc.Parser/LuaContext.cs
@@ -156,6 +156,7 @@ internal partial class LuaContext : IDisposable {
 
         var helpers = NewTable();
         helpers["game_version"] = gameVersion.ToString(3);
+        helpers["stage"] = "prototype";
         SetGlobal("helpers", helpers);
         SetGlobal("yafc", NewTable());
 

--- a/changelog.txt
+++ b/changelog.txt
@@ -24,6 +24,7 @@ Date:
     Features:
         - Allow planet selection for production tables, and complain if the selected recipe or entity can't be used there.
     Fixes:
+        - Define LuaHelpers.stage (added in 2.1) as "prototype"
 ----------------------------------------------------------------------------------------------------------------------
 Version: 2.20.0
 Date: 17 July 2026


### PR DESCRIPTION
[LuaHelpers.stage](https://lua-api.factorio.com/latest/classes/LuaHelpers.html#stage) was added in 2.1, and Things was [checking for this](https://github.com/project-cybersyn/things/blob/387200cd6dbc38d45ce73ef107f366c56a4fa478/client/client.lua#L27-L32).

Synced mods (but not settings) with one of the provided saves from 689 and loaded up without issues and showed the basic milestones I would've expected from Py.

Fixes #689